### PR TITLE
Fix for issue #100

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -425,7 +425,13 @@ AC_DEFUN([AC_C_ALIGNMENT],
        // catch unaligned word access (ARM cpus)
        *buf =  1; *(buf +1) = 2; *(buf + 2) = 3; *(buf + 3) = 4; *(buf + 4) = 5;
        int* i = (int*)(buf+1);
-       return (84148994 == i) ? 0 : 1;
+       return (
+#ifdef ENDIAN_BIG
+                0x02030405
+#else
+                0x05040302
+#endif
+                        == *i) ? 0 : 1;
     ])
   ],[
     ac_cv_c_alignment=none


### PR DESCRIPTION
The check for need of alignment introduced in fix for issue #100 is wrong as it sets 0x04030302 instead of 0x05040302. My small commit fixes this.
  http://code.google.com/p/memcached/issues/detail?id=100
