### PR TITLE
Fix -Werror=unused-but-set-variable warnings in gcc 4.6

### DIFF
--- a/items.c
+++ b/items.c
@@ -469,9 +469,7 @@ void do_item_stats_sizes(ADD_STAT add_stats, void *c) {
         for (i = 0; i < num_buckets; i++) {
             if (histogram[i] != 0) {
                 char key[8];
-                int klen = 0;
-                klen = snprintf(key, sizeof(key), "%d", i * 32);
-                assert(klen < sizeof(key));
+                snprintf(key, sizeof(key), "%d", i * 32);
                 APPEND_STAT(key, "%u", histogram[i]);
             }
         }

--- a/memcached.c
+++ b/memcached.c
@@ -4769,9 +4769,9 @@ int main (int argc, char **argv) {
 
         /* create the UDP listening socket and bind it */
         errno = 0;
-        if (settings.udpport && server_sockets(settings.udpport, udp_transport,
+        if (udp_port && server_sockets(udp_port, udp_transport,
                                               portnumber_file)) {
-            vperror("failed to listen on UDP port %d", settings.udpport);
+            vperror("failed to listen on UDP port %d", udp_port);
             exit(EX_OSERR);
         }
 


### PR DESCRIPTION
Two minor fixups. One is a no-longer needed assert after a conversion
from sprintf() to snprintf(); the other failed to use a local udp_port
variable that can be derived from two different settings properties.

Signed-off-by: Dan McGee dan@archlinux.org
