### PR TITLE
Fixed problem on multi get requests

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1226,6 +1226,7 @@ static void process_bin_get(conn *c) {
         /* Add the data minus the CRLF */
         add_iov(c, ITEM_data(it), it->nbytes - 2);
         conn_set_state(c, conn_mwrite);
+        c->write_and_go = conn_new_cmd;
         /* Remember this command so we can garbage collect it later */
         c->item = it;
     } else {


### PR DESCRIPTION
In the process of binary multi get responses, setting the field write_and_go is missing.

This causes only the first response of a multiget to be attended. Is easily reproduced by starting the server and doing binary multi get request, being this the first request send to the server. I reproduce this using UDP but I think it should fail also on TCP.

This usually gets hidden because other commands set write_and_go field before and if the multiget is not the first command then it happens to run just fine, but its just a matter of luck.

I found a long standing issue that seems related

http://code.google.com/p/memcached/issues/detail?id=107
