### PR TITLE
STAT_VAL_LEN too short cuts settings output when using multiple -l flags

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -104,7 +104,7 @@
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
 #define STAT_KEY_LEN 128
-#define STAT_VAL_LEN 128
+#define STAT_VAL_LEN 1024
 
 /** Append a simple stat with a stat name, value format and value */
 #define APPEND_STAT(name, fmt, val) \


### PR DESCRIPTION
"stats settings" values has 256 bytes limit -defined by STAT_VAL_LEN- and starting memcached with multiple -l flags cuts "inter" in the output, example:

./memcached -m 64 -p 11211 -u nobody\
 -l 0.0.0.0:11211 \
 -l 0.0.0.0:11212 \
 -l 0.0.0.0:11213 \
 -l 0.0.0.0:11214 \
 -l 0.0.0.0:11215 \
 -l 0.0.0.0:11216 \
 -l 0.0.0.0:11217 \
 -l 0.0.0.0:11218 \
 -l 0.0.0.0:11219 \
 -l 0.0.0.0:11220 \
 -l 0.0.0.0:11221 \
 -l 0.0.0.0:11222 \
 -l 0.0.0.0:11223 \
 -l 0.0.0.0:11224 \
 -l 0.0.0.0:11225 \
 -l 0.0.0.0:11226 \
 -l 0.0.0.0:11227 \
 -l 0.0.0.0:11228 \
 -l 0.0.0.0:11229 \
 -l 0.0.0.0:11230 \
 -l 0.0.0.0:11231 \
 -l 0.0.0.0:11232 \
 -l 0.0.0.0:11233 \
 -l 0.0.0.0:11234 \
 -l 0.0.0.0:11235 \
 -l 0.0.0.0:11236 \
 -l 0.0.0.0:11237 \
 -l 0.0.0.0:11238 \
 -l 0.0.0.0:11239 \
 -l 0.0.0.0:11240 \
 -l 0.0.0.0:11241 \
 -l 0.0.0.0:11242

$ telnet localhost 11211
stats settings
(..)
STAT inter 0.0.0.0:11211,0.0.0.0:11212,0.0.0.0:11213,0.0.0.0:11214,0.0.0.0:11215,0.0.0.0:11216,0.0.0.0:11217,0.0.0.0:11218,0.0.0.0:11219,
(..)

The "inter" value is break and doesn't show all listening interfaces.
