### PR TITLE
Add support for automake-1.12

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -39,7 +39,7 @@ $AUTOHEADER || exit 1
 
 echo "automake..."
 if test x$AUTOMAKE = x; then
-  AUTOMAKE=`locate_binary automake-1.11 automake-1.10 automake-1.9 automake-1.7`
+  AUTOMAKE=`locate_binary automake-1.12 automake-1.11 automake-1.10 automake-1.9 automake-1.7`
   if test x$AUTOMAKE = x; then
     die "Did not find a supported automake"
   fi


### PR DESCRIPTION
autogen.sh is unable to test/locate latest automake version.

```
 shell~> ./automake.sh
 aclocal...
 autoheader...
 automake...
 Did not find a supported automake
```

**FIX**
Add _automake-1.12_ to list of supported $AUTOMAKE test
