### PR TITLE
Make tail leak repair time configurable

### DIFF
--- a/items.c
+++ b/items.c
@@ -125,7 +125,7 @@ item *do_item_alloc(char *key, const size_t nkey, const int flags,
             /* Old rare bug could cause a refcount leak. We haven't seen
              * it in years, but we leave this code in to prevent failures
              * just in case */
-            if (search->time + TAIL_REPAIR_TIME < current_time) {
+            if (search->time + settings.tail_repair_time < current_time) {
                 itemstats[id].tailrepairs++;
                 search->refcount = 1;
                 do_item_unlink_nolock(search, hv);

--- a/memcached.c
+++ b/memcached.c
@@ -225,6 +225,7 @@ static void settings_init(void) {
     settings.hashpower_init = 0;
     settings.slab_reassign = false;
     settings.slab_automove = 0;
+    settings.tail_repair_time = TAIL_REPAIR_TIME_DEFAULT;
 }
 
 /*
@@ -2623,6 +2624,7 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("hashpower_init", "%d", settings.hashpower_init);
     APPEND_STAT("slab_reassign", "%s", settings.slab_reassign ? "yes" : "no");
     APPEND_STAT("slab_automove", "%d", settings.slab_automove);
+    APPEND_STAT("tail_repair_time", "%d", settings.tail_repair_time);
 }
 
 static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
@@ -4501,6 +4503,9 @@ static void usage(void) {
            "                table should be. Can be grown at runtime if not big enough.\n"
            "                Set this based on \"STAT hash_power_level\" before a \n"
            "                restart.\n"
+           "              - tail_repair_time: Time in seconds that indicates how long to wait before\n"
+           "                forcefully taking over the LRU tail item whose refcount has leaked.\n"
+           "                The default is 3 hours.\n"
            );
     return;
 }
@@ -4722,13 +4727,15 @@ int main (int argc, char **argv) {
         MAXCONNS_FAST = 0,
         HASHPOWER_INIT,
         SLAB_REASSIGN,
-        SLAB_AUTOMOVE
+        SLAB_AUTOMOVE,
+        TAIL_REPAIR_TIME
     };
     char *const subopts_tokens[] = {
         [MAXCONNS_FAST] = "maxconns_fast",
         [HASHPOWER_INIT] = "hashpower",
         [SLAB_REASSIGN] = "slab_reassign",
         [SLAB_AUTOMOVE] = "slab_automove",
+        [TAIL_REPAIR_TIME] = "tail_repair_time",
         NULL
     };
 
@@ -4991,6 +4998,13 @@ int main (int argc, char **argv) {
                     fprintf(stderr, "slab_automove must be between 0 and 2\n");
                     return 1;
                 }
+                break;
+            case TAIL_REPAIR_TIME:
+                if (subopts_value == NULL) {
+                    fprintf(stderr, "Missing numeric argument for tail_repair_time\n");
+                    return 1;
+                }
+                settings.tail_repair_time = atoi(subopts_value);
                 break;
             default:
                 printf("Illegal suboption \"%s\"\n", subopts_value);

--- a/memcached.h
+++ b/memcached.h
@@ -76,7 +76,7 @@
 
 /** How long an object can reasonably be assumed to be locked before
     harvesting it on a low memory condition. */
-#define TAIL_REPAIR_TIME (3 * 3600)
+#define TAIL_REPAIR_TIME_DEFAULT (3 * 3600)
 
 /* warning: don't use these macros with a function, as it evals its arg twice */
 #define ITEM_get_cas(i) (((i)->it_flags & ITEM_CAS) ? \
@@ -307,6 +307,7 @@ struct settings {
     bool slab_reassign;     /* Whether or not slab reassignment is allowed */
     int slab_automove;     /* Whether or not to automatically move slabs */
     int hashpower_init;     /* Starting hash power level */
+    int tail_repair_time;   /* LRU tail refcount leak repair time */
 };
 
 extern struct stats stats;


### PR DESCRIPTION
At Etsy we've been hit by the LRU tail refcount leak a bunch of times. We're currently using official 1.4.13.

The 3 hour default is a bit too long, we'd prefer to reduce it to something more manageable like 30s. With 30k req/sec once we hit the issue, over 20% of set requests start failing with the OOM error and stay that way until the 3 hours are up.
