### PR TITLE
Updated memcached-tool script

### DIFF
--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -159,7 +159,6 @@ if ($mode eq 'settings') {
     printf ("#%-17s %5s %11s\n", $addr, "Field", "Value");
     foreach my $name (sort(keys(%items))) {
         printf ("%24s %12s\n", $name, $items{$name});
-
     }
     exit;
 }
@@ -180,7 +179,6 @@ if ($mode eq 'sizes') {
     printf ("#%-17s %5s %11s\n", $addr, "Size", "Count");
     foreach my $name (sort(keys(%items))) {
         printf ("%24s %12s\n", $name, $items{$name});
-
     }
     exit;
 }


### PR DESCRIPTION
Hello.

I've made three changed for standard memcached-tool:
- display mode now shows information about allocated empty slabs (slabs without keys)
- new settings mode shows stats settings output
- new sizes mode shows stats sizes output

Thanks.
