### PR TITLE
configure.ac cleanup/etc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,3 +103,16 @@ docs:
 
 dist-hook:
 	rm -f $(distdir)/*/*~ $(distdir)/t/lib/*~ $(distdir)/*~
+
+maintainer-clean-local:
+	-rm Makefile.in
+	-rm aclocal.m4
+	-rm config.guess
+	-rm config.sub
+	-rm depcomp
+	-rm install-sh
+	-rm ltmain.sh
+	-rm missing
+	-rm configure
+	-rm config.log
+	-rm config.status

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,13 @@
+# vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
 AC_PREREQ(2.52)
 m4_include([version.m4])
 m4_include([m4/c99-backport.m4])
-AC_INIT(memcached, VERSION_NUMBER, memcached@googlegroups.com)
-AC_CANONICAL_SYSTEM
-AC_CONFIG_SRCDIR(memcached.c)
-AM_INIT_AUTOMAKE(AC_PACKAGE_NAME, AC_PACKAGE_VERSION)
-AM_CONFIG_HEADER(config.h)
+AC_INIT([memcached], [VERSION_NUMBER], [memcached@googlegroups.com], [memcached])
+AC_CANONICAL_TARGET
+AC_USE_SYSTEM_EXTENSIONS
+AC_CONFIG_SRCDIR([memcached.c])
+AM_INIT_AUTOMAKE([1.11 color-tests -Wno-portability subdir-objects foreign tar-ustar])
+AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CC
 
@@ -19,18 +21,18 @@ AC_DEFUN([DETECT_ICC],
 [
     ICC="no"
     AC_MSG_CHECKING([for icc in use])
-    if test "$GCC" = "yes"; then
-       dnl check if this is icc acting as gcc in disguise
-       AC_EGREP_CPP([^__INTEL_COMPILER], [__INTEL_COMPILER],
-         AC_MSG_RESULT([no])
-         [$2],
-         AC_MSG_RESULT([yes])
-         [$1]
-         ICC="yes")
-    else
-       AC_MSG_RESULT([no])
-       [$2]
-    fi
+    AS_IF([test "$GCC" = "yes"],[
+           dnl check if this is icc acting as gcc in disguise
+           AC_EGREP_CPP([^__INTEL_COMPILER], [__INTEL_COMPILER],
+                        AC_MSG_RESULT([no])
+                        [$2],
+                        AC_MSG_RESULT([yes])
+                        [$1]
+                        ICC="yes")
+           ],[
+              AC_MSG_RESULT([no])
+              [$2]
+              ])
 ])
 
 DETECT_ICC([], [])
@@ -44,29 +46,37 @@ dnl **********************************************************************
 AC_DEFUN([DETECT_SUNCC],
 [
     AC_CHECK_DECL([__SUNPRO_C], [SUNCC="yes"], [SUNCC="no"])
-    AS_IF(test "x$SUNCC" = "xyes", [$1], [$2])
+    AS_IF([test "x$SUNCC" = "xyes"], [$1], [$2])
 
 ])
 
 DETECT_SUNCC([CFLAGS="-mt $CFLAGS"], [])
-AS_IF([test "$ICC" = "yes" -o "$GCC" = "yes"],
-      [CFLAGS="$CFLAGS -pthread"])
 
-if test "$ICC" = "no"; then
-   AC_PROG_CC_C99
-fi
+AC_DEFUN([AX_TEST_CC],[
+          AC_REQUIRE([DETECT_LIBEVENT])dnl
+          AX_PTHREAD([
+                      CFLAGS="${PTHREAD_CFLAGS} $CFLAGS"
+                      LIBS="${PTHREAD_LIBS} $LIBS"
+                      ],[AC_MSG_ERROR([could not find libpthread])])
+          AS_IF([test "$ICC" = "yes" -o "$GCC" = "yes"],
+                [CFLAGS="$CFLAGS -pthread"])
+
+          AS_IF([test "$ICC" = "no"],[
+                 AC_PROG_CC_C99
+                 ])
+          ])
 
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
 
-AC_ARG_ENABLE(sasl,
+AC_ARG_ENABLE([sasl],
   [AS_HELP_STRING([--enable-sasl],[Enable SASL authentication])])
 
-AC_ARG_ENABLE(sasl_pwdb,
+AC_ARG_ENABLE([sasl_pwdb],
   [AS_HELP_STRING([--enable-sasl-pwdb],[Enable plaintext password db])])
 
 AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
-      [enable_sasl=yes ])
+      [enable_sasl=yes])
 
 
 dnl **********************************************************************
@@ -93,41 +103,40 @@ unsigned long val = SASL_CB_GETCONF;
 ])
 
 AC_CHECK_HEADERS([sasl/sasl.h])
-if test "x$enable_sasl" = "xyes"; then
-  AC_C_DETECT_SASL_CB_GETCONF
-  AC_DEFINE([ENABLE_SASL],1,[Set to nonzero if you want to include SASL])
-  AC_SEARCH_LIBS([sasl_server_init], [sasl2 sasl], [],
-    [
-      AC_MSG_ERROR([Failed to locate the library containing sasl_server_init])
-    ])
+AS_IF([test "x$enable_sasl" = "xyes"],[
+       AC_C_DETECT_SASL_CB_GETCONF
+       AC_DEFINE([ENABLE_SASL],1,[Set to nonzero if you want to include SASL])
+       AC_SEARCH_LIBS([sasl_server_init], [sasl2 sasl], [],
+                      [
+                       AC_MSG_ERROR([Failed to locate the library containing sasl_server_init])
+                       ])
 
-  AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
-        [AC_DEFINE([ENABLE_SASL_PWDB], 1,
-                   [Set to nonzero if you want to enable a SASL pwdb])])
-fi
+       AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
+             [AC_DEFINE([ENABLE_SASL_PWDB], 1,
+                        [Set to nonzero if you want to enable a SASL pwdb])])
+       ])
 
 AC_ARG_ENABLE(dtrace,
   [AS_HELP_STRING([--enable-dtrace],[Enable dtrace probes])])
-if test "x$enable_dtrace" = "xyes"; then
-  AC_PATH_PROG([DTRACE], [dtrace], "no", [/usr/sbin:$PATH])
-  if test "x$DTRACE" != "xno"; then
-    AC_DEFINE([ENABLE_DTRACE],1,[Set to nonzero if you want to include DTRACE])
-    build_dtrace=yes
-    # DTrace on MacOSX does not use -G option
-    $DTRACE -G -o conftest.$$ -s memcached_dtrace.d 2>/dev/zero
-    if test $? -eq 0
-    then
-        dtrace_instrument_obj=yes
-        rm conftest.$$
-    fi
+AS_IF([test "x$enable_dtrace" = "xyes"],[
+       AC_PATH_PROG([DTRACE], [dtrace], [no], [/usr/sbin:$PATH])
+       AS_IF([test "x$DTRACE" != "xno"],[
+              AC_DEFINE([ENABLE_DTRACE],[1],[Set to nonzero if you want to include DTRACE])
+              build_dtrace=yes
+              # DTrace on MacOSX does not use -G option
+              $DTRACE -G -o conftest.$$ -s memcached_dtrace.d 2>/dev/zero
+              AS_IF([test $? -eq 0],[
+                     dtrace_instrument_obj=yes
+                     rm conftest.$$
+                     ])
 
-    if test "`which tr`" = "/usr/ucb/tr"; then
-        AC_MSG_ERROR([Please remove /usr/ucb from your path. See man standards for more info])
-    fi
-  else
-    AC_MSG_ERROR([Need dtrace binary and OS support.])
-  fi
-fi
+              AS_IF([test "`which tr`" = "/usr/ucb/tr"],[
+                     AC_MSG_ERROR([Please remove /usr/ucb from your path. See man standards for more info])
+                     ])
+              ],[
+                 AC_MSG_ERROR([Need dtrace binary and OS support.])
+                 ])
+       ])
 
 AM_CONDITIONAL([BUILD_DTRACE],[test "$build_dtrace" = "yes"])
 AM_CONDITIONAL([DTRACE_INSTRUMENT_OBJ],[test "$dtrace_instrument_obj" = "yes"])
@@ -141,148 +150,152 @@ AC_SUBST(PROFILER_LDFLAGS)
 AC_ARG_ENABLE(coverage,
   [AS_HELP_STRING([--disable-coverage],[Disable code coverage])])
 
-if test "x$enable_coverage" != "xno"; then
-   if test "$GCC" = "yes" -a "$ICC" != "yes"
-   then
-      CFLAGS="$CFLAGS -pthread"
-      AC_PATH_PROG([PROFILER], [gcov], "no", [$PATH])
-      if test "x$PROFILER" != "xno"; then
-         # Issue 97: The existense of gcov doesn't mean we have -lgcov
-         AC_CHECK_LIB(gcov, main,
-                    [
-                      PROFILER_FLAGS="-fprofile-arcs -ftest-coverage"
-                      PROFILER_LDFLAGS="-lgcov"
-                    ], [
-                      PROFILER_FLAGS=
-                      PROFILER_LDFLAGS=
-                    ])
-      fi
-   elif test "$SUNCC" = "yes"
-   then
-      AC_PATH_PROG([PROFILER], [tcov], "no", [$PATH])
-      if test "x$PROFILER" != "xno"; then
-         PROFILER_FLAGS=-xprofile=tcov
-      fi
-   fi
-fi
+AS_IF([test "x$enable_coverage" != "xno"],[
+       AS_IF([test "$GCC" = "yes" -a "$ICC" != "yes"],[
+              AX_SAVE_FLAGS
+              CFLAGS="$CFLAGS -pthread"
+              AC_PATH_PROG([PROFILER], [gcov], "no", [$PATH])
+              if test "x$PROFILER" != "xno"; then
+                # Issue 97: The existense of gcov doesn't mean we have -lgcov
+                AC_CHECK_LIB(gcov, main,
+                             [
+                              PROFILER_FLAGS="-fprofile-arcs -ftest-coverage"
+                              PROFILER_LDFLAGS="-lgcov"
+                              ], [
+                                  PROFILER_FLAGS=
+                                  PROFILER_LDFLAGS=
+                                  ])
+                fi
+              elif test "$SUNCC" = "yes"
+              then
+                AC_PATH_PROG([PROFILER], [tcov], "no", [$PATH])
+                AS_IF([test "x$PROFILER" != "xno"],[
+                       PROFILER_FLAGS=-xprofile=tcov
+                       ])
+                AX_RESTORE_FLAGS
+                ])
+       ])
 AC_SUBST(PROFILER_FLAGS)
 
 
 AC_ARG_ENABLE(64bit,
   [AS_HELP_STRING([--enable-64bit],[build 64bit version])])
-if test "x$enable_64bit" = "xyes"
-then
-    org_cflags=$CFLAGS
-    CFLAGS=-m64
-    AC_RUN_IFELSE(
-      [AC_LANG_PROGRAM([], [dnl
-return sizeof(void*) == 8 ? 0 : 1;
-      ])
-    ],[
-      CFLAGS="-m64 $org_cflags"
-    ],[
-    AC_MSG_ERROR([Don't know how to build a 64-bit object.])
-    ])
-fi
+AS_IF([test "x$enable_64bit" = "xyes"],[
+       AX_SAVE_FLAGS
+       CFLAGS=-m64
+       ax_m64=no
+       AC_RUN_IFELSE(
+                     [AC_LANG_PROGRAM([], [dnl
+                      return sizeof(void*) == 8 ? 0 : 1;
+                      ])
+                     ],[
+                        ax_m64=yes
+                        ],[
+                           AC_MSG_ERROR([Do not know how to build a 64-bit object.])
+                           ])
+       AX_RESTORE_FLAGS
+       AS_IF([test "$ax_m64" = yes],[CFLAGS="-m64 $org_cflags"])
+       ])
 
 # Issue 213: Search for clock_gettime to help people linking
 #            with a static version of libevent
-AC_SEARCH_LIBS(clock_gettime, rt)
+AC_SEARCH_LIBS([clock_gettime],[rt])
+
 # Issue 214: Search for the network libraries _before_ searching
 #            for libevent (to help people linking with static libevent)
-AC_SEARCH_LIBS(socket, socket)
-AC_SEARCH_LIBS(gethostbyname, nsl)
+AC_SEARCH_LIBS([socket],[socket])
+AC_SEARCH_LIBS([gethostbyname],[nsl])
 
-trylibeventdir=""
-AC_ARG_WITH(libevent,
-       [  --with-libevent=PATH     Specify path to libevent installation ],
-       [
-                if test "x$withval" != "xno" ; then
-                        trylibeventdir=$withval
-                fi
-       ]
-)
+trylibeventdir=
+AC_ARG_WITH([libevent],
+            [  --with-libevent=PATH     Specify path to libevent installation ],
+            [
+             AS_IF([test "x$withval" != "xno"],[
+                    trylibeventdir=$withval
+                    ])
+             ]
+            )
 
-dnl ------------------------------------------------------
-dnl libevent detection.  swiped from Tor.  modified a bit.
+AC_DEFUN([DETECT_LIBEVENT],[
+          dnl ------------------------------------------------------
+          dnl libevent detection.  swiped from Tor.  modified a bit.
 
-LIBEVENT_URL=http://www.monkey.org/~provos/libevent/
+          LIBEVENT_URL=http://www.monkey.org/~provos/libevent/
 
-AC_CACHE_CHECK([for libevent directory], ac_cv_libevent_dir, [
-  saved_LIBS="$LIBS"
-  saved_LDFLAGS="$LDFLAGS"
-  saved_CPPFLAGS="$CPPFLAGS"
-  le_found=no
-  for ledir in $trylibeventdir "" $prefix /usr/local ; do
-    LDFLAGS="$saved_LDFLAGS"
-    LIBS="-levent $saved_LIBS"
+          AC_CACHE_CHECK([for libevent directory], [ac_cv_libevent_dir], [
+                          AX_SAVE_FLAGS
+                          le_found=no
+                          for ledir in $trylibeventdir "" $prefix /usr/local ; do
+                            LDFLAGS="$saved_LDFLAGS"
+                            LIBS="-levent $saved_LIBS"
 
-    # Skip the directory if it isn't there.
-    if test ! -z "$ledir" -a ! -d "$ledir" ; then
-       continue;
-    fi
-    if test ! -z "$ledir" ; then
-      if test -d "$ledir/lib" ; then
-        LDFLAGS="-L$ledir/lib $LDFLAGS"
-      else
-        LDFLAGS="-L$ledir $LDFLAGS"
-      fi
-      if test -d "$ledir/include" ; then
-        CPPFLAGS="-I$ledir/include $CPPFLAGS"
-      else
-        CPPFLAGS="-I$ledir $CPPFLAGS"
-      fi
-    fi
-    # Can I compile and link it?
-    AC_TRY_LINK([#include <sys/time.h>
-#include <sys/types.h>
-#include <event.h>], [ event_init(); ],
-       [ libevent_linked=yes ], [ libevent_linked=no ])
-    if test $libevent_linked = yes; then
-       if test ! -z "$ledir" ; then
-         ac_cv_libevent_dir=$ledir
-         _myos=`echo $target_os | cut -f 1 -d .`
-         AS_IF(test "$SUNCC" = "yes" -o "x$_myos" = "xsolaris2",
-               [saved_LDFLAGS="$saved_LDFLAGS -Wl,-R$ledir/lib"],
-               [AS_IF(test "$GCC" = "yes",
-                     [saved_LDFLAGS="$saved_LDFLAGS -Wl,-rpath,$ledir/lib"])])
-       else
-         ac_cv_libevent_dir="(system)"
-       fi
-       le_found=yes
-       break
-    fi
-  done
-  LIBS="$saved_LIBS"
-  LDFLAGS="$saved_LDFLAGS"
-  CPPFLAGS="$saved_CPPFLAGS"
-  if test $le_found = no ; then
-    AC_MSG_ERROR([libevent is required.  You can get it from $LIBEVENT_URL
+                            # Skip the directory if it isn't there.
+                            if test ! -z "$ledir" -a ! -d "$ledir" ; then
+                              continue;
+                            fi
+                            if test ! -z "$ledir" ; then
+                              if test -d "$ledir/lib" ; then
+                                LDFLAGS="-L$ledir/lib $LDFLAGS"
+                              else
+                                LDFLAGS="-L$ledir $LDFLAGS"
+                              fi
+                              if test -d "$ledir/include" ; then
+                                CPPFLAGS="-I$ledir/include $CPPFLAGS"
+                              else
+                                CPPFLAGS="-I$ledir $CPPFLAGS"
+                              fi
+                            fi
+                            # Can I compile and link it?
+                            AC_TRY_LINK([#include <sys/time.h>
+                                         #include <sys/types.h>
+                                         #include <event.h>], [ event_init(); ],
+                                         [ libevent_linked=yes ], [ libevent_linked=no ])
+                            if test $libevent_linked = yes; then
+                              if test ! -z "$ledir" ; then
+                                ac_cv_libevent_dir=$ledir
+                                _myos=`echo $target_os | cut -f 1 -d .`
+                                AS_IF([test "$SUNCC" = "yes" -o "x$_myos" = "xsolaris2"],
+                                      [saved_LDFLAGS="$saved_LDFLAGS -Wl,-R$ledir/lib"],
+                                      [AS_IF([test "$GCC" = "yes"],
+                                             [saved_LDFLAGS="$saved_LDFLAGS -Wl,-rpath,$ledir/lib"])])
+                                else
+                                  ac_cv_libevent_dir="(system)"
+                                fi
+                                le_found=yes
+                                break
+                              fi
+                            done
 
-      If it's already installed, specify its path using --with-libevent=/dir/
-])
-  fi
-])
-LIBS="-levent $LIBS"
-if test $ac_cv_libevent_dir != "(system)"; then
-  if test -d "$ac_cv_libevent_dir/lib" ; then
-    LDFLAGS="-L$ac_cv_libevent_dir/lib $LDFLAGS"
-    le_libdir="$ac_cv_libevent_dir/lib"
-  else
-    LDFLAGS="-L$ac_cv_libevent_dir $LDFLAGS"
-    le_libdir="$ac_cv_libevent_dir"
-  fi
-  if test -d "$ac_cv_libevent_dir/include" ; then
-    CPPFLAGS="-I$ac_cv_libevent_dir/include $CPPFLAGS"
-  else
-    CPPFLAGS="-I$ac_cv_libevent_dir $CPPFLAGS"
-  fi
-fi
+                            AX_RESTORE_FLAGS
 
-dnl ----------------------------------------------------------------------------
+                            if test $le_found = no ; then
+                              AC_MSG_ERROR([libevent is required.  You can get it from $LIBEVENT_URL
 
-AC_SEARCH_LIBS(umem_cache_create, umem)
-AC_SEARCH_LIBS(gethugepagesizes, hugetlbfs)
+                                            If it is already installed, specify its path using --with-libevent=/dir/
+                                            ])
+                              fi
+                              ])
+          LIBS="-levent $LIBS"
+          if test $ac_cv_libevent_dir != "(system)"; then
+            if test -d "$ac_cv_libevent_dir/lib" ; then
+              LDFLAGS="-L$ac_cv_libevent_dir/lib $LDFLAGS"
+              le_libdir="$ac_cv_libevent_dir/lib"
+            else
+              LDFLAGS="-L$ac_cv_libevent_dir $LDFLAGS"
+              le_libdir="$ac_cv_libevent_dir"
+            fi
+            if test -d "$ac_cv_libevent_dir/include" ; then
+              CPPFLAGS="-I$ac_cv_libevent_dir/include $CPPFLAGS"
+            else
+              CPPFLAGS="-I$ac_cv_libevent_dir $CPPFLAGS"
+            fi
+          fi
+
+          dnl ----------------------------------------------------------------------------
+          ])
+
+AC_SEARCH_LIBS([umem_cache_create],[umem])
+AC_SEARCH_LIBS([gethugepagesizes],[hugetlbfs])
 
 AC_HEADER_STDBOOL
 AH_BOTTOM([#if HAVE_STDBOOL_H
@@ -304,25 +317,25 @@ dnl Figure out if this system has the stupid sasl_callback_ft
 dnl **********************************************************************
 
 AC_DEFUN([AC_HAVE_SASL_CALLBACK_FT],
-[AC_CACHE_CHECK(for sasl_callback_ft, ac_cv_has_sasl_callback_ft,
-[
-  AC_TRY_COMPILE([
-    #ifdef HAVE_SASL_SASL_H
-    #include <sasl/sasl.h>
-    #include <sasl/saslplug.h>
-    #endif
-  ],[
-    sasl_callback_ft a_callback;
-  ],[
-    ac_cv_has_sasl_callback_ft=yes
-  ],[
-    ac_cv_has_sasl_callback_ft=no
-  ])
-])
-if test $ac_cv_has_sasl_callback_ft = yes; then
-  AC_DEFINE(HAVE_SASL_CALLBACK_FT, 1, [we have sasl_callback_ft])
-fi
-])
+         [AC_CACHE_CHECK([for sasl_callback_ft], [ac_cv_has_sasl_callback_ft],
+          [
+           AC_TRY_COMPILE([
+                           #ifdef HAVE_SASL_SASL_H
+                           #include <sasl/sasl.h>
+                           #include <sasl/saslplug.h>
+                           #endif
+                           ],[
+                              sasl_callback_ft a_callback;
+                              ],[
+                                 ac_cv_has_sasl_callback_ft=yes
+                                 ],[
+                                    ac_cv_has_sasl_callback_ft=no
+                                    ])
+           ])
+         AS_IF([test "$ac_cv_has_sasl_callback_ft" = yes],[
+                AC_DEFINE(HAVE_SASL_CALLBACK_FT, 1, [we have sasl_callback_ft])
+                ])
+         ])
 
 AC_HAVE_SASL_CALLBACK_FT
 
@@ -363,119 +376,118 @@ AC_C_CONST
 dnl From licq: Copyright (c) 2000 Dirk Mueller
 dnl Check if the type socklen_t is defined anywhere
 AC_DEFUN([AC_C_SOCKLEN_T],
-[AC_CACHE_CHECK(for socklen_t, ac_cv_c_socklen_t,
-[
-  AC_TRY_COMPILE([
-    #include <sys/types.h>
-    #include <sys/socket.h>
-  ],[
-    socklen_t foo;
-  ],[
-    ac_cv_c_socklen_t=yes
-  ],[
-    ac_cv_c_socklen_t=no
-  ])
-])
-if test $ac_cv_c_socklen_t = no; then
-  AC_DEFINE(socklen_t, int, [define to int if socklen_t not available])
-fi
-])
+         [AC_CACHE_CHECK([for socklen_t], [ac_cv_c_socklen_t],
+          [
+           AC_TRY_COMPILE([
+                           #include <sys/types.h>
+                           #include <sys/socket.h>
+                           ],[
+                              socklen_t foo;
+                              ],[
+                                 ac_cv_c_socklen_t=yes
+                                 ],[
+                                    ac_cv_c_socklen_t=no
+                                    ])
+           ])
+
+         AS_IF([test $ac_cv_c_socklen_t = no],[
+                AC_DEFINE([socklen_t], [int], [define to int if socklen_t not available])
+                ])
+         ])
 
 AC_C_SOCKLEN_T
 
 dnl Check if we're a little-endian or a big-endian system, needed by hash code
 AC_DEFUN([AC_C_ENDIAN],
-[AC_CACHE_CHECK(for endianness, ac_cv_c_endian,
-[
-  AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM([], [dnl
-        long val = 1;
-        char *c = (char *) &val;
-        exit(*c == 1);
-    ])
-  ],[
-    ac_cv_c_endian=big
-  ],[
-    ac_cv_c_endian=little
-  ])
-])
-if test $ac_cv_c_endian = big; then
-  AC_DEFINE(ENDIAN_BIG, 1, [machine is bigendian])
-fi
-if test $ac_cv_c_endian = little; then
-  AC_DEFINE(ENDIAN_LITTLE, 1, [machine is littleendian])
-fi
-])
+         [AC_CACHE_CHECK([for endianness], [ac_cv_c_endian],
+          [
+           AC_RUN_IFELSE(
+                         [AC_LANG_PROGRAM([], [dnl
+                          long val = 1;
+                          char *c = (char *) &val;
+                          exit(*c == 1);
+                          ])
+                         ],[
+                            ac_cv_c_endian=big
+                            ],[
+                               ac_cv_c_endian=little
+                               ])
+           ])
+
+         AS_IF([test "$ac_cv_c_endian" = big],[
+                AC_DEFINE([ENDIAN_BIG], [1], [machine is bigendian])
+                ])
+         AS_IF([test "$ac_cv_c_endian" = little],[
+                AC_DEFINE([ENDIAN_LITTLE], [1], [machine is littleendian])
+                ])
+         ])
 
 AC_C_ENDIAN
 
 AC_DEFUN([AC_C_HTONLL],
-[
-    AC_MSG_CHECKING([for htonll])
-    have_htoll="no"
-    AC_TRY_LINK([
-#include <sys/types.h>
-#include <netinet/in.h>
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h> */
-#endif
-       ], [
-          return htonll(0);
-       ], [
-          have_htoll="yes"
-          AC_DEFINE([HAVE_HTONLL], [1], [Have ntohll])
-    ], [
-          have_htoll="no"
-    ])
+         [
+          AC_MSG_CHECKING([for htonll])
+          ax_have_htoll=no
+          AC_LANG_PUSH([C])
+          AC_RUN_IFELSE([
+                         AC_LANG_PROGRAM([
+                                          #include <sys/types.h>
+                                          #include <netinet/in.h>
+                                          #ifdef HAVE_INTTYPES_H
+                                          #include <inttypes.h> */
+                                          #endif
+                                          ], [
+                                              return htonll(0);
+                                              ])], [
+                                                    ax_have_htoll=yes
+                                                    AC_DEFINE([HAVE_HTONLL], [1], [Have ntohll])
+                                                    ],
+                                                    [ax_have_htoll=no],
+                                                    [AC_MSG_WARN([test program execution failed])])
+          AC_LANG_POP
 
-    AC_MSG_RESULT([$have_htoll])
-])
+          AC_MSG_RESULT([$ax_have_htoll])
+          ])
 
 AC_C_HTONLL
 
-dnl Check whether the user's system supports pthread
-AC_SEARCH_LIBS(pthread_create, pthread)
-if test "x$ac_cv_search_pthread_create" = "xno"; then
-  AC_MSG_ERROR([Can't enable threads without the POSIX thread library.])
-fi
-
-AC_CHECK_FUNCS(mlockall)
-AC_CHECK_FUNCS(getpagesizes)
-AC_CHECK_FUNCS(memcntl)
-AC_CHECK_FUNCS(sigignore)
-AC_CHECK_FUNCS(clock_gettime)
+AC_CHECK_FUNCS([mlockall])
+AC_CHECK_FUNCS([getpagesizes])
+AC_CHECK_FUNCS([memcntl])
+AC_CHECK_FUNCS([sigignore])
+AC_CHECK_FUNCS([clock_gettime])
 
 AC_DEFUN([AC_C_ALIGNMENT],
-[AC_CACHE_CHECK(for alignment, ac_cv_c_alignment,
-[
-  AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM([
-#include <stdlib.h>
-#include <inttypes.h>
-    ], [
-       char *buf = malloc(32);
+         [AC_CACHE_CHECK([for alignment],[ac_cv_c_alignment],
+          [
+           AC_RUN_IFELSE(
+                         [AC_LANG_PROGRAM([
+                          #include <stdlib.h>
+                          #include <inttypes.h>
+                          ], [
+                              char *buf = malloc(32);
 
-       uint64_t *ptr = (uint64_t*)(buf+2);
-       // catch sigbus, etc.
-       *ptr = 0x1;
+                              uint64_t *ptr = (uint64_t*)(buf+2);
+                              // catch sigbus, etc.
+                              *ptr = 0x1;
 
-       // catch unaligned word access (ARM cpus)
-       *buf =  1; *(buf +1) = 2; *(buf + 2) = 2; *(buf + 3) = 3; *(buf + 4) = 4;
-       int* i = (int*)(buf+1);
-       return (84148994 == i) ? 0 : 1;
-    ])
-  ],[
-    ac_cv_c_alignment=none
-  ],[
-    ac_cv_c_alignment=need
-  ],[
-    ac_cv_c_alignment=need
-  ])
-])
-if test $ac_cv_c_alignment = need; then
-  AC_DEFINE(NEED_ALIGN, 1, [Machine need alignment])
-fi
-])
+                              // catch unaligned word access (ARM cpus)
+                              *buf =  1; *(buf +1) = 2; *(buf + 2) = 2; *(buf + 3) = 3; *(buf + 4) = 4;
+                              int* i = (int*)(buf+1);
+                              return (84148994 == i) ? 0 : 1;
+                              ])
+                         ],[
+                            ac_cv_c_alignment=none
+                            ],[
+                               ac_cv_c_alignment=need
+                               ],[
+                                  ac_cv_c_alignment=need
+                                  ])
+           ])
+         AS_IF([test "$ac_cv_c_alignment" = need],[
+                AC_DEFINE(NEED_ALIGN, 1, [Machine need alignment])
+                ])
+         ])
 
 AC_C_ALIGNMENT
 
@@ -483,7 +495,7 @@ dnl Check for our specific usage of GCC atomics.
 dnl These were added in 4.1.2, but 32bit OS's may lack shorts and 4.1.2
 dnl lacks testable defines.
 have_gcc_atomics=no
-AC_MSG_CHECKING(for GCC atomics)
+AC_MSG_CHECKING([for GCC atomics])
 AC_TRY_LINK([],[
   unsigned short a;
   unsigned short b;
@@ -499,8 +511,8 @@ dnl If you want to add support for other platforms you should check for
 dnl your requirements, define HAVE_DROP_PRIVILEGES, and make sure you add
 dnl the source file containing the implementation into memcached_SOURCE
 dnl in Makefile.am
-AC_CHECK_FUNCS(setppriv, [
-   AC_CHECK_HEADER(priv.h, [
+AC_CHECK_FUNCS([setppriv], [
+   AC_CHECK_HEADER([priv.h], [
       AC_DEFINE([HAVE_DROP_PRIVILEGES], 1,
          [Define this if you have an implementation of drop_privileges()])
       build_solaris_privs=yes
@@ -509,7 +521,7 @@ AC_CHECK_FUNCS(setppriv, [
 
 AM_CONDITIONAL([BUILD_SOLARIS_PRIVS],[test "$build_solaris_privs" = "yes"])
 
-AC_CHECK_HEADER(umem.h, [
+AC_CHECK_HEADER([umem.h], [
    AC_DEFINE([HAVE_UMEM_H], 1,
          [Define this if you have umem.h])
    build_cache=no
@@ -517,7 +529,7 @@ AC_CHECK_HEADER(umem.h, [
 
 AM_CONDITIONAL([BUILD_CACHE], [test "x$build_cache" = "xyes"])
 
-AC_ARG_ENABLE(docs,
+AC_ARG_ENABLE([docs],
   [AS_HELP_STRING([--disable-docs],[Disable documentation generation])])
 
 AC_PATH_PROG([XML2RFC], [xml2rfc], "no")
@@ -526,6 +538,7 @@ AC_PATH_PROG([XSLTPROC], [xsltproc], "no")
 AM_CONDITIONAL([BUILD_SPECIFICATIONS],
                [test "x$enable_docs" != "xno" -a "x$XML2RFC" != "xno" -a "x$XSLTPROC" != "xno"])
 
+AX_TEST_CC
 
 dnl Let the compiler be a bit more picky. Please note that you cannot
 dnl specify these flags to the compiler before AC_CHECK_FUNCS, because
@@ -551,5 +564,5 @@ then
   CFLAGS="$CFLAGS -errfmt=error -errwarn -errshort=tags"
 fi
 
-AC_CONFIG_FILES(Makefile doc/Makefile)
+AC_CONFIG_FILES([Makefile doc/Makefile])
 AC_OUTPUT

--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -3,10 +3,10 @@ use strict;
 use FindBin qw($Bin);
 chdir "$Bin/.." or die;
 
-my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md);
+my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md config.in);
 push(@exempted, glob("doc/*.xml"));
 push(@exempted, glob("doc/xml2rfc/*.xsl"));
-push(@exempted, glob("m4/*backport*m4"));
+push(@exempted, glob("m4/*m4"));
 my %exempted_hash = map { $_ => 1 } @exempted;
 
 my @stuff = split /\0/, `git ls-files -z -c -m -o --exclude-standard`;

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,313 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC to any special C compiler that is needed for
+#   multi-threaded programs (defaults to the value of CC otherwise). (This
+#   is necessary on AIX to use the special cc_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also link it with them as well. e.g. you should link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threads programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, defines PTHREAD_CREATE_JOINABLE to that name
+#   (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 18
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on True64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test x"$PTHREAD_LIBS$PTHREAD_CFLAGS" != x; then
+        save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        save_LIBS="$LIBS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS])
+        AC_TRY_LINK_FUNC(pthread_join, ax_pthread_ok=yes)
+        AC_MSG_RESULT($ax_pthread_ok)
+        if test x"$ax_pthread_ok" = xno; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try.  Items starting with a "-" are
+# C compiler flags, and other items are library names, except for "none"
+# which indicates that we try without any flags at all, and "pthread-config"
+# which is a program returning the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -kthread lthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+# lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads)
+# -pthreads: Solaris/gcc
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads too;
+#      also defines -D_REENTRANT)
+#      ... -mt is also the pthreads flag for HP/aCC
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case ${host_os} in
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed.  (We need to link with -pthreads/-mt/
+        # -lpthread.)  (The stubs are missing pthread_cleanup_push, or rather
+        # a function called by this macro, so we could check for that, but
+        # who knows whether they'll stub that too in a future libc.)  So,
+        # we'll just look for -pthreads and -lpthread first:
+
+        ax_pthread_flags="-pthreads pthread -mt -pthread $ax_pthread_flags"
+        ;;
+
+        darwin12*)
+        ax_pthread_flags="$ax_pthread_flags"
+        ;;
+
+        darwin*)
+        ax_pthread_flags="-pthread $ax_pthread_flags"
+        ;;
+esac
+
+if test x"$ax_pthread_ok" = xno; then
+for flag in $ax_pthread_flags; do
+
+        case $flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $flag])
+                PTHREAD_CFLAGS="$flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG(ax_pthread_config, pthread-config, yes, no)
+                if test x"$ax_pthread_config" = xno; then continue; fi
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$flag])
+                PTHREAD_LIBS="-l$flag"
+                ;;
+        esac
+
+        save_LIBS="$LIBS"
+        save_CFLAGS="$CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+                        static void routine(void *a) { a = 0; }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+                [ax_pthread_ok=yes],
+                [])
+
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+
+        AC_MSG_RESULT($ax_pthread_ok)
+        if test "x$ax_pthread_ok" = xyes; then
+                break;
+        fi
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+# Various other checks:
+if test "x$ax_pthread_ok" = xyes; then
+        save_LIBS="$LIBS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_MSG_CHECKING([for joinable pthread attribute])
+        attr_name=unknown
+        for attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                           [int attr = $attr; return attr /* ; */])],
+                [attr_name=$attr; break],
+                [])
+        done
+        AC_MSG_RESULT($attr_name)
+        if test "$attr_name" != PTHREAD_CREATE_JOINABLE; then
+            AC_DEFINE_UNQUOTED(PTHREAD_CREATE_JOINABLE, $attr_name,
+                               [Define to necessary symbol if this constant
+                                uses a non-standard name on your system.])
+        fi
+
+        AC_MSG_CHECKING([if more special flags are required for pthreads])
+        flag=no
+        case ${host_os} in
+            aix* | freebsd* | darwin*) flag="-D_THREAD_SAFE";;
+            osf* | hpux*) flag="-D_REENTRANT";;
+            solaris*)
+            if test "$GCC" = "yes"; then
+                flag="-D_REENTRANT"
+            else
+                flag="-mt -D_REENTRANT"
+            fi
+            ;;
+        esac
+        AC_MSG_RESULT(${flag})
+        if test "x$flag" != xno; then
+            PTHREAD_CFLAGS="$flag $PTHREAD_CFLAGS"
+        fi
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            ax_cv_PTHREAD_PRIO_INHERIT, [
+                AC_LINK_IFELSE([
+                    AC_LANG_PROGRAM([[#include <pthread.h>]], [[int i = PTHREAD_PRIO_INHERIT;]])],
+                    [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                    [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes"],
+            AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], 1, [Have PTHREAD_PRIO_INHERIT.]))
+
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+
+        # More AIX lossage: must compile with xlc_r or cc_r
+        if test x"$GCC" != xyes; then
+          AC_CHECK_PROGS(PTHREAD_CC, xlc_r cc_r, ${CC})
+        else
+          PTHREAD_CC=$CC
+        fi
+else
+        PTHREAD_CC="$CC"
+fi
+
+AC_SUBST(PTHREAD_LIBS)
+AC_SUBST(PTHREAD_CFLAGS)
+AC_SUBST(PTHREAD_CC)
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test x"$ax_pthread_ok" = xyes; then
+        ifelse([$1],,AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.]),[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD

--- a/m4/ax_restore_flags.m4
+++ b/m4/ax_restore_flags.m4
@@ -1,0 +1,31 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_restore_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_RESTORE_FLAGS()
+#
+# DESCRIPTION
+#
+#   Restore common compilation flags from temporary variables
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Filippo Giunchedi <filippo@esaurito.net>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 3
+
+AC_DEFUN([AX_RESTORE_FLAGS], [
+  CPPFLAGS="${CPPFLAGS_save}"
+  CFLAGS="${CFLAGS_save}"
+  CXXFLAGS="${CXXFLAGS_save}"
+  OBJCFLAGS="${OBJCFLAGS_save}"
+  LDFLAGS="${LDFLAGS_save}"
+  LIBS="${LIBS_save}"
+])

--- a/m4/ax_save_flags.m4
+++ b/m4/ax_save_flags.m4
@@ -1,0 +1,31 @@
+# ===========================================================================
+#       http://www.gnu.org/software/autoconf-archive/ax_save_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_SAVE_FLAGS()
+#
+# DESCRIPTION
+#
+#   Save common compilation flags into temporary variables
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Filippo Giunchedi <filippo@esaurito.net>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 3
+
+AC_DEFUN([AX_SAVE_FLAGS], [
+  CPPFLAGS_save="${CPPFLAGS}"
+  CFLAGS_save="${CFLAGS}"
+  CXXFLAGS_save="${CXXFLAGS}"
+  OBJCFLAGS_save="${OBJCFLAGS}"
+  LDFLAGS_save="${LDFLAGS}"
+  LIBS_save="${LIBS}"
+])


### PR DESCRIPTION
... tests had been completed.

2) Adds a better test for pthreads (more platforms, etc).
3) Cleans up quoting in in configure.ac (not all of it,... but a lot of it).
4) A number of portability issues in configure.ac are not fixed.
5) make maintainer-clean now works.
