### PR TITLE
Fix segfault if memcached recieved next string, that did "c->rlbytes" not correct int number.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3871,6 +3871,16 @@ static void drive_machine(conn *c) {
                 complete_nread(c);
                 break;
             }
+
+            /* seems that we don't recieved int */
+            if (c->rlbytes < 0) {
+                if (settings.verbose > 0)
+                    fprintf(stderr, "Invalid rlbytes to read:  len %u\n", c->rlbytes);
+
+                conn_set_state(c, conn_closing);
+                break;
+            }
+
             /* first check if we have leftovers in the conn_read buffer */
             if (c->rbytes > 0) {
                 int tocopy = c->rbytes > c->rlbytes ? c->rlbytes : c->rbytes;


### PR DESCRIPTION
`echo -en
'\x80\x12\x00\x01\x08\x00\x00\x00\xff\xff\xff\xe8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x01\x00\x00\x00\x00\x00\x00\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
| nc localhost 11211`

Patch was written by sherlockhua@163.com.
I just did refactoring.

Issue at code.google.com
https://code.google.com/p/memcached/issues/detail?id=192
