### PR TITLE
check libevent compile-time version and runtime version at runtime

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4702,6 +4702,14 @@ static bool sanitycheck(void) {
         }
     }
 
+    if (strcmp(ever, LIBEVENT_VERSION) != 0) {
+        fprintf(stderr, "Running with a libevent version (%s) different from the"
+                " one we were built with (%s).\n"
+                " Try rerun ./configure --with-libevent=PATH.\n",
+                ever, LIBEVENT_VERSION);
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Check at runtime that compile-time version (in header file) and runtime version (in the lib memcached linked with) of libevent match. 
If the versions don't match, wired things happen.
In my case, I install both 2.0.19-stable (with Ubuntu apt-get, header files in /usr/include, libs in /usr/lib/x86_64-linux-gnu/) and 2.1.2-alpha-dev in /usr/local. 
If I don't specify --with-libevent=/usr/local when running configure, it seems that memcached use the header file in /usr/local/include and the lib in /usr/lib/x86_64-linux-gnu/. In this case memcached doesn't work, and continuously prints "[warn] event_del: event has no event_base set." when new connections come.
