### PR TITLE
add aclocal-1.12 in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -26,7 +26,7 @@ locate_binary() {
 
 echo "aclocal..."
 if test x$ACLOCAL = x; then
-  ACLOCAL=`locate_binary aclocal-1.11 aclocal-1.10 aclocal-1.9 aclocal19 aclocal-1.7 aclocal17 aclocal-1.5 aclocal15 aclocal`
+  ACLOCAL=`locate_binary aclocal-1.12 aclocal-1.11 aclocal-1.10 aclocal-1.9 aclocal19 aclocal-1.7 aclocal17 aclocal-1.5 aclocal15 aclocal`
   if test x$ACLOCAL = x; then
     die "Did not find a supported aclocal"
   fi


### PR DESCRIPTION
My aclocal and automake has multi version. And When I run autogen.sh,
automake is using 1.12 but aclocal not,then some error happen:

[liubo@linux64 memcached]$ ./autogen.sh
aclocal...
autoheader...
automake...
configure.ac:7: error: version mismatch.  This is Automake 1.12,
configure.ac:7: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:7: comes from Automake 1.7.9.  You should recreate
configure.ac:7: aclocal.m4 with aclocal and run automake again.
configure.ac:7: error: version mismatch.  This is Automake 1.12,
configure.ac:7: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:7: comes from Automake 1.7.9.  You should recreate
configure.ac:7: aclocal.m4 with aclocal and run automake again.
doc/Makefile.am:12: warning: '%'-style pattern rules are a GNU make
extension
doc/Makefile.am:15: warning: '%'-style pattern rules are a GNU make
extension
doc/Makefile.am:18: warning: '%'-style pattern rules are a GNU make
extension

my aclocal:
[liubo@linux64 memcached]$ aclocal
aclocal       aclocal-1.12  aclocal-1.4   aclocal-1.5   aclocal-1.6
aclocal-1.7

my automake
[liubo@linux64 memcached]$ automake
automake       automake-1.12  automake-1.4   automake-1.5   automake-1.6
automake-1.7
