### PR TITLE
Allow proper shutdown by adding libevent's loop-break to SIGINT handler

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4625,7 +4625,9 @@ static void remove_pidfile(const char *pid_file) {
 
 static void sig_handler(const int sig) {
     printf("SIGINT handled.\n");
-    exit(EXIT_SUCCESS);
+    if(event_base_loopbreak(main_base) != 0) {
+      exit(EXIT_SUCCESS);
+    }
 }
 
 #ifndef HAVE_SIGIGNORE


### PR DESCRIPTION
This may be related to known issues with PID file, but SIGINT terminates entire application without allowing shutdown sequence to complete. 

``` C
  /* enter the event loop */
  if (event_base_loop(main_base, 0) != 0) {  
    retval = EXIT_FAILURE;
  } 
  // Everything below is unreachable
```

Ideally, `sig_handler` would interrupt event's main loop, and allow memcached to free resources properly.
