### PR TITLE
Record and report on time spent in listen_disabled

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -271,6 +271,8 @@ struct stats {
     uint64_t      evicted_unfetched; /* items evicted but never touched */
     bool          slab_reassign_running; /* slab reassign in progress */
     uint64_t      slabs_moved;       /* times slabs were moved around */
+    uint64_t      time_in_listen_disabled_us;  /* elapsed time in microseconds while server unable to process new connections */
+    struct timeval maxconns_entered;  /* last time maxconns entered */
 };
 
 #define MAX_VERBOSITY_LEVEL 2

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3549;
+use Test::More tests => 3561;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -61,7 +61,6 @@ my $mc = MC::Client->new;
 # Let's turn on detail stats for all this stuff
 
 $mc->stats('detail on');
-
 my $check = sub {
     my ($key, $orig_flags, $orig_val) = @_;
     my ($flags, $val, $cas) = $mc->get($key);

--- a/t/stats.t
+++ b/t/stats.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 95;
+use Test::More tests => 96;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -44,6 +44,7 @@ my $sock = $server->sock;
 ## STAT limit_maxbytes 67108864
 ## STAT accepting_conns 1
 ## STAT listen_disabled_num 0
+## STAT time_in_listen_disabled_us 0
 ## STAT threads 4
 ## STAT conn_yields 0
 ## STAT bytes 0
@@ -58,12 +59,12 @@ my $sock = $server->sock;
 my $stats = mem_stats($sock);
 
 # Test number of keys
-is(scalar(keys(%$stats)), 48, "48 stats values");
+is(scalar(keys(%$stats)), 49, "49 stats values");
 
 # Test initial state
 foreach my $key (qw(curr_items total_items bytes cmd_get cmd_set get_hits evictions get_misses
                  bytes_written delete_hits delete_misses incr_hits incr_misses decr_hits
-                 decr_misses listen_disabled_num)) {
+                 decr_misses listen_disabled_num time_in_listen_disabled_us)) {
     is($stats->{$key}, 0, "initial $key is zero");
 }
 is($stats->{accepting_conns}, 1, "initial accepting_conns is one");


### PR DESCRIPTION
Hi. 

We had some issues on production where we were in a listen_disabled state and it would have been operationally useful to know how long the server was in this state across the various events.

I've written a patch which reports on the time the server is in the listen_disabled state in microseconds.

Thanks for your time!

zwischenzugs