### PR TITLE
Added parameter to disable flush_all (nice to have on production)

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -308,6 +308,7 @@ struct settings {
     int slab_automove;     /* Whether or not to automatically move slabs */
     int hashpower_init;     /* Starting hash power level */
     bool shutdown_command; /* allow shutdown command */
+    bool flush_enabled;     /* flush_all enabled */
 };
 
 extern struct stats stats;

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3549;
+use Test::More tests => 3553;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -414,6 +414,7 @@ $mc->silent_mutation(::CMD_ADDQ, 'silentadd', 'silentaddval');
     is('NULL', $stats{'domain_socket'});
     is('on', $stats{'evictions'});
     is('yes', $stats{'cas_enabled'});
+    is('yes', $stats{'flush_enabled'});
 }
 
 # diag "Test quit commands.";


### PR DESCRIPTION
On production environments, its nice to have an option to disable flush_all to avoid accidental flushes. Also is good to have a more secure memcached server.
