### PR TITLE
Fix for issue 320: incorrect initial value length stored for binary incr command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1087,12 +1087,16 @@ static void complete_incr_bin(conn *c) {
         if (req->message.body.expiration != 0xffffffff) {
             /* Save some room for the response */
             rsp->message.body.value = htonll(req->message.body.initial);
+
+            snprintf(tmpbuf, INCR_MAX_STORAGE_LEN, "%llu",
+                (unsigned long long)req->message.body.initial);
+            int res = strlen(tmpbuf);
             it = item_alloc(key, nkey, 0, realtime(req->message.body.expiration),
-                            INCR_MAX_STORAGE_LEN);
+                            res + 2);
 
             if (it != NULL) {
-                snprintf(ITEM_data(it), INCR_MAX_STORAGE_LEN, "%llu",
-                         (unsigned long long)req->message.body.initial);
+                memcpy(ITEM_data(it), tmpbuf, res);
+                memcpy(ITEM_data(it) + res, "\r\n", 2);
 
                 if (store_item(it, NREAD_ADD, c)) {
                     c->cas = ITEM_get_cas(it);

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3549;
+use Test::More tests => 3560;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -190,6 +190,15 @@ is($mc->incr("x", 2**33), 8589934804, "Blast the 32bit border");
     $rv =()= eval { $mc->decr('issue48'); };
     ok($@ && $@->delta_badval, "Expected invalid value when decrementing text.");
     $check->('issue48', 0, "text");
+}
+
+# diag "Issue 320 - incr/decr wrong length for initial value";
+{
+    $mc->flush;
+    is($mc->incr("issue320", 1, 1, 0), 1, "incr initial value is 1");
+    my (undef, $rv, undef) = $mc->get("issue320");
+    is(length($rv), 1, "initial value length is 1");
+    is($rv, "1", "initial value is 1");
 }
 
 


### PR DESCRIPTION
Possible fix for issue 320:
http://code.google.com/p/memcached/issues/detail?id=320

Also added unit test to check the length of get(k) after incr(k)
