### PR TITLE
Bug fix. Issue#325.

### DIFF
--- a/daemon/memcached.c
+++ b/daemon/memcached.c
@@ -3183,13 +3183,13 @@ static void process_bin_update(conn *c) {
     case ENGINE_DISCONNECT:
         c->state = conn_closing;
         break;
+    case ENGINE_E2BIG:
+        write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_E2BIG, vlen);
+        c->write_and_go = conn_swallow;
+        break;
     default:
-        if (ret == ENGINE_E2BIG) {
-            write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_E2BIG, vlen);
-        } else {
-            write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_ENOMEM, vlen);
-        }
-
+        write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_ENOMEM, vlen);
+        
         /*
          * Avoid stale data persisting in cache because we failed alloc.
          * Unacceptable for SET (but only if cas matches).


### PR DESCRIPTION
If the user sends "SET k v" and memcached cannot allocate space for v,
memcached will DELETE k. The comment for this reads "Avoid stale data
persisting in cache because we failed alloc." That makes sense.
But this also happened in the case of ENGINE_E2BIG.  E2BIG is a protocol
error, a request that will _always_ fail, and the user should expect it to
have no side effects.
