### PR TITLE
Do not bind to same interface more than once. Fixes #328

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4832,6 +4832,9 @@ int main (int argc, char **argv) {
             break;
         case 'l':
             if (settings.inter != NULL) {
+                if (strstr(settings.inter, optarg) != NULL) {
+                    break;
+                }
                 size_t len = strlen(settings.inter) + strlen(optarg) + 2;
                 char *p = malloc(len);
                 if (p == NULL) {


### PR DESCRIPTION
Before 6ba9aa2771adcf785fe3fde03cd71832db15b086, multiple -l arguments
were ignored, and the last option passed was the one actually used.

This changes the behaviour to silently ignore duplicate -l flag options
passed and not crash and burn on the bind() call.

https://code.google.com/p/memcached/issues/detail?id=328
