### PR TITLE
Fixing the whitespace test

### DIFF
--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -11,6 +11,7 @@ BEGIN {
     push(@exempted, glob("doc/xml2rfc/*.xsl"));
     push(@exempted, glob("m4/*backport*m4"));
     push(@exempted, glob(".*project"));
+    push(@exempted, glob(qx/find . -type l -printf '%P\n'/));
     my %exempted_hash = map { $_ => 1 } @exempted;
 
     my @stuff = split /\0/, `git ls-files -z -c -m -o --exclude-standard`;


### PR DESCRIPTION
This makes the whitespace test ignore symlinks which are created by the build process (such as compile, which points to automake's compile).

I have this problem on OSX and macports.
