### PR TITLE
fix for "variable length array folded to constant array as an extension"...

### DIFF
--- a/testapp.c
+++ b/testapp.c
@@ -1807,7 +1807,7 @@ static enum test_return test_binary_pipeline_hickup(void)
 
 
 static enum test_return test_issue_101(void) {
-    const int max = 2;
+    enum { max = 2 };
     enum test_return ret = TEST_PASS;
     int fds[max];
     int ii = 0;


### PR DESCRIPTION
make fails with latest Mac OS X

testapp.c:1788:13: error: variable length array folded to constant array as an extension [-Werror,-Wpedantic]
    int fds[max];
            ^~~
1 error generated.
