### PR TITLE
Fix udp mode when listening on ipv6 addresses.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3573,7 +3573,8 @@ static enum try_read_result try_read_udp(conn *c) {
 
     c->request_addr_size = sizeof(c->request_addr);
     res = recvfrom(c->sfd, c->rbuf, c->rsize,
-                   0, &c->request_addr, &c->request_addr_size);
+                   0, (struct sockaddr *)&c->request_addr,
+                   &c->request_addr_size);
     if (res > 8) {
         unsigned char *buf = (unsigned char *)c->rbuf;
         pthread_mutex_lock(&c->thread->stats.mutex);

--- a/memcached.h
+++ b/memcached.h
@@ -436,7 +436,7 @@ struct conn {
 
     /* data for UDP clients */
     int    request_id; /* Incoming UDP request ID, if this is a UDP "connection" */
-    struct sockaddr request_addr; /* Who sent the most recent request */
+    struct sockaddr_in6 request_addr; /* udp: Who sent the most recent request */
     socklen_t request_addr_size;
     unsigned char *hdrbuf; /* udp packet headers */
     int    hdrsize;   /* number of headers' worth of space is allocated */


### PR DESCRIPTION
Previously memcached could not respond to ipv6 udp packets correctly, since the client's address was stored in a struct sockaddr (16 bytes on linux) instead of a struct sockaddr_in6 (28 bytes).
