### PR TITLE
Stampede/Thundering Herd protection

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -311,6 +311,7 @@ struct settings {
     bool shutdown_command; /* allow shutdown command */
     int tail_repair_time;   /* LRU tail refcount leak repair time */
     bool flush_enabled;     /* flush_all enabled */
+    int anti_stampede;
 };
 
 extern struct stats stats;
@@ -324,7 +325,7 @@ extern struct settings settings;
 #define ITEM_SLABBED 4
 
 #define ITEM_FETCHED 8
-
+#define ITEM_FAKE_MISSED 16
 /**
  * Structure for storing items within memcached.
  */


### PR DESCRIPTION
Simply fake a NOT FOUND on one get request when the item is about to expire.

The time it takes to recover from some stampedes can be dramatically high, depending on the time it takes to calculate the key's value.

I just thought it will be very simple to fake a miss to one of the get requests, it will take its time calculating the value
and update it, without the other guys noticing anything.

This pull request is very limited, as it keeps the state locally, but still having (nodes*fake misses) is manageable.

P.S. I am almost certain that there is better way to implement this, so think of this pull request more as of 'request for comment' on the idea to include somekind of stampede protection in memcached
