### PR TITLE
Don't lose item_size_max units in command line

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4829,6 +4829,7 @@ int main (int argc, char **argv) {
     char *pid_file = NULL;
     struct passwd *pw;
     struct rlimit rlim;
+    char *buf;
     char unit = '\0';
     int size_max = 0;
     int retval = EXIT_SUCCESS;
@@ -5050,18 +5051,19 @@ int main (int argc, char **argv) {
             }
             break;
         case 'I':
-            unit = optarg[strlen(optarg)-1];
+            buf = strdup(optarg);
+            unit = buf[strlen(buf)-1];
             if (unit == 'k' || unit == 'm' ||
                 unit == 'K' || unit == 'M') {
-                optarg[strlen(optarg)-1] = '\0';
-                size_max = atoi(optarg);
+                buf[strlen(buf)-1] = '\0';
+                size_max = atoi(buf);
                 if (unit == 'k' || unit == 'K')
                     size_max *= 1024;
                 if (unit == 'm' || unit == 'M')
                     size_max *= 1024 * 1024;
                 settings.item_size_max = size_max;
             } else {
-                settings.item_size_max = atoi(optarg);
+                settings.item_size_max = atoi(buf);
             }
             if (settings.item_size_max < 1024) {
                 fprintf(stderr, "Item max size cannot be less than 1024 bytes.\n");
@@ -5078,6 +5080,7 @@ int main (int argc, char **argv) {
                     " and will decrease your memory efficiency.\n"
                 );
             }
+            free(buf);
             break;
         case 'S': /* set Sasl authentication to true. Default is false */
 #ifndef ENABLE_SASL


### PR DESCRIPTION
Hi. This patch fixes problem that units in -I option isn't shown.
# > ps -ocmd -C memcached

/usr/bin/memcached -m 4096 -p 11211 -u nobody -l 0.0.0.0 -I 8
