### PR TITLE
hacked in some basic idle timeout functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -553,6 +553,13 @@ AM_CONDITIONAL([BUILD_CACHE], [test "x$build_cache" = "xyes"])
 AC_ARG_ENABLE(docs,
   [AS_HELP_STRING([--disable-docs],[Disable documentation generation])])
 
+AC_ARG_ENABLE(idle-timeouts,
+  [AS_HELP_STRING([--enable-idle-timeouts],[Enable per-connection idle timeouts (not for high-volume use!)])])
+
+AS_IF([test "x$enable_idle_timeouts" = "xyes"],
+  [AC_DEFINE([ENABLE_IDLE_TIMEOUTS], 1,
+    [Set to nonzero if you want per-connection idle timeouts (not intended for extremely high connecton count usage)])])
+
 AC_PATH_PROG([XML2RFC], [xml2rfc], "no")
 AC_PATH_PROG([XSLTPROC], [xsltproc], "no")
 

--- a/memcached.h
+++ b/memcached.h
@@ -250,6 +250,9 @@ struct stats {
     unsigned int  curr_conns;
     unsigned int  total_conns;
     uint64_t      rejected_conns;
+#ifdef ENABLE_IDLE_TIMEOUTS
+    uint64_t      idle_disc_conns;
+#endif
     uint64_t      malloc_fails;
     unsigned int  reserved_fds;
     unsigned int  conn_structs;
@@ -311,6 +314,9 @@ struct settings {
     bool shutdown_command; /* allow shutdown command */
     int tail_repair_time;   /* LRU tail refcount leak repair time */
     bool flush_enabled;     /* flush_all enabled */
+#ifdef ENABLE_IDLE_TIMEOUTS
+    unsigned int idle_timeout; /* Disconnect after this many idle seconds */
+#endif
 };
 
 extern struct stats stats;
@@ -450,6 +456,11 @@ struct conn {
         size_t size;
         size_t offset;
     } stats;
+
+    /* timeout extension */
+    unsigned int timeout;
+    unsigned int *timeout_pending;
+    struct event timeout_event;
 
     /* Binary protocol stuff */
     /* This is where the binary header goes */

--- a/memcached.h
+++ b/memcached.h
@@ -457,10 +457,12 @@ struct conn {
         size_t offset;
     } stats;
 
+#ifdef ENABLE_IDLE_TIMEOUTS
     /* timeout extension */
     unsigned int timeout;
     unsigned int *timeout_pending;
     struct event timeout_event;
+#endif
 
     /* Binary protocol stuff */
     /* This is where the binary header goes */


### PR DESCRIPTION
**Idle timeout support:**

The following PR provides basic idle timeout support for the 1.4 tree. I realize this isn't the "active development" branch, but it is the one I was required to work with so this is what I'm sending back upstream.

Timeouts are configured globally, in seconds, via the `-T` command line argument. Default timeout is 0 -- *no timeout*. Each connection's timer is, of course, distinct. Each connection's idle timer is reset to the global initial value during *any* I/O and cleared when a connection is finalized. Idle timeouts are not meaningful with regard to UDP sockets and thus are not applied to them. Timeouts are handled synchronously, via libevent, and will perform a clean disconnect if/when they fire on a valid active connection.

Idle timeout support is enabled via ``./configure --enable-idle-timouts``, but one must still supply `-T` on the command line to activate at run-time.

A new stat is provided to track idle disconnections -``idle_disconnected_connections``. This counter can be viewed just like the rest of the general statistics.

Use of this feature is not recommended in extremely high connection count environments as the overhead could begin to take its toll when there are many thousands of concurrent connections.