### PR TITLE
Issue 360 - Alignment check on in configure.ac is broken and results in addition memcpy()s

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -493,15 +493,18 @@ AC_DEFUN([AC_C_ALIGNMENT],
        *ptr = 0x1;
 
        // catch unaligned word access (ARM cpus)
-       *buf =  1; *(buf +1) = 2; *(buf + 2) = 2; *(buf + 3) = 3; *(buf + 4) = 4;
-       int* i = (int*)(buf+1);
-       return (
 #ifdef ENDIAN_BIG
-                0x02030405
+#define ALIGNMENT 0x02030405
 #else
-                0x05040302
+#define ALIGNMENT 0x05040302
 #endif
-                        == *i) ? 0 : 1;
+       *(buf + 0) = 1;
+       *(buf + 1) = 2;
+       *(buf + 2) = 3;
+       *(buf + 3) = 4;
+       *(buf + 4) = 5;
+       int* i = (int*)(buf+1);
+       return (ALIGNMENT == *i) ? 0 : 1;
     ])
   ],[
     ac_cv_c_alignment=none


### PR DESCRIPTION
### Scope of Change

Rewriting of existing alignment check. Merge of previous pull request [#3](https://github.com/memcached/memcached/pull/3), and [Issue 360](https://code.google.com/p/memcached/issues/detail?id=360). 
### Testing Hardware

Testing was complete on a G5 PowerPC, running Debian OS.  _Note:_ An additional patch was need to allow test suite to complete on system, but has been omitted from commit.

``` diff
diff --git a/testapp.c b/testapp.c
index 5a62aca..0aff644 100644
--- a/testapp.c
+++ b/testapp.c
@@ -1037,6 +1037,7 @@ static enum test_return test_binary_quit_impl(uint8_t cmd) {
                                  PROTOCOL_BINARY_RESPONSE_SUCCESS);
     }

+    usleep(1); /* let socket catch up */
     /* Socket should be closed now, read should return 0 */
     assert(read(sock, buffer.bytes, sizeof(buffer.bytes)) == 0);
     close(sock);
```
### Testing Evidence

Below is a diff between release 1.4.18 (testapp-memcached-1.4.18.log) & this pull request (testapp-memcached-360fix.log). Both executed on the same machine with the above patch applied.

``` diff
--- testapp-memcached-1.4.18.log    2014-04-25 00:02:50.294848641 +0000
+++ testapp-memcached-360fix.log    2014-04-25 00:57:39.952546993 +0000
@@ -1,8 +1,8 @@
 ./sizes
 Slab Stats 64
 Thread stats   200
-Global stats   224
-Settings   128
+Global stats   216
+Settings   120
 Item (no cas)  32
 Item (cas) 40
 Libevent thread    104
@@ -62,6 +62,8 @@
 ok 47 - shutdown
 ok 48 - stop_server
 prove ./t
+getaddrinfo(): Name or service not known
+failed to listen on TCP port 42353: Success
 slab class   1: chunk size        80 perslab   13107
 slab class   2: chunk size       104 perslab   10082
 slab class   3: chunk size       136 perslab    7710
@@ -232,8 +234,6 @@
 <36 connection closed.
 Invalid value for binding protocol: http
  -- should be one of auto, binary, or ascii
-getaddrinfo(): Name or service not known
-failed to listen on TCP port 40191: Success
 Number of threads must be greater than 0
 t/00-startup.t ....... ok
 t/64bit.t ............ skipped: Skipping 64-bit tests on 32-bit build
@@ -279,7 +279,6 @@
  and will decrease your memory efficiency.
 t/item_size_max.t .... ok
 t/line-lengths.t ..... ok
-t/lru-crawler.t ...... ok
 t/lru.t .............. ok
 t/maxconns.t ......... ok
 t/multiversioning.t .. ok
@@ -291,18 +290,17 @@
 t/touch.t ............ ok
 t/udp.t .............. ok
 t/unixsocket.t ....... ok
-fatal: Not a git repository (or any of the parent directories): .git
-t/whitespace.t ....... skipped: Skipping tests probably because you don't have git.
+t/whitespace.t ....... ok
 All tests successful.
-Files=48, Tests=7077, 363 wallclock secs (48.72 usr  4.56 sys + 131.10 cusr 40.36 csys = 224.74 CPU)
+Files=47, Tests=6986, 368 wallclock secs (52.89 usr  4.79 sys + 137.09 cusr 40.06 csys = 234.83 CPU)
 Result: PASS
 File 'assoc.c' Lines executed:44.44% of 117 
 File 'cache.c' Lines executed:53.33% of 75 
 File 'daemon.c' Lines executed:9.09% of 22 
 File 'hash.c' Lines executed:62.50% of 8 
-File 'items.c' Lines executed:82.63% of 518 
+File 'items.c' Lines executed:85.76% of 316 
 File 'jenkins_hash.c' Lines executed:100.00% of 56 
-File 'memcached.c' Lines executed:70.54% of 2695 
+File 'memcached.c' Lines executed:71.22% of 2627 
 File 'murmur3_hash.c' Lines executed:0.00% of 32 
 File 'slabs.c' Lines executed:70.98% of 410 
 File 'stats.c' Lines executed:90.36% of 83 
```
