### PR TITLE
Use unlink instead of `rm -f` in start-memcached script

### DIFF
--- a/scripts/start-memcached
+++ b/scripts/start-memcached
@@ -97,7 +97,7 @@ if(-e $pidfile)
         print STDERR "memcached is already running.\n";
         exit;
     }else{
-        `rm -f $localpid`;
+        unlink $pidfile;
     }
 
 }


### PR DESCRIPTION
This is necessary for an Upstart job, because the call out to rm -f causes Perl to fork off a process, and Upstart think that new process is the main one (not the exec'd memcached process later on).