### PR TITLE
fixed libevent version check: add the missing 1.0.x version check

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -5004,7 +5004,7 @@ static bool sanitycheck(void) {
     if (ever != NULL) {
         if (strncmp(ever, "1.", 2) == 0) {
             /* Require at least 1.3 (that's still a couple of years old) */
-            if ((ever[2] == '1' || ever[2] == '2') && !isdigit(ever[3])) {
+            if (('0' <= ever[2] && ever[2] < '3') && !isdigit(ever[3])) {
                 fprintf(stderr, "You are using libevent %s.\nPlease upgrade to"
                         " a more recent version (1.3 or newer)\n",
                         event_get_version());


### PR DESCRIPTION
The origin code only check the 1.1.x & 1.2.x version, however libevent has 1.0.x release.