### PR TITLE
idle connection kicker using 'stats conns' and event notifier frameworks

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -604,6 +604,8 @@ integers separated by a colon (treat this as a floating point number).
 | auth_cmds             | 64u     | Number of authentication commands         |
 |                       |         | handled, success or failure.              |
 | auth_errors           | 64u     | Number of failed authentications.         |
+| idle_kicks            | 64u     | Number of connections closed due to       |
+|                       |         | reaching their idle timeout.              |
 | evictions             | 64u     | Number of valid items removed from cache  |
 |                       |         | to free memory for new items              |
 | reclaimed             | 64u     | Number of times an entry was stored using |
@@ -709,13 +711,15 @@ other stats command.
 | lru_crawler       | bool     | Whether the LRU crawler is enabled           |
 | lru_crawler_sleep | 32       | Microseconds to sleep between LRU crawls     |
 | lru_crawler_tocrawl                                                         |
-|                   | 32u     | Max items to crawl per slab per run           |
+|                   | 32u      | Max items to crawl per slab per run          |
 | lru_maintainer_thread                                                       |
-|                   | bool    | Split LRU mode and background threads         |
-| hot_lru_pct       | 32      | Pct of slab memory reserved for HOT LRU       |
-| warm_lru_pct      | 32      | Pct of slab memory reserved for WARM LRU      |
+|                   | bool     | Split LRU mode and background threads        |
+| hot_lru_pct       | 32       | Pct of slab memory reserved for HOT LRU      |
+| warm_lru_pct      | 32       | Pct of slab memory reserved for WARM LRU     |
 | expirezero_does_not_evict                                                   |
-|                   | bool    | If yes, items with 0 exptime cannot evict     |
+|                   | bool     | If yes, items with 0 exptime cannot evict    |
+| idle_time         | 0        | Drop connections that are idle this many     |
+|                   |          | seconds (0 disables)                         |
 |-------------------+----------+----------------------------------------------|
 
 

--- a/memcached.h
+++ b/memcached.h
@@ -202,6 +202,7 @@ enum pause_thread_types {
     RESUME_WORKER_THREADS
 };
 
+#define IS_TCP(x) (x == tcp_transport)
 #define IS_UDP(x) (x == udp_transport)
 
 #define NREAD_ADD 1
@@ -254,6 +255,7 @@ struct thread_stats {
     uint64_t          conn_yields; /* # of yields for connections (-R option)*/
     uint64_t          auth_cmds;
     uint64_t          auth_errors;
+    uint64_t          idle_kicks;  /* idle connections killed */
     struct slab_stats slab_stats[MAX_NUMBER_OF_SLAB_CLASSES];
 };
 
@@ -353,6 +355,7 @@ struct settings {
     int warm_lru_pct; /* percentage of slab space for WARM_LRU */
     int crawls_persleep; /* Number of LRU crawls to run before sleeping */
     bool expirezero_does_not_evict; /* exptime == 0 goes into NOEXP_LRU */
+    int idle_timeout;       /* Number of seconds to let connections idle */
 };
 
 extern struct stats stats;
@@ -592,6 +595,7 @@ enum delta_result_type add_delta(conn *c, const char *key,
 void accept_new_conns(const bool do_accept);
 conn *conn_from_freelist(void);
 bool  conn_add_to_freelist(conn *c);
+void  conn_close_idle(conn *c);
 int   is_listen_thread(void);
 item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbytes);
 item *item_get(const char *key, const size_t nkey, conn *c);

--- a/t/idle-timeout.t
+++ b/t/idle-timeout.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 11;
+
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+# start up a server with 10 maximum connections
+my $server = new_memcached("-o idle_timeout=3");
+my $sock = $server->sock;
+
+# Make sure we can talk to start with
+my $stats = mem_stats($sock);
+is($stats->{idle_kicks}, "0", "check stats initial");
+isnt($sock->connected(), undef, "check connected");
+
+# Make sure we don't timeout when active
+for (my $i = 0; $i < 6; $i++) {
+    $stats = mem_stats($sock);
+    isnt($stats->{version}, undef, "check active $i");
+}
+$stats = mem_stats($sock);
+is($stats->{idle_kicks}, "0", "check stats 2");
+
+# Make sure we do timeout when not
+sleep(5);
+mem_stats($sock);   # Network activity, so socket code will see dead socket
+sleep(1);
+is($sock->connected(), undef, "check disconnected");
+
+$sock = $server->sock;
+$stats = mem_stats($sock);
+isnt($stats->{idle_kicks}, 0, "check stats timeout");

--- a/thread.c
+++ b/thread.c
@@ -398,31 +398,32 @@ static void thread_libevent_process(int fd, short which, void *arg) {
 
     switch (buf[0]) {
     case 'c':
-    item = cq_pop(me->new_conn_queue);
+        item = cq_pop(me->new_conn_queue);
 
-    if (NULL != item) {
-        conn *c = conn_new(item->sfd, item->init_state, item->event_flags,
-                           item->read_buffer_size, item->transport, me->base);
-        if (c == NULL) {
-            if (IS_UDP(item->transport)) {
-                fprintf(stderr, "Can't listen for events on UDP socket\n");
-                exit(1);
-            } else {
-                if (settings.verbose > 0) {
-                    fprintf(stderr, "Can't listen for events on fd %d\n",
-                        item->sfd);
+        if (NULL != item) {
+            conn *c = conn_new(item->sfd, item->init_state, item->event_flags,
+                               item->read_buffer_size, item->transport,
+                               me->base);
+            if (c == NULL) {
+                if (IS_UDP(item->transport)) {
+                    fprintf(stderr, "Can't listen for events on UDP socket\n");
+                    exit(1);
+                } else {
+                    if (settings.verbose > 0) {
+                        fprintf(stderr, "Can't listen for events on fd %d\n",
+                            item->sfd);
+                    }
+                    close(item->sfd);
                 }
-                close(item->sfd);
+            } else {
+                c->thread = me;
             }
-        } else {
-            c->thread = me;
+            cqi_free(item);
         }
-        cqi_free(item);
-    }
         break;
     /* we were told to pause and report in */
     case 'p':
-    register_thread_initialized();
+        register_thread_initialized();
         break;
     }
 }

--- a/thread.c
+++ b/thread.c
@@ -391,10 +391,13 @@ static void thread_libevent_process(int fd, short which, void *arg) {
     LIBEVENT_THREAD *me = arg;
     CQ_ITEM *item;
     char buf[1];
+    unsigned int timeout_fd;
 
-    if (read(fd, buf, 1) != 1)
+    if (read(fd, buf, 1) != 1) {
         if (settings.verbose > 0)
             fprintf(stderr, "Can't read from libevent pipe\n");
+        return;
+    }
 
     switch (buf[0]) {
     case 'c':
@@ -424,6 +427,15 @@ static void thread_libevent_process(int fd, short which, void *arg) {
     /* we were told to pause and report in */
     case 'p':
         register_thread_initialized();
+        break;
+    /* a client socket timed out */
+    case 't':
+        if (read(fd, &timeout_fd, sizeof(timeout_fd)) != sizeof(timeout_fd)) {
+            if (settings.verbose > 0)
+                fprintf(stderr, "Can't read timeout fd from libevent pipe\n");
+            return;
+        }
+        conn_close_idle(conns[timeout_fd]);
         break;
     }
 }
@@ -673,6 +685,7 @@ void threadlocal_stats_reset(void) {
         threads[ii].stats.conn_yields = 0;
         threads[ii].stats.auth_cmds = 0;
         threads[ii].stats.auth_errors = 0;
+        threads[ii].stats.idle_kicks = 0;
 
         for(sid = 0; sid < MAX_NUMBER_OF_SLAB_CLASSES; sid++) {
             threads[ii].stats.slab_stats[sid].set_cmds = 0;
@@ -714,6 +727,7 @@ void threadlocal_stats_aggregate(struct thread_stats *stats) {
         stats->conn_yields += threads[ii].stats.conn_yields;
         stats->auth_cmds += threads[ii].stats.auth_cmds;
         stats->auth_errors += threads[ii].stats.auth_errors;
+        stats->idle_kicks += threads[ii].stats.idle_kicks;
 
         for (sid = 0; sid < MAX_NUMBER_OF_SLAB_CLASSES; sid++) {
             stats->slab_stats[sid].set_cmds +=


### PR DESCRIPTION
Still needs some cleanup and a stats counter, but submitting now for review. Could you please let me know if I'm missing anything obvious and that I'm following the suggested path for making this happen?

Possible problems/issues/observations:

1. it wasn't real obvious how many connections to do per run through the thread, or how long to sleep. I ended up picking an arbitrary number (100) and sleeping for enough time that it takes roughly 1 second to cycle through all the possible connections. This may be a bit heavyweight (we could probably get away with once per 10 seconds or once per minute)
2. That number is just a #define right now. I don't really see much value in making it tunable at runtime, though.
3. There might be a more efficient way to doing this by figuring out which connection would time out next, and then scanning the entire connection list to find a new one when that connection expires/updates, but that requires doing a full connection scan and probably a mutex'd variable that's checked on every command, plus is way more complex, so probably isn't worth it.
4. Only works on idle (rather than stuck-in-transmission) connections. Not sure how hard it would be to make it kill 'active' connections too.