### PR TITLE
Fix the behavior of TTL to allow more than 30 days

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -84,10 +84,10 @@ Some commands involve a client sending some kind of expiration time
 the server. In all such cases, the actual value sent may either be
 Unix time (number of seconds since January 1, 1970, as a 32-bit
 value), or a number of seconds starting from current time. In the
-latter case, this number of seconds may not exceed 60*60*24*30 (number
-of seconds in 30 days); if the number sent by a client is larger than
-that, the server will consider it to be real Unix time value rather
-than an offset from current time.
+latter case, a number less than 1000000000 is interpreted as delta.
+If the number sent by a client is larger than that, the server will
+consider it to be real Unix time value rather than an offset from
+current time.
 
 
 Error strings

--- a/memcached.c
+++ b/memcached.c
@@ -144,15 +144,15 @@ static void maxconns_handler(const int fd, const short which, void *arg) {
     }
 }
 
-#define REALTIME_MAXDELTA 60*60*24*30
+#define REALTIME_MAXDELTA 1000000000
 
 /*
  * given time value that's either unix time or delta from current unix time, return
- * unix time. Use the fact that delta can't exceed one month (and real time value can't
+ * unix time. Use the fact that delta can't exceed a billion (and real time value can't
  * be that low).
  */
 static rel_time_t realtime(const time_t exptime) {
-    /* no. of seconds in 30 days - largest possible delta exptime */
+    /* Your maximum TTL can be ~32 years, then it interpets this as UNIX timestamp */
 
     if (exptime == 0) return 0; /* 0 means never expire */
 
@@ -3057,11 +3057,10 @@ static void process_update_command(conn *c, token_t *tokens, const size_t ntoken
     /* Ubuntu 8.04 breaks when I pass exptime to safe_strtol */
     exptime = exptime_int;
 
-    /* Negative exptimes can underflow and end up immortal. realtime() will
-       immediately expire values that are greater than REALTIME_MAXDELTA, but less
-       than process_started, so lets aim for that. */
+    /* Negative exptimes can underflow and end up immortal. Let's expire the
+       value immediately instead */
     if (exptime < 0)
-        exptime = REALTIME_MAXDELTA + 1;
+        exptime = 1;
 
     // does cas value exist?
     if (handle_cas) {


### PR DESCRIPTION
This is a backwards compatible change for those who use timestamps as
TTL but now allows for TTLs greater than 30 days. The only case this
will not be backwards compatible is when someone depends on the instant
expiration behavior of setting a TTL between 2592000 and the current time.

The API of interpreting TTL as a UNIX timestamp depending on value is
non-intuitive and prone to create bugs. Instead, only interpret this
value as a UNIX timestamp when it's a more larger number that can be
reasonably assumed as a timestamp. I chose a billion seconds. This
translates to a 9/9/2001. This is a number that is much less likely
to cause issues.

I had considered making the minimum value the server start time, or
a time around it. The issue there is that we cannot assume callers have
their clocks set correctly. There would be an edge case where a caller's
clock is behind and the TTL ends up being 30 years. The choice of a
billion seconds gives a padding of 13 years of caller clock accuracy.

Also changed a check that seemed unintuitive -- it was adding 1 to
REALTIME_MAXDELTA and will set it to one again anyway.
