### PR TITLE
Add high-res timestamp to log file

### DIFF
--- a/scripts/start-memcached
+++ b/scripts/start-memcached
@@ -41,12 +41,18 @@ sub handle_logfile
     $fd_reopened = $logfile;
 }
 
+my $timestamp = '';
+
 sub reopen_logfile
 {
     my ($logfile) = @_;
 
-    open *STDERR, ">>$logfile";
-    open *STDOUT, ">>$logfile";
+    # If you want to use highres timestamping, you need to install package 'moreutils' (debian/ubuntu)   
+    # Otherwise, timestamping is being silently ignored
+    $timestamp = "|ts '%Y-%m-%dT%H:%m:%.SZ' " if system('which ts >/dev/null') == 0;
+
+    open *STDERR, "$timestamp>>$logfile";
+    open *STDOUT, "$timestamp>>$logfile";
     open *STDIN, ">>/dev/null";
     $fd_reopened = $logfile;
 }


### PR DESCRIPTION
While debugging our systems we noticed that the log files written by `memcached` are virtually useless as it's impossible to tell when a particular event has happened.

This is an add-on which depends on the Debian package [moreutils](https://packages.debian.org/wheezy/moreutils) - If not installed, nothing happens and the log file gets written as before, without timestamps.

I did some tests on a virtual machine and adding a timestamp slows writing to a log file considerably, but given that `memcached` is not overly verbose, we can live with it.
