### PR TITLE
Fix text protocol output for too big flags

### DIFF
--- a/items.c
+++ b/items.c
@@ -83,7 +83,7 @@ uint64_t get_cas_id(void) {
 static size_t item_make_header(const uint8_t nkey, const int flags, const int nbytes,
                      char *suffix, uint8_t *nsuffix) {
     /* suffix is defined at 40 chars elsewhere.. */
-    *nsuffix = (uint8_t) snprintf(suffix, 40, " %d %d\r\n", flags, nbytes - 2);
+    *nsuffix = (uint8_t) snprintf(suffix, 40, " %u %d\r\n", flags, nbytes - 2);
     return sizeof(item) + nkey + *nsuffix + nbytes;
 }
 


### PR DESCRIPTION
Flags is declared as unsigned 32 bits value however if higher bit is used then text protocol returns negative number.