### PR TITLE
gatkq: return key in response

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1868,7 +1868,7 @@ static void dispatch_bin_command(conn *c) {
         c->cmd = PROTOCOL_BINARY_CMD_GAT;
         break;
     case PROTOCOL_BINARY_CMD_GATKQ:
-        c->cmd = PROTOCOL_BINARY_CMD_GAT;
+        c->cmd = PROTOCOL_BINARY_CMD_GATK;
         break;
     default:
         c->noreply = false;


### PR DESCRIPTION
GATKQ was incorrectly mapped to GAT instead of GATK in binary protocol
handling and thus didn't return a key in the response.  Fixed that and added
test cases for GAT, GATQ, GATK and GATKQ in testapp.

Noticed this while testing a new memcahe client library, OMcache:
    https://github.com/saaros/omcache/