### PR TITLE
unset conn->noreply when it is not invalid in process_delete_command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3309,6 +3309,10 @@ enum delta_result_type do_add_delta(conn *c, const char *key, const size_t nkey,
     return OK;
 }
 
+static void unset_noreply(conn *c) {
+    c->noreply = false;
+}
+
 static void process_delete_command(conn *c, token_t *tokens, const size_t ntokens) {
     char *key;
     size_t nkey;
@@ -3322,6 +3326,7 @@ static void process_delete_command(conn *c, token_t *tokens, const size_t ntoken
         bool valid = (ntokens == 4 && (hold_is_zero || sets_noreply))
             || (ntokens == 5 && hold_is_zero && sets_noreply);
         if (!valid) {
+            unset_noreply(c);
             out_string(c, "CLIENT_ERROR bad command line format.  "
                        "Usage: delete <key> [noreply]");
             return;


### PR DESCRIPTION
in process_delete_command.

below command is invalid. because 0 is only allowed.
delete <key> 1 noreply

but because of noreply, although it is not executed. error is not returned.
so I think it is necessary to send error message it is not executed.
