### PR TITLE
incr/decr: the value should be part of extras according to doc

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1135,7 +1135,8 @@ static void complete_incr_bin(conn *c) {
         if (cas) {
             c->cas = cas;
         }
-        write_bin_response(c, &rsp->message.body, 0, 0,
+        write_bin_response(c, &rsp->message.body,
+                           sizeof(rsp->message.body.value), 0,
                            sizeof(rsp->message.body.value));
         break;
     case NON_NUMERIC:
@@ -1161,7 +1162,9 @@ static void complete_incr_bin(conn *c) {
 
                 if (store_item(it, NREAD_ADD, c)) {
                     c->cas = ITEM_get_cas(it);
-                    write_bin_response(c, &rsp->message.body, 0, 0, sizeof(rsp->message.body.value));
+                    write_bin_response(c, &rsp->message.body,
+                                       sizeof(rsp->message.body.value), 0,
+                                       sizeof(rsp->message.body.value));
                 } else {
                     write_bin_error(c, PROTOCOL_BINARY_RESPONSE_NOT_STORED,
                                     NULL, 0);

--- a/testapp.c
+++ b/testapp.c
@@ -956,7 +956,7 @@ static void validate_response_header(protocol_binary_response_no_extras *respons
         case PROTOCOL_BINARY_CMD_DECREMENT:
         case PROTOCOL_BINARY_CMD_INCREMENT:
             assert(response->message.header.response.keylen == 0);
-            assert(response->message.header.response.extlen == 0);
+            assert(response->message.header.response.extlen == 8);
             assert(response->message.header.response.bodylen == 8);
             assert(response->message.header.response.cas != 0);
             break;


### PR DESCRIPTION
protocol-binary.xml states:
  Increment, Decrement
    MUST have extras.
    MUST have key.
    MUST NOT have value.

but memcached did not set extlen for incr and decr responses.  Most client
applications didn't appear to care, they just used the 8 bytes of the body
as the delta value and thus should not break when incr and decr start saying
the new value is in extras.