### PR TITLE
Release memory back to system

### DIFF
--- a/items.c
+++ b/items.c
@@ -899,7 +899,7 @@ enum crawler_result_type lru_crawler_crawl(char *slabs) {
     }
 
     for (sid = 0; sid < LARGEST_ID; sid++) {
-        if (tocrawl[sid] != 0 && tails[sid] != NULL) {
+        if (tocrawl[sid] != 0 && tails[sid] != NULL && !crawlers[sid].it_flags) {
             if (settings.verbose > 2)
                 fprintf(stderr, "Kicking LRU crawler off for slab %d\n", sid);
             crawlers[sid].nbytes = 0;

--- a/memcached.c
+++ b/memcached.c
@@ -180,6 +180,7 @@ static void stats_init(void) {
     stats.hash_power_level = stats.hash_bytes = stats.hash_is_expanding = 0;
     stats.expired_unfetched = stats.evicted_unfetched = 0;
     stats.slabs_moved = 0;
+    stats.slabs_freed = 0;
     stats.accepting_conns = true; /* assuming we start in this state. */
     stats.slab_reassign_running = false;
     stats.lru_crawler_running = false;
@@ -239,6 +240,10 @@ static void settings_init(void) {
     settings.shutdown_command = false;
     settings.tail_repair_time = TAIL_REPAIR_TIME_DEFAULT;
     settings.flush_enabled = true;
+    settings.release_mem_sleep = 30;
+    settings.release_mem_start = 50;
+    settings.release_mem_stop  = 80;
+    settings.lru_crawler_interval = 0;
 }
 
 /*
@@ -2616,6 +2621,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     if (settings.slab_reassign) {
         APPEND_STAT("slab_reassign_running", "%u", stats.slab_reassign_running);
         APPEND_STAT("slabs_moved", "%llu", stats.slabs_moved);
+        APPEND_STAT("slabs_freed", "%llu", stats.slabs_freed);
     }
     if (settings.lru_crawler) {
         APPEND_STAT("lru_crawler_running", "%u", stats.lru_crawler_running);
@@ -2662,6 +2668,10 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("tail_repair_time", "%d", settings.tail_repair_time);
     APPEND_STAT("flush_enabled", "%s", settings.flush_enabled ? "yes" : "no");
     APPEND_STAT("hash_algorithm", "%s", settings.hash_algorithm);
+    APPEND_STAT("release_mem_sleep", "%d", settings.release_mem_sleep);
+    APPEND_STAT("release_mem_start", "%d", settings.release_mem_start);
+    APPEND_STAT("release_mem_stop",  "%d", settings.release_mem_stop);
+    APPEND_STAT("lru_crawler_interval",  "%d", settings.lru_crawler_interval);
 }
 
 static void conn_to_str(const conn *c, char *buf) {
@@ -3384,7 +3394,7 @@ static void process_slabs_automove_command(conn *c, token_t *tokens, const size_
     level = strtoul(tokens[2].value, NULL, 10);
     if (level == 0) {
         settings.slab_automove = 0;
-    } else if (level == 1 || level == 2) {
+    } else if (level == 1 || level == 2 || level == 3) {
         settings.slab_automove = level;
     } else {
         out_string(c, "ERROR");
@@ -4800,6 +4810,19 @@ static void usage(void) {
            "                table should be. Can be grown at runtime if not big enough.\n"
            "                Set this based on \"STAT hash_power_level\" before a \n"
            "                restart.\n"
+           "              - slab_reassign: Enable the feature of slabs rebalance,\n"
+           "                including command of 'slab reassign' and 'automove'\n"
+           "              - slab_automove: Enable the feature of slabs auto rebalance when evicted happen.\n"
+           "                Slab_reassign should be enable at the same time.\n"
+           "                1: Rebalance when detect evicted happan, using a timer (1s interval).\n"
+           "                2: Rebalance when evicted happen;\n"
+           "                3: Release memory to system if too many(more than 2/3) items is free in slabs,\n"
+           "                   lru_crawler should enable at the same time.\n"
+    	   "              - release_mem_sleep: Interval (in second) between release two pages ."
+    	   "              - release_mem_start: The percent of memory usage when start memory release. "
+    	   "                It will start release memory when less than this point. Default is 50."
+     	   "              - release_mem_stop: The percent of memory usage when stop memory release. "
+     	   "                It will stop release memory when greater than this point. Default is 80."
            "              - tail_repair_time: Time in seconds that indicates how long to wait before\n"
            "                forcefully taking over the LRU tail item whose refcount has leaked.\n"
            "                The default is 3 hours.\n"
@@ -5052,8 +5075,12 @@ int main (int argc, char **argv) {
         HASH_ALGORITHM,
         LRU_CRAWLER,
         LRU_CRAWLER_SLEEP,
-        LRU_CRAWLER_TOCRAWL
-    };
+        LRU_CRAWLER_TOCRAWL,
+        RELEASE_MEM_SLEEP,
+        RELEASE_MEM_START,
+        RELEASE_MEM_STOP,
+        LRU_CRAWLER_INTERVAL,
+   };
     char *const subopts_tokens[] = {
         [MAXCONNS_FAST] = "maxconns_fast",
         [HASHPOWER_INIT] = "hashpower",
@@ -5064,6 +5091,10 @@ int main (int argc, char **argv) {
         [LRU_CRAWLER] = "lru_crawler",
         [LRU_CRAWLER_SLEEP] = "lru_crawler_sleep",
         [LRU_CRAWLER_TOCRAWL] = "lru_crawler_tocrawl",
+        [RELEASE_MEM_SLEEP] = "release_mem_sleep",
+        [RELEASE_MEM_START] = "release_mem_start",
+        [RELEASE_MEM_STOP]  = "release_mem_stop",
+        [LRU_CRAWLER_INTERVAL]  = "lru_crawler_interval",
         NULL
     };
 
@@ -5076,6 +5107,9 @@ int main (int argc, char **argv) {
 
     /* init settings */
     settings_init();
+
+    /* Run regardless of initializing it later */
+    init_lru_crawler();
 
     /* set stderr non-buffering (for running under, say, daemontools) */
     setbuf(stderr, NULL);
@@ -5334,11 +5368,58 @@ int main (int argc, char **argv) {
                     break;
                 }
                 settings.slab_automove = atoi(subopts_value);
-                if (settings.slab_automove < 0 || settings.slab_automove > 2) {
-                    fprintf(stderr, "slab_automove must be between 0 and 2\n");
+                if (settings.slab_automove < 0 || settings.slab_automove > 3) {
+                    fprintf(stderr, "slab_automove must be between 0 and 3\n");
                     return 1;
                 }
+                if (settings.slab_automove==3){
+                	if (settings.lru_crawler_interval==0)settings.lru_crawler_interval =7200;
+                }
                 break;
+            case RELEASE_MEM_SLEEP:
+                if (subopts_value == NULL) {
+                     fprintf(stderr, "Missing numeric argument for release_mem_sleep\n");
+                     return 1;
+                 }
+                 settings.release_mem_sleep = atoi(subopts_value);
+                 if (settings.release_mem_sleep < 1) {
+                     fprintf(stderr, "Can not set release_mem_sleep to less than 1 seconds.\n");
+                     return 1;
+                 }
+                 break;
+            case RELEASE_MEM_START:
+                if (subopts_value == NULL) {
+                     fprintf(stderr, "Missing numeric argument for release_mem_start\n");
+                     return 1;
+                 }
+                 settings.release_mem_start = atoi(subopts_value);
+                 if (settings.release_mem_start < 5) {
+                     fprintf(stderr, "Can not set release_mem_start point to less than 5 percent.\n");
+                     return 1;
+                 }
+                 break;
+            case RELEASE_MEM_STOP:
+                if (subopts_value == NULL) {
+                     fprintf(stderr, "Missing numeric argument for release_mem_stop\n");
+                     return 1;
+                 }
+                 settings.release_mem_stop = atoi(subopts_value);
+                 if (settings.release_mem_stop > 95) {
+                     fprintf(stderr, "Can not set release_mem_stop point to greater than 95 percent.\n");
+                     return 1;
+                 }
+                 break;
+            case LRU_CRAWLER_INTERVAL:
+                if (subopts_value == NULL) {
+                     fprintf(stderr, "Missing numeric argument for release_mem_stop\n");
+                     return 1;
+                 }
+                 settings.lru_crawler_interval = atoi(subopts_value);
+                 if (settings.lru_crawler_interval < 5) {
+                     fprintf(stderr, "Can not set lru_crawler_interval less than 5 seconds.\n");
+                     return 1;
+                 }
+                 break;
             case TAIL_REPAIR_TIME:
                 if (subopts_value == NULL) {
                     fprintf(stderr, "Missing numeric argument for tail_repair_time\n");
@@ -5535,7 +5616,10 @@ int main (int argc, char **argv) {
         perror("failed to ignore SIGPIPE; sigaction");
         exit(EX_OSERR);
     }
-    /* start up worker threads if MT mode */
+
+
+
+   /* start up worker threads if MT mode */
     thread_init(settings.num_threads, main_base);
 
     if (start_assoc_maintenance_thread() == -1) {
@@ -5547,8 +5631,6 @@ int main (int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
 
-    /* Run regardless of initializing it later */
-    init_lru_crawler();
 
     /* initialise clock event */
     clock_handler(0, 0, 0);

--- a/memcached.c
+++ b/memcached.c
@@ -3400,6 +3400,9 @@ static void process_slabs_automove_command(conn *c, token_t *tokens, const size_
         out_string(c, "ERROR");
         return;
     }
+    if (level == 3 && settings.lru_crawler_interval==0)
+        settings.lru_crawler_interval =3600;
+
     out_string(c, "OK");
     return;
 }
@@ -4816,13 +4819,14 @@ static void usage(void) {
            "                Slab_reassign should be enable at the same time.\n"
            "                1: Rebalance when detect evicted happan, using a timer (1s interval).\n"
            "                2: Rebalance when evicted happen;\n"
-           "                3: Release memory to system if too many(more than 2/3) items is free in slabs,\n"
+           "                3: Release memory to system if too many items is free in slabs,\n"
            "                   lru_crawler should enable at the same time.\n"
-    	   "              - release_mem_sleep: Interval (in second) between release two pages ."
-    	   "              - release_mem_start: The percent of memory usage when start memory release. "
-    	   "                It will start release memory when less than this point. Default is 50."
-     	   "              - release_mem_stop: The percent of memory usage when stop memory release. "
-     	   "                It will stop release memory when greater than this point. Default is 80."
+           "              - release_mem_sleep: Interval (in second) between release two pages.\n"
+           "                default is 30s.\n"
+           "              - release_mem_start: The percent of memory usage when start memory release.\n"
+           "                It will start release memory when less than this point. Default is 50.\n"
+           "              - release_mem_stop: The percent of memory usage when stop memory release. \n"
+           "                It will stop release memory when greater than this point. Default is 80.\n"
            "              - tail_repair_time: Time in seconds that indicates how long to wait before\n"
            "                forcefully taking over the LRU tail item whose refcount has leaked.\n"
            "                The default is 3 hours.\n"
@@ -4833,6 +4837,8 @@ static void usage(void) {
            "                default is 100.\n"
            "              - lru_crawler_tocrawl: Max items to crawl per slab per run\n"
            "                default is 0 (unlimited)\n"
+           "              - lru_crawler_interval: The interval that automatically executes \n"
+           "                lru_crawler when slab_reassign is enable. Default is 0.\n"
            );
     return;
 }
@@ -5373,7 +5379,7 @@ int main (int argc, char **argv) {
                     return 1;
                 }
                 if (settings.slab_automove==3){
-                	if (settings.lru_crawler_interval==0)settings.lru_crawler_interval =7200;
+                    if (settings.lru_crawler_interval==0)settings.lru_crawler_interval =3600;
                 }
                 break;
             case RELEASE_MEM_SLEEP:

--- a/memcached.h
+++ b/memcached.h
@@ -280,6 +280,7 @@ struct stats {
     uint64_t      evicted_unfetched; /* items evicted but never touched */
     bool          slab_reassign_running; /* slab reassign in progress */
     uint64_t      slabs_moved;       /* times slabs were moved around */
+    uint64_t      slabs_freed;       /* times slabs were freed */
     bool          lru_crawler_running; /* crawl in progress */
 };
 
@@ -323,7 +324,11 @@ struct settings {
     bool flush_enabled;     /* flush_all enabled */
     char *hash_algorithm;     /* Hash algorithm in use */
     int lru_crawler_sleep;  /* Microsecond sleep between items */
-    uint32_t lru_crawler_tocrawl; /* Number of items to crawl per run */
+    int release_mem_sleep;  /* Second sleep between release each page */
+    int release_mem_start;  /* The percent of memory usage when start release memory*/
+    int release_mem_stop;   /* The percent of memory usage when stop release memory*/
+    int lru_crawler_interval; /* The interval of run the lru_crawler for all slab*/
+   uint32_t lru_crawler_tocrawl; /* Number of items to crawl per run */
 };
 
 extern struct stats stats;

--- a/slabs.c
+++ b/slabs.c
@@ -622,7 +622,7 @@ static void slab_rebalance_finish(void) {
         free(slab_rebal.slab_start);
         mem_malloced -= settings.item_size_max; /*same as do_slabs_newslab*/
         if (s_cls->slabs>0 && 100*s_cls->sl_curr/s_cls->perslab/s_cls->slabs
-        	 > (100-settings.release_mem_stop)){
+             > (100-settings.release_mem_stop)){
             /*clean the rebalance flag to stop release memory to system*/
             s_cls->status_flag &= ~SLAB_ST_REBALANCE;
         }
@@ -674,7 +674,7 @@ static int slab_free_memory_decision(int *src) {
     int free_ratio=0;
 
     if (last_release + settings.release_mem_sleep> current_time)
-    	return ret;
+        return ret;
 
     if (settings.slab_automove != 3)
         return ret;
@@ -688,7 +688,7 @@ static int slab_free_memory_decision(int *src) {
         if (cur > power_largest)
             cur = POWER_SMALLEST;
         if (slabclass[cur].slabs<=1 || slabclass[cur].perslab<1)
-        	continue;
+            continue;
         /* check free slab to release memory to system. start when startPercent of items
          * are free, and stop when stopPercent of items are free.
          * if  slabs>1
@@ -795,17 +795,17 @@ static void *slab_maintenance_thread(void *arg) {
             }else if (slab_free_memory_decision(&src)){
                 slabs_reassign(src, -1);
             }
-			sleep(1);
+            sleep(1);
         } else {
             /* Don't wake as often if we're not enabled.
              * This is lazier than setting up a condition right now. */
             sleep(5);
         }
-		if (settings.lru_crawler && settings.lru_crawler_interval>0
-				&& lru_ts+settings.lru_crawler_interval<current_time){
-			lru_ts = current_time;
-			lru_crawler_crawl("all");
-		}
+        if (settings.lru_crawler && settings.lru_crawler_interval>0
+                && lru_ts+settings.lru_crawler_interval<current_time){
+            lru_ts = current_time;
+            lru_crawler_crawl("all");
+        }
     }
     return NULL;
 }

--- a/slabs.c
+++ b/slabs.c
@@ -618,11 +618,11 @@ static void slab_rebalance_finish(void) {
     s_cls->killing = 0;
 
     //it is releasing memory to system
-    if (slab_rebal.d_clsid == -1){
+    if (slab_rebal.d_clsid == -1) {
         free(slab_rebal.slab_start);
         mem_malloced -= settings.item_size_max; /*same as do_slabs_newslab*/
         if (s_cls->slabs>0 && 100*s_cls->sl_curr/s_cls->perslab/s_cls->slabs
-             > (100-settings.release_mem_stop)){
+             > (100-settings.release_mem_stop)) {
             /*clean the rebalance flag to stop release memory to system*/
             s_cls->status_flag &= ~SLAB_ST_REBALANCE;
         }
@@ -631,7 +631,7 @@ static void slab_rebalance_finish(void) {
         stats.slab_reassign_running = false;
         stats.slabs_freed++;
         STATS_UNLOCK();
-    }else{
+    } else {
         d_cls   = &slabclass[slab_rebal.d_clsid];
         memset(slab_rebal.slab_start, 0, (size_t)settings.item_size_max);
 
@@ -700,7 +700,7 @@ static int slab_free_memory_decision(int *src) {
         free_ratio = 100*slabclass[cur].sl_curr/slabclass[cur].perslab/slabclass[cur].slabs;
         if (free_ratio>(100-settings.release_mem_start)
                 || ((slabclass[cur].status_flag & SLAB_ST_REBALANCE)
-                    && free_ratio > (100-settings.release_mem_stop))){
+                    && free_ratio > (100-settings.release_mem_stop))) {
             ret = 1;
             *src = cur;
             last_release = current_time;
@@ -802,7 +802,7 @@ static void *slab_maintenance_thread(void *arg) {
             sleep(5);
         }
         if (settings.lru_crawler && settings.lru_crawler_interval>0
-                && lru_ts+settings.lru_crawler_interval<current_time){
+                && lru_ts+settings.lru_crawler_interval<current_time) {
             lru_ts = current_time;
             lru_crawler_crawl("all");
         }
@@ -899,7 +899,7 @@ enum reassign_result_type slabs_reassign(int src, int dst) {
     enum reassign_result_type ret;
 
     //It is pre-assign, never free the memory
-    if (dst == -1 && mem_base != NULL){
+    if (dst == -1 && mem_base != NULL) {
         return REASSIGN_NOSPARE;
     }
 

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3615;
+use Test::More tests => 3627;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;

--- a/t/slab_free_memory.t
+++ b/t/slab_free_memory.t
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 110;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached('-m 32 -I 100k -o slab_reassign,lru_crawler,slab_automove=3,release_mem_sleep=1,release_mem_start=40,release_mem_stop=10,lru_crawler_interval=5');
+{
+    my $stats = mem_stats($server->sock, ' settings');
+    is($stats->{slab_automove}, "3");
+    is($stats->{release_mem_sleep}, "1");
+    is($stats->{release_mem_start}, "40");
+    is($stats->{release_mem_stop}, "10");
+    is($stats->{lru_crawler_interval}, "5");
+}
+
+my $sock = $server->sock;
+# Fill a slab .
+my $data = 'y' x 20000; # slab 25
+
+for (1 .. 100) {
+    print $sock "set ifoo$_ 0 30 20000\r\n$data\r\n";
+    is(scalar <$sock>, "STORED\r\n");
+}
+
+
+
+{
+    my $slabs = mem_stats($sock, "slabs");
+    is($slabs->{"25:total_pages"}, 25, "slab 25 has 25 used pages");
+}
+
+#wait for expire and release memory.
+print "wait for expire and release memory... \n";
+sleep 32+26;
+
+{
+    my $slabs = mem_stats($sock, "slabs");
+    is($slabs->{"25:total_pages"}, 1, "slab 25 now has 1 used pages");
+    my $items = mem_stats($sock);
+    is($items->{"slabs_freed"}, 24, "slab 25 has 24 freed pages");
+}
+
+
+#<STDIN>;
+
+print $sock "slabs automove 0\r\n";
+is(scalar <$sock>, "OK\r\n", "disabled auto move");
+{
+    my $stats = mem_stats($server->sock, ' settings');
+    is($stats->{slab_automove}, "0","disabled auto move ok");
+}
+

--- a/t/slab_free_memory.t
+++ b/t/slab_free_memory.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 110;
+use Test::More tests => 111;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -26,6 +26,11 @@ for (1 .. 100) {
     is(scalar <$sock>, "STORED\r\n");
 }
 
+my $stats = mem_stats($sock);
+my $pid = $stats->{pid};
+#print $pid;
+my $mem_before_release=`ps -p $pid -orss= `;
+print "Memory before release is(kB):".$mem_before_release;
 
 
 {
@@ -36,6 +41,11 @@ for (1 .. 100) {
 #wait for expire and release memory.
 print "wait for expire and release memory... \n";
 sleep 32+26;
+
+# check the memory is released.
+my $mem_after_release=`ps -p $pid -orss= `;
+print "Memory after release is(kB):".$mem_after_release;
+is(($mem_before_release-$mem_after_release)>=2048, 1==1, " release memory to system ok.");
 
 {
     my $slabs = mem_stats($sock, "slabs");

--- a/t/slab_free_memory_compare.t
+++ b/t/slab_free_memory_compare.t
@@ -1,0 +1,61 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 111;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+#######################################################
+#Test the release memory feature by setting  random expire, random value length.
+#
+print "memcached1 disable release memory function, while memcache2 enable release memory function.\n";
+my $server1 = new_memcached('-m 32 -I 128k -o slab_reassign,lru_crawler,slab_automove=1,release_mem_sleep=1,release_mem_start=60,release_mem_stop=90,lru_crawler_interval=5');
+my $server2 = new_memcached('-m 32 -I 128k -o slab_reassign,lru_crawler,slab_automove=3,release_mem_sleep=1,release_mem_start=60,release_mem_stop=90,lru_crawler_interval=5');
+
+my $sock1 = $server1->sock;
+my $sock2 = $server2->sock;
+my $evict1_old=0;
+my $evict2_old=0;
+# test loop number.
+my $loop_cnt=100000;
+while($loop_cnt--){
+ my $rd_ttl=int(rand()*100+1);
+ #ramdom value len
+ my $rd_len=int(rand()*10000+1);
+ my $data = 'y' x $rd_len;  
+
+ #print "rd_ttl=$rd_ttl,rd_len=$rd_len \n";
+ print $sock1 "set ifoo$loop_cnt 0 $rd_ttl $rd_len\r\n$data\r\n";
+ scalar <$sock1>;
+ print $sock2 "set ifoo$loop_cnt 0 $rd_ttl $rd_len\r\n$data\r\n";
+ scalar <$sock2>;
+ #display info.
+ if ($loop_cnt%500==0){
+  my $slabs1 = mem_stats($sock1, "slabs");
+  my $total_mem1=$slabs1->{"total_malloced"};
+  my $slabs2 = mem_stats($sock2, "slabs");
+  my $total_mem2=$slabs2->{"total_malloced"};
+  my $total_diff=int(($total_mem1-$total_mem2)/1000);
+ 
+  my $stats1 = mem_stats($sock1);
+  my $pid1 = $stats1->{pid};
+  my $mem1=int(`ps -p $pid1 -orss= `);
+  my $stats2 = mem_stats($sock2);
+  my $pid2 = $stats2->{pid};
+  my $mem2=int(`ps -p $pid2 -orss= `);
+  my $release_mem = $mem1-$mem2;
+
+  my $evict1 = int($stats1->{evictions});
+  my $evict2 = int($stats2->{evictions});
+  my $evict_diff = ($evict1-$evict1_old) - ($evict2-$evict2_old);
+  my $evict1_incr = ($evict1-$evict1_old);
+  $evict1_old = $evict1;
+  $evict2_old = $evict2;
+
+ print "total_mem1=$total_mem1 B,total_mem2=$total_mem2 B,diff=$total_diff kB,evict1_incr=$evict1_incr,evict_diff=$evict_diff,sys_mem1=$mem1 kB,sys_mem2=$mem2 kB,release sys_memory:$release_mem kB\n";
+  #sleep 1;
+ }
+#<STDIN>;
+
+}

--- a/thread.c
+++ b/thread.c
@@ -56,7 +56,7 @@ static pthread_mutex_t cqi_freelist_lock;
 static pthread_mutex_t *item_locks;
 /* size of the item lock hash table */
 static uint32_t item_lock_count;
-unsigned int item_lock_hashpower;
+static unsigned int item_lock_hashpower;
 #define hashsize(n) ((unsigned long int)1<<(n))
 #define hashmask(n) (hashsize(n)-1)
 /* this lock is temporarily engaged during a hash table expansion */

--- a/thread.c
+++ b/thread.c
@@ -56,7 +56,7 @@ static pthread_mutex_t cqi_freelist_lock;
 static pthread_mutex_t *item_locks;
 /* size of the item lock hash table */
 static uint32_t item_lock_count;
-static unsigned int item_lock_hashpower;
+unsigned int item_lock_hashpower;
 #define hashsize(n) ((unsigned long int)1<<(n))
 #define hashmask(n) (hashsize(n)-1)
 /* this lock is temporarily engaged during a hash table expansion */


### PR DESCRIPTION
  Add a feature that support release memory back to system. If the ratio of used items in a slab is less than release_mem_start(default is 50%), then start release memory; If the ratio  of used items greater than release_mem_stop(default is 80%), then stop release memory.
  It is not complicated because it base on the slab_reassign(auto move) function. The different is that the picked page is not assign to other slab, but freed. And it also depend on the lru_crawler to clear the expired items.
  The feature is useful when a cache cluster support  a lot of services(or application). We assign each service several cache instance in fixed size(say 4GB) randomly among cache servers(it's memory is 32GB or 64GB). Most of the time the service just used a few memory of their caches, and only reach the peak of memory usage at certain time. What is worse is that some services just don't know how much memory they need, so they required a lot of memory for 'safety'. With this feature, we can support more services using the current cache servers.