### PR TITLE
[Work In Progress] LRU rework

### DIFF
--- a/doc/new_lru.txt
+++ b/doc/new_lru.txt
@@ -1,0 +1,39 @@
+In versions new enough to have the `-o lru_maintainer` option, a new LRU
+mechanic is available.
+
+Previously: Each slab class has an independent doubly-linked list comprising
+its LRU. Items are pulled from the bottom and either reclaimed or evicted as
+needed.
+
+Now, enabling `-o lru_maintainer` changes all of the behavior below:
+
+ * LRU's are now split between HOT, WARM, and COLD LRU's. New items enter the
+   HOT LRU.
+ * LRU updates only happen as items reach the bottom of an LRU. If active in
+   HOT, stay in HOT, if active in WARM, stay in WARM. If active in COLD, move
+   to WARM.
+ * HOT/WARM each capped at 32% of memory available for that slab class. COLD
+   is uncapped (by default, as of this writing).
+ * Items flow from HOT/WARM into COLD.
+ * A background thread exists which shuffles items between/within the LRU's as
+   limits are reached.
+ * The background thread can also control the lru_crawler, if enabled.
+
+The primary goal is to better protect active items from "scanning". Items
+which are never hit again will flow from HOT, through COLD, and out the
+bottom. Items occasionally active (reaching COLD, but being hit before
+eviction), move to WARM. There they can stay relatively protected.
+
+A secondary goal is to improve latency. The LRU locks are no longer used on
+item reads, only during sets and from the background thread. Also the
+background thread is likely to find expired items and release them back to the
+slab class asynchronously, which speeds up new allocations.
+
+It is recommended to use this feature with the lru crawler as well:
+`memcached -o lru_maintainer,lru_crawler` - Then it will automatically scan
+slab classes for items with expired TTL's. If your items are always set to
+never expire, you can omit this option safely.
+
+An extra option: `-o expirezero_does_not_evict` (when used with
+lru_maintainer) will make items with an expiration time of 0 unevictable. Take
+caution as this will crowd out memory available for other items.

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -583,7 +583,14 @@ integers separated by a colon (treat this as a floating point number).
 | slabs_moved           | 64u     | Total slab pages moved                    |
 | crawler_reclaimed     | 64u     | Total items freed by LRU Crawler          |
 | lrutail_reflocked     | 64u     | Times LRU tail was found with active ref. |
-|                       |         | Items moved to head to avoid OOM errors.  |
+|                       |         | Items can be evicted to avoid OOM errors. |
+| moves_to_cold         | 64u     | Items moved from HOT/WARM to COLD LRU's   |
+| moves_to_warm         | 64u     | Items moved from COLD to WARM LRU         |
+| moves_within_lru      | 64u     | Items reshuffled within HOT or WARM LRU's |
+| direct_reclaims       | 64u     | Times worker threads had to directly      |
+|                       |         | reclaim or evict items.                   |
+| lru_maintainer_juggles                                                      |
+|                       | 64u     | Number of times the LRU bg thread woke up |
 |-----------------------+---------+-------------------------------------------|
 
 Settings statistics
@@ -629,7 +636,14 @@ other stats command.
 | hash_algorithm    | char     | Hash table algorithm in use                  |
 | lru_crawler       | bool     | Whether the LRU crawler is enabled           |
 | lru_crawler_sleep | 32       | Microseconds to sleep between LRU crawls     |
-| lru_crawler_tocrawl| 32u     | Max items to crawl per slab per run          |
+| lru_crawler_tocrawl                                                         |
+|                   | 32u     | Max items to crawl per slab per run           |
+| lru_maintainer_thread                                                       |
+|                   | bool    | Split LRU mode and background threads         |
+| hot_lru_pct       | 32      | Pct of slab memory reserved for HOT LRU       |
+| warm_lru_pct      | 32      | Pct of slab memory reserved for WARM LRU      |
+| expirezero_does_not_evict                                                   |
+|                   | bool    | If yes, items with 0 exptime cannot evict     |
 |-------------------+----------+----------------------------------------------|
 
 
@@ -657,6 +671,10 @@ Name                   Meaning
 ------------------------------
 number                 Number of items presently stored in this class. Expired
                        items are not automatically excluded.
+number_hot             Number of items presently stored in the HOT LRU.
+number_warm            Number of items presently stored in the WARM LRU.
+number_cold            Number of items presently stored in the COLD LRU.
+number_noexp           Number of items presently stored in the NOEXP class.
 age                    Age of the oldest item in the LRU.
 evicted                Number of times an item had to be evicted from the LRU
                        before it expired.
@@ -679,6 +697,14 @@ expired_unfetched      Number of expired items reclaimed from the LRU which
 evicted_unfetched      Number of valid items evicted from the LRU which were
                        never touched after being set.
 crawler_reclaimed      Number of items freed by the LRU Crawler.
+lrutail_reflocked      Number of items found to be refcount locked in the
+                       LRU tail.
+moves_to_cold          Number of items moved from HOT or WARM into COLD.
+moves_to_warm          Number of items moved from COLD to WARM.
+moves_within_lru       Number of times active items were bumped within
+                       HOT or WARM.
+direct_reclaims        Number of times worker threads had to directly pull LRU
+                       tails to find memory for a new item.
 
 Note this will only display information about slabs which exist, so an empty
 cache will return an empty set.

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -582,6 +582,7 @@ integers separated by a colon (treat this as a floating point number).
 | slab_reassign_running | bool    | If a slab page is being moved             |
 | slabs_moved           | 64u     | Total slab pages moved                    |
 | crawler_reclaimed     | 64u     | Total items freed by LRU Crawler          |
+| crawler_items-checked | 64u     | Total items examined by LRU Crawler       |
 | lrutail_reflocked     | 64u     | Times LRU tail was found with active ref. |
 |                       |         | Items can be evicted to avoid OOM errors. |
 | moves_to_cold         | 64u     | Items moved from HOT/WARM to COLD LRU's   |
@@ -589,6 +590,7 @@ integers separated by a colon (treat this as a floating point number).
 | moves_within_lru      | 64u     | Items reshuffled within HOT or WARM LRU's |
 | direct_reclaims       | 64u     | Times worker threads had to directly      |
 |                       |         | reclaim or evict items.                   |
+| lru_crawler_starts    | 64u     | Times an LRU crawler was started          |
 | lru_maintainer_juggles                                                      |
 |                       | 64u     | Number of times the LRU bg thread woke up |
 |-----------------------+---------+-------------------------------------------|

--- a/doc/threads.txt
+++ b/doc/threads.txt
@@ -1,6 +1,3 @@
-WARNING: This document is currently a stub. It is incomplete, but provided to
-give a vague overview of how threads are implemented.
-
 Multithreading in memcached *was* originally simple:
 
 - One listener thread
@@ -14,9 +11,6 @@ and modifications happen under central locks.
 
 THIS HAS CHANGED!
 
-I do need to flesh this out more, and it'll need a lot more tuning, but it has
-changed in the following ways:
-
 - A secondary small hash table of locks is used to lock an item by its hash
   value. This prevents multiple threads from acting on the same item at the
   same time.
@@ -25,16 +19,37 @@ changed in the following ways:
   thread may read or write against a particular hash table bucket.
 - atomic refcounts per item are used to manage garbage collection and
   mutability.
-- A central lock is still held around any "item modifications" - any change to
-  any item flags on any item, the LRU state, or refcount incrementing are
-  still centrally locked.
 
 - When pulling an item off of the LRU tail for eviction or re-allocation, the
   system must attempt to lock the item's bucket, which is done with a trylock
   to avoid deadlocks. If a bucket is in use (and not by that thread) it will
   walk up the LRU a little in an attempt to fetch a non-busy item.
 
-Since I'm sick of hearing it:
+- Each LRU (and sub-LRU's in newer modes) has an independent lock.
+
+- Raw accessses to the slab class are protected by a global slabs_lock. This
+  is a short lock which covers pushing and popping free memory.
+
+- item_lock must be held while modifying an item.
+- slabs_lock must be held while modifying the ITEM_SLABBED flag bit within an item.
+- ITEM_LINKED must not be set before an item has a key copied into it.
+- items without ITEM_SLABBED set cannot have their memory zeroed out.
+
+LOCK ORDERS:
+
+(incomplete as of writing, sorry):
+
+item_lock -> lru_lock -> slabs_lock
+
+lru_lock -> item_trylock
+
+Various stats_locks should never have other locks as dependencies.
+
+Various locks exist for background threads. They can be used to pause the
+thread execution or update settings while the threads are idle. They may call
+item or lru locks.
+
+A low priority isssue:
 
 - If you remove the per-thread stats lock, CPU usage goes down by less than a
   point of a percent, and it does not improve scalability.
@@ -42,5 +57,4 @@ Since I'm sick of hearing it:
 
 Yes, more stats can be moved to threads, and those locks can actually be
 removed entirely on x86-64 systems. However my tests haven't shown that as
-beneficial so far, so I've prioritized other work. Apologies for the rant but
-it's a common question.
+beneficial so far, so I've prioritized other work.

--- a/items.c
+++ b/items.c
@@ -859,7 +859,7 @@ static int lru_pull_tail(const int orig_id, const int cur_lru,
 
     if (it != NULL) {
         if (move_to_lru) {
-            it->slabs_clsid &= ~(3>>6);
+            it->slabs_clsid &= ~(3<<6);
             it->slabs_clsid |= move_to_lru;
             item_link_q(it);
         }
@@ -1180,7 +1180,7 @@ static item *crawler_crawl_q(item *it) {
  * main thread's values too much. Should rethink again.
  */
 static void item_crawler_evaluate(item *search, uint32_t hv, int i) {
-    int slab_id = i & ~(3>>6);
+    int slab_id = i & ~(3<<6);
     crawlerstats_t *s = &crawlerstats[slab_id];
     if ((search->exptime != 0 && search->exptime < current_time)
         || is_flushed(search)) {
@@ -1246,8 +1246,8 @@ static void *item_crawler_thread(void *arg) {
                 crawler_unlink_q((item *)&crawlers[i]);
                 pthread_mutex_unlock(&lru_locks[i]);
                 pthread_mutex_lock(&lru_crawler_stats_lock);
-                crawlerstats[i & ~(3>>6)].end_time = current_time;
-                crawlerstats[i & ~(3>>6)].run_complete = true;
+                crawlerstats[i & ~(3<<6)].end_time = current_time;
+                crawlerstats[i & ~(3<<6)].run_complete = true;
                 pthread_mutex_unlock(&lru_crawler_stats_lock);
                 continue;
             }
@@ -1384,8 +1384,8 @@ enum crawler_result_type lru_crawler_crawl(char *slabs) {
             crawler_count++;
             starts++;
             pthread_mutex_lock(&lru_crawler_stats_lock);
-            memset(&crawlerstats[sid & ~(3>>6)], 0, sizeof(crawlerstats_t));
-            crawlerstats[sid & ~(3>>6)].start_time = current_time;
+            memset(&crawlerstats[sid & ~(3<<6)], 0, sizeof(crawlerstats_t));
+            crawlerstats[sid & ~(3<<6)].start_time = current_time;
             pthread_mutex_unlock(&lru_crawler_stats_lock);
         }
         pthread_mutex_unlock(&lru_locks[sid]);

--- a/items.c
+++ b/items.c
@@ -488,7 +488,7 @@ void item_stats_evictions(uint64_t *evicted) {
         for (x = 0; x < 4; x++) {
             i = n | lru_type_map[x];
             pthread_mutex_lock(&lru_locks[i]);
-            evicted[i] = itemstats[i].evicted;
+            evicted[n] += itemstats[i].evicted;
             pthread_mutex_unlock(&lru_locks[i]);
         }
     }

--- a/items.c
+++ b/items.c
@@ -187,7 +187,7 @@ item *do_item_alloc(char *key, const size_t nkey, const int flags,
     assert(it->slabs_clsid == 0);
     //assert(it != heads[id]);
 
-    it->refcount = 1;     /* the caller will have a reference */
+    /* Refcount is seeded to 1 by slabs_alloc() */
     it->next = it->prev = it->h_next = 0;
     /* Items are initially loaded into the HOT_LRU. This is '0' but I want at
      * least a note here. Compiler (hopefully?) optimizes this out.
@@ -216,7 +216,6 @@ void item_free(item *it) {
 
     /* so slab size changer can tell later if item is already free or not */
     clsid = ITEM_clsid(it);
-    it->slabs_clsid = 0;
     DEBUG_REFCNT(it, 'F');
     slabs_free(it, ntotal, clsid);
 }

--- a/items.c
+++ b/items.c
@@ -1437,7 +1437,7 @@ enum crawler_result_type lru_crawler_crawl(char *slabs) {
              p = strtok_r(NULL, ",", &b)) {
 
             if (!safe_strtoul(p, &sid) || sid < POWER_SMALLEST
-                    || sid >= MAX_NUMBER_OF_SLAB_CLASSES) {
+                    || sid >= MAX_NUMBER_OF_SLAB_CLASSES-1) {
                 pthread_mutex_unlock(&lru_crawler_lock);
                 return CRAWLER_BADCLASS;
             }

--- a/items.c
+++ b/items.c
@@ -432,6 +432,12 @@ int do_item_replace(item *it, item *new_it, const uint32_t hv) {
 }
 
 /*@null@*/
+/* This is walking the line of violating lock order, but I think it's safe.
+ * If the LRU lock is held, an item in the LRU cannot be wiped and freed.
+ * The data could possibly be overwritten, but this is only accessing the
+ * headers.
+ * It may not be the best idea to leave it like this, but for now it's safe.
+ */
 char *do_item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, unsigned int *bytes) {
     unsigned int memlimit = 2 * 1024 * 1024;   /* 2MB max response size */
     char *buffer;
@@ -553,6 +559,10 @@ void do_item_stats(ADD_STAT add_stats, void *c) {
 
 /** dumps out a list of objects of each size, with granularity of 32 bytes */
 /*@null@*/
+/* Locks are correct based on a technicality. Holds LRU lock while doing the
+ * work, so items can't go invalid, and it's only looking at header sizes
+ * which don't change.
+ */
 void do_item_stats_sizes(ADD_STAT add_stats, void *c) {
 
     /* max 1MB object, divided into 32 bytes size buckets */

--- a/items.c
+++ b/items.c
@@ -803,9 +803,9 @@ static int lru_pull_tail(const int orig_id, const int cur_lru,
         /* FIXME: Hardcoded percentage */
         switch (cur_lru) {
             case HOT_LRU:
-                limit = total_chunks * 32 / 100;
+                limit = total_chunks * settings.hot_lru_pct / 100;
             case WARM_LRU:
-                limit = total_chunks * 32 / 100;
+                limit = total_chunks * settings.warm_lru_pct / 100;
                 if (sizes[id] > limit) {
                     itemstats[id].moves_to_cold++;
                     move_to_lru = COLD_LRU;

--- a/items.h
+++ b/items.h
@@ -29,7 +29,7 @@ extern pthread_mutex_t lru_locks[POWER_LARGEST];
 void item_stats_evictions(uint64_t *evicted);
 
 enum crawler_result_type {
-    CRAWLER_OK=0, CRAWLER_RUNNING, CRAWLER_BADCLASS
+    CRAWLER_OK=0, CRAWLER_RUNNING, CRAWLER_BADCLASS, CRAWLER_NOTSTARTED
 };
 
 int start_lru_maintainer_thread(void);

--- a/items.h
+++ b/items.h
@@ -24,7 +24,6 @@ void item_stats_sizes(ADD_STAT add_stats, void *c);
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv);
 void item_stats_reset(void);
-extern pthread_mutex_t cache_lock;
 extern pthread_mutex_t lru_locks[POWER_LARGEST];
 void item_stats_evictions(uint64_t *evicted);
 

--- a/items.h
+++ b/items.h
@@ -33,6 +33,13 @@ enum crawler_result_type {
     CRAWLER_OK=0, CRAWLER_RUNNING, CRAWLER_BADCLASS
 };
 
+int start_lru_maintainer_thread(void);
+int stop_lru_maintainer_thread(void);
+int init_lru_maintainer(void);
+void lru_maintainer_pause(void);
+void lru_maintainer_resume(void);
+void lru_maintainer_wake(int slabs_clsid);
+
 int start_item_crawler_thread(void);
 int stop_item_crawler_thread(void);
 int init_lru_crawler(void);

--- a/items.h
+++ b/items.h
@@ -20,7 +20,6 @@ void do_item_stats(ADD_STAT add_stats, void *c);
 void do_item_stats_totals(ADD_STAT add_stats, void *c);
 /*@null@*/
 void do_item_stats_sizes(ADD_STAT add_stats, void *c);
-void do_item_flush_expired(void);
 
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv);

--- a/items.h
+++ b/items.h
@@ -2,7 +2,6 @@
 uint64_t get_cas_id(void);
 
 /*@null@*/
-item *do_item_alloc_old(char *key, const size_t nkey, const int flags, const rel_time_t exptime, const int nbytes, const uint32_t cur_hv);
 item *do_item_alloc(char *key, const size_t nkey, const int flags, const rel_time_t exptime, const int nbytes, const uint32_t cur_hv);
 void item_free(item *it);
 bool item_size_ok(const size_t nkey, const int flags, const int nbytes);
@@ -38,7 +37,6 @@ int stop_lru_maintainer_thread(void);
 int init_lru_maintainer(void);
 void lru_maintainer_pause(void);
 void lru_maintainer_resume(void);
-void lru_maintainer_wake(int slabs_clsid);
 
 int start_item_crawler_thread(void);
 int stop_item_crawler_thread(void);

--- a/items.h
+++ b/items.h
@@ -2,6 +2,7 @@
 uint64_t get_cas_id(void);
 
 /*@null@*/
+item *do_item_alloc_old(char *key, const size_t nkey, const int flags, const rel_time_t exptime, const int nbytes, const uint32_t cur_hv);
 item *do_item_alloc(char *key, const size_t nkey, const int flags, const rel_time_t exptime, const int nbytes, const uint32_t cur_hv);
 void item_free(item *it);
 bool item_size_ok(const size_t nkey, const int flags, const int nbytes);
@@ -15,16 +16,17 @@ void do_item_update_nolock(item *it);
 int  do_item_replace(item *it, item *new_it, const uint32_t hv);
 
 /*@null@*/
-char *do_item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, unsigned int *bytes);
-void do_item_stats(ADD_STAT add_stats, void *c);
-void do_item_stats_totals(ADD_STAT add_stats, void *c);
+char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, unsigned int *bytes);
+void item_stats(ADD_STAT add_stats, void *c);
+void item_stats_totals(ADD_STAT add_stats, void *c);
 /*@null@*/
-void do_item_stats_sizes(ADD_STAT add_stats, void *c);
+void item_stats_sizes(ADD_STAT add_stats, void *c);
 
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv);
 void item_stats_reset(void);
 extern pthread_mutex_t cache_lock;
+extern pthread_mutex_t lru_locks[POWER_LARGEST];
 void item_stats_evictions(uint64_t *evicted);
 
 enum crawler_result_type {

--- a/memcached.c
+++ b/memcached.c
@@ -238,6 +238,7 @@ static void settings_init(void) {
     settings.lru_maintainer_thread = false;
     settings.hot_lru_pct = 32;
     settings.warm_lru_pct = 32;
+    settings.expirezero_does_not_evict = false;
     settings.hashpower_init = 0;
     settings.slab_reassign = false;
     settings.slab_automove = 0;
@@ -2680,6 +2681,7 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("lru_maintainer_thread", "%s", settings.lru_maintainer_thread ? "yes" : "no");
     APPEND_STAT("hot_lru_pct", "%d", settings.hot_lru_pct);
     APPEND_STAT("warm_lru_pct", "%d", settings.hot_lru_pct);
+    APPEND_STAT("expirezero_does_not_evict", "%s", settings.expirezero_does_not_evict ? "yes" : "no");
 }
 
 static void conn_to_str(const conn *c, char *buf) {
@@ -5084,7 +5086,8 @@ int main (int argc, char **argv) {
         LRU_CRAWLER_TOCRAWL,
         LRU_MAINTAINER,
         HOT_LRU_PCT,
-        WARM_LRU_PCT
+        WARM_LRU_PCT,
+        NOEXP_NOEVICT
     };
     char *const subopts_tokens[] = {
         [MAXCONNS_FAST] = "maxconns_fast",
@@ -5099,6 +5102,7 @@ int main (int argc, char **argv) {
         [LRU_MAINTAINER] = "lru_maintainer",
         [HOT_LRU_PCT] = "hot_lru_pct",
         [WARM_LRU_PCT] = "warm_lru_pct",
+        [NOEXP_NOEVICT] = "expirezero_does_not_evict",
         NULL
     };
 
@@ -5454,6 +5458,9 @@ int main (int argc, char **argv) {
                     fprintf(stderr, "warm_lru_pct must be > 1 and < 80\n");
                     return 1;
                 }
+                break;
+            case NOEXP_NOEVICT:
+                settings.expirezero_does_not_evict = true;
                 break;
             default:
                 printf("Illegal suboption \"%s\"\n", subopts_value);

--- a/memcached.c
+++ b/memcached.c
@@ -184,6 +184,7 @@ static void stats_init(void) {
     stats.accepting_conns = true; /* assuming we start in this state. */
     stats.slab_reassign_running = false;
     stats.lru_crawler_running = false;
+    stats.lru_crawler_starts = 0;
 
     /* make the time we started always be 2 seconds before we really
        did, so time(0) - time.started is never zero.  if so, things
@@ -2633,6 +2634,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     }
     if (settings.lru_crawler) {
         APPEND_STAT("lru_crawler_running", "%u", stats.lru_crawler_running);
+        APPEND_STAT("lru_crawler_starts", "%u", stats.lru_crawler_starts);
     }
     if (settings.lru_maintainer_thread) {
         APPEND_STAT("lru_maintainer_juggles", "%llu", (unsigned long long)stats.lru_maintainer_juggles);

--- a/memcached.c
+++ b/memcached.c
@@ -4833,7 +4833,7 @@ static void usage(void) {
            "                restart.\n"
            "              - tail_repair_time: Time in seconds that indicates how long to wait before\n"
            "                forcefully taking over the LRU tail item whose refcount has leaked.\n"
-           "                The default is 3 hours.\n"
+           "                Disabled by default; dangerous option.\n"
            "              - hash_algorithm: The hash table algorithm\n"
            "                default is jenkins hash. options: jenkins, murmur3\n"
            "              - lru_crawler: Enable LRU Crawler background thread\n"
@@ -4841,6 +4841,13 @@ static void usage(void) {
            "                default is 100.\n"
            "              - lru_crawler_tocrawl: Max items to crawl per slab per run\n"
            "                default is 0 (unlimited)\n"
+           "              - lru_maintainer: Enable new LRU system + background thread\n"
+           "              - hot_lru_pct: Pct of slab memory to reserve for hot lru.\n"
+           "                (requires lru_maintainer)\n"
+           "              - warm_lru_pct: Pct of slab memory to reserve for warm lru.\n"
+           "                (requires lru_maintainer)\n"
+           "              - expirezero_does_not_evict: Items set to not expire, will not evict.\n"
+           "                (requires lru_maintainer)\n"
            );
     return;
 }

--- a/memcached.c
+++ b/memcached.c
@@ -3603,6 +3603,9 @@ static void process_command(conn *c, char *command) {
             case CRAWLER_BADCLASS:
                 out_string(c, "BADCLASS invalid class id");
                 break;
+            case CRAWLER_NOTSTARTED:
+                out_string(c, "NOTSTARTED no items to crawl");
+                break;
             }
             return;
         } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "tocrawl") == 0) {

--- a/memcached.c
+++ b/memcached.c
@@ -245,6 +245,7 @@ static void settings_init(void) {
     settings.shutdown_command = false;
     settings.tail_repair_time = TAIL_REPAIR_TIME_DEFAULT;
     settings.flush_enabled = true;
+    settings.crawls_persleep = 1000;
 }
 
 /*

--- a/memcached.c
+++ b/memcached.c
@@ -180,6 +180,7 @@ static void stats_init(void) {
     stats.hash_power_level = stats.hash_bytes = stats.hash_is_expanding = 0;
     stats.expired_unfetched = stats.evicted_unfetched = 0;
     stats.slabs_moved = 0;
+    stats.lru_maintainer_juggles = 0;
     stats.accepting_conns = true; /* assuming we start in this state. */
     stats.slab_reassign_running = false;
     stats.lru_crawler_running = false;
@@ -2627,6 +2628,9 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     }
     if (settings.lru_crawler) {
         APPEND_STAT("lru_crawler_running", "%u", stats.lru_crawler_running);
+    }
+    if (settings.lru_maintainer_thread) {
+        APPEND_STAT("lru_maintainer_juggles", "%llu", (unsigned long long)stats.lru_maintainer_juggles);
     }
     APPEND_STAT("malloc_fails", "%llu",
                 (unsigned long long)stats.malloc_fails);

--- a/memcached.c
+++ b/memcached.c
@@ -2835,7 +2835,7 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
             return;
         }
 
-        if (id >= MAX_NUMBER_OF_SLAB_CLASSES) {
+        if (id >= MAX_NUMBER_OF_SLAB_CLASSES-1) {
             out_string(c, "CLIENT_ERROR Illegal slab id");
             return;
         }

--- a/memcached.c
+++ b/memcached.c
@@ -3275,9 +3275,7 @@ enum delta_result_type do_add_delta(conn *c, const char *key, const size_t nkey,
     if (res + 2 <= it->nbytes && it->refcount == 2) { /* replace in-place */
         /* When changing the value without replacing the item, we
            need to update the CAS on the existing item. */
-        mutex_lock(&cache_lock); /* FIXME */
         ITEM_set_cas(it, (settings.use_cas) ? get_cas_id() : 0);
-        mutex_unlock(&cache_lock);
 
         memcpy(ITEM_data(it), buf, res);
         memset(ITEM_data(it) + res, ' ', it->nbytes - res - 2);

--- a/memcached.c
+++ b/memcached.c
@@ -5077,6 +5077,8 @@ int main (int argc, char **argv) {
     bool protocol_specified = false;
     bool tcp_specified = false;
     bool udp_specified = false;
+    bool start_lru_maintainer = false;
+    bool start_lru_crawler = false;
     enum hashfunc_type hash_type = JENKINS_HASH;
     uint32_t tocrawl;
 
@@ -5420,10 +5422,7 @@ int main (int argc, char **argv) {
                 }
                 break;
             case LRU_CRAWLER:
-                if (start_item_crawler_thread() != 0) {
-                    fprintf(stderr, "Failed to enable LRU crawler thread\n");
-                    return 1;
-                }
+                start_lru_crawler = true;
                 break;
             case LRU_CRAWLER_SLEEP:
                 settings.lru_crawler_sleep = atoi(subopts_value);
@@ -5440,10 +5439,7 @@ int main (int argc, char **argv) {
                 settings.lru_crawler_tocrawl = tocrawl;
                 break;
             case LRU_MAINTAINER:
-                if (start_lru_maintainer_thread() != 0) {
-                    fprintf(stderr, "Failed to enable LRU maintainer thread\n");
-                    return 1;
-                }
+                start_lru_maintainer = true;
                 break;
             case HOT_LRU_PCT:
                 if (subopts_value == NULL) {
@@ -5631,6 +5627,16 @@ int main (int argc, char **argv) {
 
     if (start_assoc_maintenance_thread() == -1) {
         exit(EXIT_FAILURE);
+    }
+
+    if (start_lru_crawler && start_item_crawler_thread() != 0) {
+        fprintf(stderr, "Failed to enable LRU crawler thread\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (start_lru_maintainer && start_lru_maintainer_thread() != 0) {
+        fprintf(stderr, "Failed to enable LRU maintainer thread\n");
+        return 1;
     }
 
     if (settings.slab_reassign &&

--- a/memcached.c
+++ b/memcached.c
@@ -5096,6 +5096,7 @@ int main (int argc, char **argv) {
 
     /* Run regardless of initializing it later */
     init_lru_crawler();
+    init_lru_maintainer();
 
     /* set stderr non-buffering (for running under, say, daemontools) */
     setbuf(stderr, NULL);
@@ -5562,6 +5563,10 @@ int main (int argc, char **argv) {
     memcached_thread_init(settings.num_threads, main_base);
 
     if (start_assoc_maintenance_thread() == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    if (start_lru_maintainer_thread() == -1) {
         exit(EXIT_FAILURE);
     }
 

--- a/memcached.h
+++ b/memcached.h
@@ -299,6 +299,7 @@ struct settings {
     char *inter;
     int verbose;
     rel_time_t oldest_live; /* ignore existing items older than this */
+    uint64_t oldest_cas; /* ignore existing items with CAS values lower than this */
     int evict_to_free;
     char *socketpath;   /* path to unix socket if using local socket */
     int access;  /* access mask (a la chmod) for unix domain socket */
@@ -565,7 +566,6 @@ bool  conn_add_to_freelist(conn *c);
 int   is_listen_thread(void);
 item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbytes);
 char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, unsigned int *bytes);
-void  item_flush_expired(void);
 item *item_get(const char *key, const size_t nkey);
 item *item_touch(const char *key, const size_t nkey, uint32_t exptime);
 int   item_link(item *it);

--- a/memcached.h
+++ b/memcached.h
@@ -540,12 +540,7 @@ enum store_item_type do_store_item(item *item, int comm, conn* c, const uint32_t
 conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size, enum network_transport transport, struct event_base *base);
 extern int daemonize(int nochdir, int noclose);
 
-static inline int mutex_lock(pthread_mutex_t *mutex)
-{
-    while (pthread_mutex_trylock(mutex));
-    return 0;
-}
-
+#define mutex_lock(x) pthread_mutex_lock(x)
 #define mutex_unlock(x) pthread_mutex_unlock(x)
 
 #include "stats.h"

--- a/memcached.h
+++ b/memcached.h
@@ -285,6 +285,7 @@ struct stats {
     uint64_t      evicted_unfetched; /* items evicted but never touched */
     bool          slab_reassign_running; /* slab reassign in progress */
     uint64_t      slabs_moved;       /* times slabs were moved around */
+    uint64_t      lru_crawler_starts; /* Number of item crawlers kicked off */
     bool          lru_crawler_running; /* crawl in progress */
     uint64_t      lru_maintainer_juggles; /* number of LRU bg pokes */
 };

--- a/memcached.h
+++ b/memcached.h
@@ -286,6 +286,7 @@ struct stats {
     bool          slab_reassign_running; /* slab reassign in progress */
     uint64_t      slabs_moved;       /* times slabs were moved around */
     bool          lru_crawler_running; /* crawl in progress */
+    uint64_t      lru_maintainer_juggles; /* number of LRU bg pokes */
 };
 
 #define MAX_VERBOSITY_LEVEL 2
@@ -321,6 +322,7 @@ struct settings {
     bool sasl;              /* SASL on/off */
     bool maxconns_fast;     /* Whether or not to early close connections */
     bool lru_crawler;        /* Whether or not to enable the autocrawler thread */
+    bool lru_maintainer_thread; /* LRU maintainer background thread */
     bool slab_reassign;     /* Whether or not slab reassignment is allowed */
     int slab_automove;     /* Whether or not to automatically move slabs */
     int hashpower_init;     /* Starting hash power level */

--- a/memcached.h
+++ b/memcached.h
@@ -332,6 +332,8 @@ struct settings {
     char *hash_algorithm;     /* Hash algorithm in use */
     int lru_crawler_sleep;  /* Microsecond sleep between items */
     uint32_t lru_crawler_tocrawl; /* Number of items to crawl per run */
+    int hot_lru_pct; /* percentage of slab space for HOT_LRU */
+    int warm_lru_pct; /* percentage of slab space for WARM_LRU */
 };
 
 extern struct stats stats;

--- a/memcached.h
+++ b/memcached.h
@@ -80,7 +80,7 @@
 #define POWER_LARGEST  255
 #define CHUNK_ALIGN_BYTES 8
 /* slab class max is a 6-bit number, -1. */
-#define MAX_NUMBER_OF_SLAB_CLASSES 63
+#define MAX_NUMBER_OF_SLAB_CLASSES (63 + 1)
 
 /** How long an object can reasonably be assumed to be locked before
     harvesting it on a low memory condition. Default: disabled. */

--- a/memcached.h
+++ b/memcached.h
@@ -344,8 +344,10 @@ extern struct settings settings;
  * Structure for storing items within memcached.
  */
 typedef struct _stritem {
+    /* Protected by LRU locks */
     struct _stritem *next;
     struct _stritem *prev;
+    /* Rest are protected by an item lock */
     struct _stritem *h_next;    /* hash chain next */
     rel_time_t      time;       /* least recent access */
     rel_time_t      exptime;    /* expire time */

--- a/memcached.h
+++ b/memcached.h
@@ -334,6 +334,7 @@ struct settings {
     uint32_t lru_crawler_tocrawl; /* Number of items to crawl per run */
     int hot_lru_pct; /* percentage of slab space for HOT_LRU */
     int warm_lru_pct; /* percentage of slab space for WARM_LRU */
+    bool expirezero_does_not_evict; /* exptime == 0 goes into NOEXP_LRU */
 };
 
 extern struct stats stats;

--- a/memcached.h
+++ b/memcached.h
@@ -334,6 +334,7 @@ struct settings {
     uint32_t lru_crawler_tocrawl; /* Number of items to crawl per run */
     int hot_lru_pct; /* percentage of slab space for HOT_LRU */
     int warm_lru_pct; /* percentage of slab space for WARM_LRU */
+    int crawls_persleep; /* Number of LRU crawls to run before sleeping */
     bool expirezero_does_not_evict; /* exptime == 0 goes into NOEXP_LRU */
 };
 

--- a/slabs.c
+++ b/slabs.c
@@ -449,8 +449,10 @@ unsigned int slabs_available_chunks(const unsigned int id, bool *mem_flag,
     pthread_mutex_lock(&slabs_lock);
     p = &slabclass[id];
     ret = p->sl_curr;
-    *mem_flag = mem_limit_reached;
-    *total_chunks = p->slabs * p->perslab;
+    if (mem_flag != NULL)
+        *mem_flag = mem_limit_reached;
+    if (total_chunks != NULL)
+        *total_chunks = p->slabs * p->perslab;
     pthread_mutex_unlock(&slabs_lock);
     return ret;
 }

--- a/slabs.c
+++ b/slabs.c
@@ -115,7 +115,7 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc) {
 
     memset(slabclass, 0, sizeof(slabclass));
 
-    while (++i < MAX_NUMBER_OF_SLAB_CLASSES && size <= settings.item_size_max / factor) {
+    while (++i < MAX_NUMBER_OF_SLAB_CLASSES-1 && size <= settings.item_size_max / factor) {
         /* Make sure items are always n-byte aligned */
         if (size % CHUNK_ALIGN_BYTES)
             size += CHUNK_ALIGN_BYTES - (size % CHUNK_ALIGN_BYTES);
@@ -161,7 +161,7 @@ static void slabs_preallocate (const unsigned int maxslabs) {
        list.  if you really don't want this, you can rebuild without
        these three lines.  */
 
-    for (i = POWER_SMALLEST; i <= MAX_NUMBER_OF_SLAB_CLASSES; i++) {
+    for (i = POWER_SMALLEST; i < MAX_NUMBER_OF_SLAB_CLASSES; i++) {
         if (++prealloc > maxslabs)
             return;
         if (do_slabs_newslab(i) == 0) {
@@ -234,7 +234,6 @@ static void *do_slabs_alloc(const size_t size, unsigned int id, unsigned int *to
         MEMCACHED_SLABS_ALLOCATE_FAILED(size, 0);
         return NULL;
     }
-
     p = &slabclass[id];
     assert(p->sl_curr == 0 || ((item *)p->slots)->slabs_clsid == 0);
 

--- a/slabs.c
+++ b/slabs.c
@@ -112,7 +112,7 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc) {
 
     memset(slabclass, 0, sizeof(slabclass));
 
-    while (++i < POWER_LARGEST && size <= settings.item_size_max / factor) {
+    while (++i < MAX_NUMBER_OF_SLAB_CLASSES && size <= settings.item_size_max / factor) {
         /* Make sure items are always n-byte aligned */
         if (size % CHUNK_ALIGN_BYTES)
             size += CHUNK_ALIGN_BYTES - (size % CHUNK_ALIGN_BYTES);
@@ -158,7 +158,7 @@ static void slabs_preallocate (const unsigned int maxslabs) {
        list.  if you really don't want this, you can rebuild without
        these three lines.  */
 
-    for (i = POWER_SMALLEST; i <= POWER_LARGEST; i++) {
+    for (i = POWER_SMALLEST; i <= MAX_NUMBER_OF_SLAB_CLASSES; i++) {
         if (++prealloc > maxslabs)
             return;
         if (do_slabs_newslab(i) == 0) {
@@ -639,15 +639,15 @@ static void slab_rebalance_finish(void) {
  * complex.
  */
 static int slab_automove_decision(int *src, int *dst) {
-    static uint64_t evicted_old[POWER_LARGEST];
-    static unsigned int slab_zeroes[POWER_LARGEST];
+    static uint64_t evicted_old[MAX_NUMBER_OF_SLAB_CLASSES];
+    static unsigned int slab_zeroes[MAX_NUMBER_OF_SLAB_CLASSES];
     static unsigned int slab_winner = 0;
     static unsigned int slab_wins   = 0;
-    uint64_t evicted_new[POWER_LARGEST];
+    uint64_t evicted_new[MAX_NUMBER_OF_SLAB_CLASSES];
     uint64_t evicted_diff = 0;
     uint64_t evicted_max  = 0;
     unsigned int highest_slab = 0;
-    unsigned int total_pages[POWER_LARGEST];
+    unsigned int total_pages[MAX_NUMBER_OF_SLAB_CLASSES];
     int i;
     int source = 0;
     int dest = 0;

--- a/slabs.h
+++ b/slabs.h
@@ -33,6 +33,9 @@ bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 /** Fill buffer with stats */ /*@null@*/
 void slabs_stats(ADD_STAT add_stats, void *c);
 
+/* Hints as to freespace in slab class */
+unsigned int slabs_available_chunks(unsigned int id, bool *mem_flag, unsigned int *total_chunks);
+
 int start_slab_maintenance_thread(void);
 void stop_slab_maintenance_thread(void);
 

--- a/slabs.h
+++ b/slabs.h
@@ -19,7 +19,7 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc);
 unsigned int slabs_clsid(const size_t size);
 
 /** Allocate object of given length. 0 on error */ /*@null@*/
-void *slabs_alloc(const size_t size, unsigned int id);
+void *slabs_alloc(const size_t size, unsigned int id, unsigned int *total_chunks);
 
 /** Free previously allocated object */
 void slabs_free(void *ptr, size_t size, unsigned int id);

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3627;
+use Test::More tests => 3639;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3615;
+use Test::More tests => 3624;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3624;
+use Test::More tests => 3627;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;

--- a/t/binary.t
+++ b/t/binary.t
@@ -612,7 +612,6 @@ sub _handle_single_response {
         my $found = length($rv);
         die("Expected $remaining bytes, got $found");
     }
-
     if (defined $myopaque) {
         Test::More::is($opaque, $myopaque, "Expected opaque");
     } else {

--- a/t/flush-all.t
+++ b/t/flush-all.t
@@ -91,7 +91,7 @@ for (1..50) {
         next;
     } elsif ($line =~ /^END/) {
         $failed_nocas++;
-        next;
+        last;
     }
 }
 is($failed_nocas, 1, "failed to set value after flush with no CAS at least once");

--- a/t/flush-all.t
+++ b/t/flush-all.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 25;
+use Test::More tests => 26;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -67,3 +67,31 @@ print $sock "flush_all\r\n";
 is(scalar <$sock>, "CLIENT_ERROR flush_all not allowed\r\n", "flush_all was not allowed");
 mem_get_is($sock, "foo", "fooval2");
 
+# Test that disabling CAS makes flush_all less accurate.
+# Due to lock ordering issues we can no longer evict items newer than
+# oldest_live, so we rely on the CAS counter for an exact cliff. So disabling
+# CAS now means all items set in the same second will fail to set.
+$server = new_memcached('-C');
+$sock = $server->sock;
+
+my $failed_nocas = 0;
+# Running this 100,000 times failed the test a handful of times. 50 tries
+# should be enough.
+for (1..50) {
+    print $sock "flush_all 0\r\n";
+    my $foo = scalar <$sock>;
+    print $sock "set foo 0 0 3\r\nnew\r\n";
+    $foo = scalar <$sock>;
+    print $sock "get foo\r\n";
+    my $line = scalar <$sock>;
+    if ($line =~ /^VALUE/) {
+        $line = scalar <$sock>;
+        $line = scalar <$sock>;
+        print STDERR "Succeeded!!!\n";
+        next;
+    } elsif ($line =~ /^END/) {
+        $failed_nocas++;
+        next;
+    }
+}
+is($failed_nocas, 1, "failed to set value after flush with no CAS at least once");

--- a/t/lru-maintainer.t
+++ b/t/lru-maintainer.t
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More tests => 117;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached('-m 6 -o lru_maintainer,lru_crawler');
+my $sock = $server->sock;
+
+for (1 .. 10) {
+    print $sock "set ifoo$_ 0 1 2\r\nok\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored key");
+}
+
+sleep 3;
+
+{
+    my $stats = mem_stats($sock);
+    is($stats->{reclaimed}, 10, "expired key automatically reclaimed");
+}
+
+my $value = "B"x66560;
+
+print $sock "set canary 0 0 66560\r\n$value\r\n";
+is(scalar <$sock>, "STORED\r\n", "stored canary key");
+
+# Now flush the slab class with junk.
+for (my $key = 0; $key < 100; $key++) {
+    if ($key == 30) {
+        my $stats = mem_stats($sock, "items");
+        isnt($stats->{"items:31:moves_to_cold"}, 0, "moved some items to cold");
+        # Fetch the canary once, so it's now marked as active.
+        mem_get_is($sock, "canary", $value);
+    }
+    print $sock "set key$key 0 0 66560\r\n$value\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored key$key");
+}
+
+{
+    my $stats = mem_stats($sock);
+    isnt($stats->{evictions}, 0, "some evictions happened");
+    my $istats = mem_stats($sock, "items");
+    isnt($stats->{"items:31:number_warm"}, 0, "our canary moved to warm");
+}
+
+# Key should've been saved to the WARM_LRU, and still exists.
+mem_get_is($sock, "canary", $value);

--- a/t/stats.t
+++ b/t/stats.t
@@ -70,7 +70,7 @@ my $sock = $server->sock;
 my $stats = mem_stats($sock);
 
 # Test number of keys
-is(scalar(keys(%$stats)), 51, "51 stats values");
+is(scalar(keys(%$stats)), 52, "52 stats values");
 
 # Test initial state
 foreach my $key (qw(curr_items total_items bytes cmd_get cmd_set get_hits evictions get_misses

--- a/t/stats.t
+++ b/t/stats.t
@@ -63,6 +63,7 @@ my $sock = $server->sock;
 ## STAT reclaimed 0
 ## STAT crawler_reclaimed 0
 ## STAT lrutail_reflocked 0
+## see doc/protocol.txt for others
 # note that auth stats are tested in auth specfic tests
 
 

--- a/thread.c
+++ b/thread.c
@@ -167,6 +167,7 @@ void pause_threads(enum pause_thread_types type) {
         case PAUSE_ALL_THREADS:
             slabs_rebalancer_pause();
             lru_crawler_pause();
+            lru_maintainer_pause();
         case PAUSE_WORKER_THREADS:
             buf[0] = 'p';
             pthread_mutex_lock(&worker_hang_lock);
@@ -174,6 +175,7 @@ void pause_threads(enum pause_thread_types type) {
         case RESUME_ALL_THREADS:
             slabs_rebalancer_resume();
             lru_crawler_resume();
+            lru_maintainer_resume();
         case RESUME_WORKER_THREADS:
             pthread_mutex_unlock(&worker_hang_lock);
             break;

--- a/thread.c
+++ b/thread.c
@@ -36,9 +36,7 @@ struct conn_queue {
     pthread_mutex_t lock;
 };
 
-/* Lock for cache LRU operations
- * Was old global lock for all item_*, assoc_*, etc operations */
-pthread_mutex_t cache_lock;
+/* Locks for cache LRU operations */
 pthread_mutex_t lru_locks[POWER_LARGEST];
 
 /* Connection lock around accepting new connections */
@@ -727,7 +725,6 @@ void memcached_thread_init(int nthreads, struct event_base *main_base) {
     int         i;
     int         power;
 
-    pthread_mutex_init(&cache_lock, NULL);
     for (i = 0; i < POWER_LARGEST; i++) {
         pthread_mutex_init(&lru_locks[i], NULL);
     }

--- a/thread.c
+++ b/thread.c
@@ -598,15 +598,6 @@ enum store_item_type store_item(item *item, int comm, conn* c) {
 }
 
 /*
- * Flushes expired items after a flush_all call
- */
-void item_flush_expired() {
-    mutex_lock(&cache_lock);
-    do_item_flush_expired();
-    mutex_unlock(&cache_lock);
-}
-
-/*
  * Dumps part of the cache
  */
 char *item_cachedump(unsigned int slabs_clsid, unsigned int limit, unsigned int *bytes) {


### PR DESCRIPTION
This branch is a functional reworking of memcached's core LRU. Looking for some help with folks willing to run tests or try swapping a development or production machine to see if the hit ratio improves (or if it crashes).

Direct link to branch: https://github.com/dormando/memcached/tree/lru_rework - you can click "download zip" if you don't want a git clone. Build: `./autogen.sh && ./configure && make && make test` - need libevent-devel or equivalent installed.

 * cache_lock is gone, LRU's are now independently locked.
 * LRU's are now split between HOT, WARM, and COLD LRU's. New items enter the HOT LRU.
 * LRU updates only happen as items reach the bottom of an LRU. If active in HOT, stay in HOT, if active in WARM, stay in WARM. If active in COLD, move to WARM.
 * HOT/WARM each capped at 32% of memory available for that slab class. COLD is uncapped.
 * Items flow from HOT/WARM into COLD.
 * A background thread exists which shuffles items between/within the LRU's as capacities are reached.

The primary goal is to better protect active items from "scanning". items which are never hit again will flow from HOT, through COLD, and out the bottom. Items occasionally active (reaching COLD, but being hit before eviction), move to WARM. There they can stay relatively protected.

A secondary goal is to improve latency. The LRU locks are no longer used on item reads, only during sets and from the background thread. Also the background thread is likely to find expired items and release them back to the slab class asynchronously, which speeds up new allocations. Further work on the thread should improve this.

There are a number of new statistics to monitor this. Mainly you'll just want to judge your hit ratio before/after, as well as any potential latency issues.

This change is rough but functional. Notes:

To enable: start with `-o lru_maintainer,lru_crawler`

To adjust percentage of memory reserved for HOT or WARM LRU's (default to 32% each):
`-o lru_maintainer,lru_crawler,hot_lru_pct=32,warm_lru_pct=32`

A recommended start line:
`-o lru_maintainer,lru_crawler,hash_algorithm=murmur3`

An extra option: `-o expirezero_does_not_evict` (when used with lru_maintainer) will make items with an expiration time of 0 unevictable. Take caution as this will crowd out memory available for other evictable items.

Some caveats exist:

* Many possible tunables are currently hardcoded.
* Max number of slab classes is now 62, instead of 200. The default slab factor gives 42 classes.
* It's run for a few hours at 550k sets/sec + 1.2m key fetches/sec with the background thread and lru_crawler running. Your mileage may vary.

Main TODO items (in rough order):

- [x] Add automated LRU crawling from the background thread. Keep a histogram of expiration times to judge how often to send the crawler out. This will reclaim any expired items early.
- [x] Repair slab rebalancer lock safety (I have notes for how already)
- [x] Repair more tests
- [x] Add compatibilty mode (which will be the default). Locks will still be split, but background thread will not start and only one LRU will be used per slab class. Item LRU bumping will be inline, so the same as the current code.
- [x] Need tests specific to LRU maintainer thread.
- [x] Make HOT/WARM ratios at least starttime tunable. Runtime tunable is ideal.
 * Runtime tunable is a bit more work, delaying it for now. Starttime works.
- [x] Background thread gates aggressiveness by a low watermark
 * Left a very high default for now.
- [ ] Manage slab rebalancer from main background thread. If a source class has at least 2 pages worth of free chunks, it's possible for the slab mover to copy items instead of evicting them (I think). Combined with the LRU crawler keeping tabs on all actual free memory, this should allow fast automated movement of slab pages to optimal destinations.
 * Might do this in a separate branch. Algorithm is easy if free space exists, but tricky if all slabs are full and evicting, which is a common problem.
- [x] Documentation
 * Names for things may not be final.
- [x] Add a new starttime option to use a fourth LRU for items set to not expire. If expiration time == 0, these items will not be subject to eviction. Items with TTL's will continue to be subject to eviction. Use with extreme care.

This is loosely inspired by the 2Q algorithm. More specifically the OpenBSD variant of it: http://www.tedunangst.com/flak/post/2Q-buffer-cache-algorithm

It's then extended to cope with the fact that memcached items do not behave the same way as a buffer pool. TTL's mean extra scanning/shuffling is done to improve memory efficiency for valid items.