### PR TITLE
Setting the pthread id of the LIBEVENT_THREAD on thread creation.

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -300,13 +300,12 @@ static void cqi_free(CQ_ITEM *item) {
  * Creates a worker thread.
  */
 static void create_worker(void *(*func)(void *), void *arg) {
-    pthread_t       thread;
     pthread_attr_t  attr;
     int             ret;
 
     pthread_attr_init(&attr);
 
-    if ((ret = pthread_create(&thread, &attr, func, arg)) != 0) {
+    if ((ret = pthread_create(&((LIBEVENT_THREAD*)arg)->thread_id, &attr, func, arg)) != 0) {
         fprintf(stderr, "Can't create thread: %s\n",
                 strerror(ret));
         exit(1);


### PR DESCRIPTION
It seems that the thread_id variable in LIBEVENT_THREAD struct is not being set, not at the thread creation time nor later through calling pthread_self(). Although, the thread_id is not being used anywhere but for dtrace probe MEMCACHED_CONN_DISPATCH, it should be set properly. 

