### PR TITLE
Reset tap slot after disconnect

### DIFF
--- a/engines/default_engine/default_engine.c
+++ b/engines/default_engine/default_engine.c
@@ -886,6 +886,7 @@ static void default_handle_disconnect(const void *cookie,
     for (ii = 0; ii < engine->tap_connections.size; ++ii) {
         if (engine->tap_connections.clients[ii] == cookie) {
             free(engine->server.cookie->get_engine_specific(cookie));
+            engine->tap_connections.clients[ii] = NULL;
             break;
         }
     }


### PR DESCRIPTION
This change allows a client to perform more than 10 taps over the lifetime of the memcached server.  There's still a limit of 10 concurrent taps, but previously we wouldn't forget a tap once it had finished (the TCP connection drops).

I initially thought this code was in place to allow recovery of taps, but the previous line destroys the engine's record of the tap so there's no chance of a recovery (and the pointer is left dangling).