### PR TITLE
Calculate correct PID when starting memcached

### DIFF
--- a/scripts/start-memcached
+++ b/scripts/start-memcached
@@ -111,19 +111,15 @@ if($pid == 0)
     reopen_logfile($fd_reopened);
     # must fork again now that tty is closed
     $pid = fork();
-    if ($pid) {
-      exit(0);
-    }
-    exec "$memcached $params";
-    exit(0);
-
-}else{
-    if(open PIDHANDLE,">$pidfile")
-    {
-        print PIDHANDLE $pid;
-        close PIDHANDLE;
+    if ($pid == 0) {
+        exec "$memcached $params";
     }else{
-
-        print STDERR "Can't write pidfile to $pidfile.\n";
+        if(open PIDHANDLE,">$pidfile")
+        {
+            print PIDHANDLE $pid;
+            close PIDHANDLE;
+        }else{
+            print STDERR "Can't write pidfile to $pidfile.\n";
+        }
     }
 }


### PR DESCRIPTION
This change allows memcached to be controlled correctly by `service` or, more specifically `start-stop-daemon`.  This used to work as expected in 1.4 but https://github.com/memcached/memcached/commit/e04ca9b70bf1f56093143f7b825ddec078a6fd42 caused us to fork twice (to drop the linkage to the calling shell) but only remembers the pid from the first fork (which soon dies).

With this fix, the pidfile contains the pid of the main memcached process so it's possible to check if memcached is still running (e.g. through monit/service).