### PR TITLE
"add" and "replace" commands return wrong error codes at binary protocol.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1190,7 +1190,6 @@ static void complete_incr_bin(conn *c) {
 }
 
 static void complete_update_bin(conn *c) {
-    protocol_binary_response_status eno = PROTOCOL_BINARY_RESPONSE_EINVAL;
     enum store_item_type ret = NOT_STORED;
     assert(c != NULL);
 

--- a/memcached.c
+++ b/memcached.c
@@ -1245,14 +1245,7 @@ static void complete_update_bin(conn *c) {
         write_bin_error(c, PROTOCOL_BINARY_RESPONSE_KEY_ENOENT, NULL, 0);
         break;
     case NOT_STORED:
-        if (c->cmd == NREAD_ADD) {
-            eno = PROTOCOL_BINARY_RESPONSE_KEY_EEXISTS;
-        } else if(c->cmd == NREAD_REPLACE) {
-            eno = PROTOCOL_BINARY_RESPONSE_KEY_ENOENT;
-        } else {
-            eno = PROTOCOL_BINARY_RESPONSE_NOT_STORED;
-        }
-        write_bin_error(c, eno, NULL, 0);
+        write_bin_error(c, PROTOCOL_BINARY_RESPONSE_NOT_STORED, NULL, 0);
     }
 
     item_remove(c->item);       /* release the c->item reference */

--- a/t/binary.t
+++ b/t/binary.t
@@ -129,7 +129,7 @@ $empty->('y');
 
     my $rv =()= eval { $mc->add('i', "ex2", 10, 5) };
     is($rv, 0, "Add didn't return anything");
-    ok($@->exists, "Expected exists error received");
+    ok($@->not_stored, "Expected not_stored error received");
     $check->('i', 5, "ex");
 }
 
@@ -151,7 +151,7 @@ $empty->('y');
 
     my $rv =()= eval { $mc->replace('j', "ex", 19, 5) };
     is($rv, 0, "Replace didn't return anything");
-    ok($@->not_found, "Expected not_found error received");
+    ok($@->not_stored, "Expected not_stored error received");
     $empty->('j');
     $mc->add('j', "ex2", 14, 5);
     $check->('j', 14, "ex2");
@@ -893,6 +893,11 @@ sub delta_badval {
 sub einval {
     my $self = shift;
     return $self->[0] == ERR_EINVAL;
+}
+
+sub not_stored {
+    my $self = shift;
+    return $self->[0] == ERR_NOT_STORED;
 }
 
 # vim: filetype=perl

--- a/testapp.c
+++ b/testapp.c
@@ -1148,7 +1148,7 @@ static enum test_return test_binary_add_impl(const char *key, uint8_t cmd) {
         } else {
             safe_recv_packet(receive.bytes, sizeof(receive.bytes));
             validate_response_header(&receive.response, cmd,
-                                     PROTOCOL_BINARY_RESPONSE_KEY_EEXISTS);
+                                     PROTOCOL_BINARY_RESPONSE_NOT_STORED);
         }
     }
 
@@ -1176,7 +1176,7 @@ static enum test_return test_binary_replace_impl(const char* key, uint8_t cmd) {
     safe_send(send.bytes, len, false);
     safe_recv_packet(receive.bytes, sizeof(receive.bytes));
     validate_response_header(&receive.response, cmd,
-                             PROTOCOL_BINARY_RESPONSE_KEY_ENOENT);
+                             PROTOCOL_BINARY_RESPONSE_NOT_STORED);
     len = storage_command(send.bytes, sizeof(send.bytes),
                           PROTOCOL_BINARY_CMD_ADD,
                           key, strlen(key), &value, sizeof(value), 0, 0);


### PR DESCRIPTION
At binary protocol,
memcached answers "Key exists"(code: 2) for "add" command and
"Key not found"(code: 1) for "replace" command if the conditions are not met.

But the document says: 
```
- "NOT_STORED\r\n" to indicate the data was not stored, but not
because of an error. This normally means that the
condition for an "add" or a "replace" command wasn't met.
```
https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L196

So, the memcached should answer "Item not stored"(code: 5) instead.

