### PR TITLE
Slab rebalancer and slab automover improvements

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -598,8 +598,13 @@ integers separated by a colon (treat this as a floating point number).
 | slab_global_page_pool | 32u     | Slab pages returned to global pool for    |
 |                       |         | reassignment to other slab classes.       |
 | slab_reassign_rescues | 64u     | Items rescued from eviction in page move  |
-| slab_reassign_evictions                                                     |
-|                       | 64u     | Valid items evicted druing a page move    |
+| slab_reassign_evictions_nomem                                               |
+|                       | 64u     | Valid items evicted during a page move    |
+|                       |         | (due to no free memory in slab)           |
+| slab_reassign_evictions_samepage                                            |
+|                       | 64u     | Valid items evicted during a page move    |
+|                       |         | (due to free memory being in the same     |
+|                       |         |  page as the source item)                 |
 | slab_reassign_busy_items                                                    |
 |                       | 64u     | Items busy during page move, requiring a  |
 |                       |         | retry before page can be moved.           |

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -601,10 +601,10 @@ integers separated by a colon (treat this as a floating point number).
 | slab_reassign_evictions_nomem                                               |
 |                       | 64u     | Valid items evicted during a page move    |
 |                       |         | (due to no free memory in slab)           |
-| slab_reassign_evictions_samepage                                            |
-|                       | 64u     | Valid items evicted during a page move    |
-|                       |         | (due to free memory being in the same     |
-|                       |         |  page as the source item)                 |
+| slab_reassign_inline_reclaim                                                |
+|                       | 64u     | Internal stat counter for when the page   |
+|                       |         | mover clears memory from the chunk        |
+|                       |         | freelist when it wasn't expecting to.     |
 | slab_reassign_busy_items                                                    |
 |                       | 64u     | Items busy during page move, requiring a  |
 |                       |         | retry before page can be moved.           |

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -395,7 +395,9 @@ The response should always be "OK\r\n"
 
 - <0> means to set the thread on standby
 
-- <1> means to run the builtin slow algorithm to choose pages to move
+- <1> means to return pages to a global pool when there are more than 2 pages
+  worth of free chunks in a slab class. Pages are then re-assigned back into
+  other classes as-needed.
 
 - <2> is a highly aggressive mode which causes pages to be moved every time
   there is an eviction. It is not recommended to run for very long in this
@@ -593,6 +595,14 @@ integers separated by a colon (treat this as a floating point number).
 | lru_crawler_starts    | 64u     | Times an LRU crawler was started          |
 | lru_maintainer_juggles                                                      |
 |                       | 64u     | Number of times the LRU bg thread woke up |
+| slab_global_page_pool | 32u     | Slab pages returned to global pool for    |
+|                       |         | reassignment to other slab classes.       |
+| slab_reassign_rescues | 64u     | Items rescued from eviction in page move  |
+| slab_reassign_evictions                                                     |
+|                       | 64u     | Valid items evicted druing a page move    |
+| slab_reassign_busy_items                                                    |
+|                       | 64u     | Items busy during page move, requiring a  |
+|                       |         | retry before page can be moved.           |
 |-----------------------+---------+-------------------------------------------|
 
 Settings statistics

--- a/items.c
+++ b/items.c
@@ -179,7 +179,7 @@ item *do_item_alloc(char *key, const size_t nkey, const int flags,
         if (!settings.lru_maintainer_thread) {
             lru_pull_tail(id, COLD_LRU, 0, false, cur_hv);
         }
-        it = slabs_alloc(ntotal, id, &total_chunks);
+        it = slabs_alloc(ntotal, id, &total_chunks, 0);
         if (settings.expirezero_does_not_evict)
             total_chunks -= noexp_lru_size(id);
         if (it == NULL) {

--- a/items.c
+++ b/items.c
@@ -862,6 +862,9 @@ static int lru_pull_tail(const int orig_id, const int cur_lru,
                     }
                     do_item_unlink_nolock(search, hv);
                     removed++;
+                    if (settings.slab_automove == 2) {
+                        slabs_reassign(-1, orig_id);
+                    }
                 } else if ((search->it_flags & ITEM_ACTIVE) != 0
                         && settings.lru_maintainer_thread) {
                     itemstats[id].moves_to_warm++;

--- a/items.c
+++ b/items.c
@@ -906,7 +906,7 @@ static int lru_maintainer_juggle(const int slabs_clsid) {
      * worth of chunks free in this class, ask (gently) to reassign a page
      * from this class back into the global pool (0)
      */
-    if (settings.slab_automove > 0 && chunks_free > (chunks_perslab * 2)) {
+    if (settings.slab_automove > 0 && chunks_free > (chunks_perslab * 2.5)) {
         slabs_reassign(slabs_clsid, SLAB_GLOBAL_PAGE_POOL);
     }
 

--- a/items.c
+++ b/items.c
@@ -113,6 +113,7 @@ int item_is_flushed(item *it) {
 
 static unsigned int noexp_lru_size(int slabs_clsid) {
     int id = CLEAR_LRU(slabs_clsid);
+    id |= NOEXP_LRU;
     unsigned int ret;
     pthread_mutex_lock(&lru_locks[id]);
     ret = sizes[id];
@@ -476,20 +477,6 @@ char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, u
     *bytes = bufcurr;
     pthread_mutex_unlock(&lru_locks[id]);
     return buffer;
-}
-
-void item_stats_evictions(uint64_t *evicted) {
-    int n;
-    for (n = 0; n < MAX_NUMBER_OF_SLAB_CLASSES; n++) {
-        int i;
-        int x;
-        for (x = 0; x < 4; x++) {
-            i = n | lru_type_map[x];
-            pthread_mutex_lock(&lru_locks[i]);
-            evicted[n] += itemstats[i].evicted;
-            pthread_mutex_unlock(&lru_locks[i]);
-        }
-    }
 }
 
 void item_stats_totals(ADD_STAT add_stats, void *c) {
@@ -907,10 +894,21 @@ static int lru_maintainer_juggle(const int slabs_clsid) {
     int did_moves = 0;
     bool mem_limit_reached = false;
     unsigned int total_chunks = 0;
+    unsigned int chunks_perslab = 0;
+    unsigned int chunks_free = 0;
     /* TODO: if free_chunks below high watermark, increase aggressiveness */
-    slabs_available_chunks(slabs_clsid, &mem_limit_reached, &total_chunks);
+    chunks_free = slabs_available_chunks(slabs_clsid, &mem_limit_reached,
+            &total_chunks, &chunks_perslab);
     if (settings.expirezero_does_not_evict)
         total_chunks -= noexp_lru_size(slabs_clsid);
+
+    /* If slab automove is enabled on any level, and we have more than 2 pages
+     * worth of chunks free in this class, ask (gently) to reassign a page
+     * from this class back into the global pool (0)
+     */
+    if (settings.slab_automove > 0 && chunks_free > (chunks_perslab * 2)) {
+        slabs_reassign(slabs_clsid, SLAB_GLOBAL_PAGE_POOL);
+    }
 
     /* Juggle HOT/WARM up to N times */
     for (i = 0; i < 1000; i++) {

--- a/items.c
+++ b/items.c
@@ -98,7 +98,7 @@ uint64_t get_cas_id(void) {
     return next_id;
 }
 
-static int is_flushed(item *it) {
+int item_is_flushed(item *it) {
     rel_time_t oldest_live = settings.oldest_live;
     uint64_t cas = ITEM_get_cas(it);
     uint64_t oldest_cas = settings.oldest_cas;
@@ -712,7 +712,7 @@ item *do_item_get(const char *key, const size_t nkey, const uint32_t hv) {
     }
 
     if (it != NULL) {
-        if (is_flushed(it)) {
+        if (item_is_flushed(it)) {
             do_item_unlink(it, hv);
             do_item_remove(it);
             it = NULL;
@@ -803,7 +803,7 @@ static int lru_pull_tail(const int orig_id, const int cur_lru,
 
         /* Expired or flushed */
         if ((search->exptime != 0 && search->exptime < current_time)
-            || is_flushed(search)) {
+            || item_is_flushed(search)) {
             itemstats[id].reclaimed++;
             if ((search->it_flags & ITEM_FETCHED) == 0) {
                 itemstats[id].expired_unfetched++;
@@ -1199,7 +1199,7 @@ static void item_crawler_evaluate(item *search, uint32_t hv, int i) {
     crawlerstats_t *s = &crawlerstats[slab_id];
     itemstats[i].crawler_items_checked++;
     if ((search->exptime != 0 && search->exptime < current_time)
-        || is_flushed(search)) {
+        || item_is_flushed(search)) {
         itemstats[i].crawler_reclaimed++;
         s->reclaimed++;
 

--- a/items.h
+++ b/items.h
@@ -14,6 +14,8 @@ void do_item_update(item *it);   /** update LRU time to current and reposition *
 void do_item_update_nolock(item *it);
 int  do_item_replace(item *it, item *new_it, const uint32_t hv);
 
+int item_is_flushed(item *it);
+
 /*@null@*/
 char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, unsigned int *bytes);
 void item_stats(ADD_STAT add_stats, void *c);

--- a/items.h
+++ b/items.h
@@ -27,7 +27,6 @@ item *do_item_get(const char *key, const size_t nkey, const uint32_t hv);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv);
 void item_stats_reset(void);
 extern pthread_mutex_t lru_locks[POWER_LARGEST];
-void item_stats_evictions(uint64_t *evicted);
 
 enum crawler_result_type {
     CRAWLER_OK=0, CRAWLER_RUNNING, CRAWLER_BADCLASS, CRAWLER_NOTSTARTED

--- a/memcached.c
+++ b/memcached.c
@@ -2631,7 +2631,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     if (settings.slab_reassign) {
         APPEND_STAT("slab_reassign_rescues", "%llu", stats.slab_reassign_rescues);
         APPEND_STAT("slab_reassign_evictions_nomem", "%llu", stats.slab_reassign_evictions_nomem);
-        APPEND_STAT("slab_reassign_evictions_samepage", "%llu", stats.slab_reassign_evictions_samepage);
+        APPEND_STAT("slab_reassign_inline_reclaim", "%llu", stats.slab_reassign_inline_reclaim);
         APPEND_STAT("slab_reassign_busy_items", "%llu", stats.slab_reassign_busy_items);
         APPEND_STAT("slab_reassign_running", "%u", stats.slab_reassign_running);
         APPEND_STAT("slabs_moved", "%llu", stats.slabs_moved);

--- a/memcached.c
+++ b/memcached.c
@@ -2629,6 +2629,9 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     APPEND_STAT("hash_bytes", "%llu", (unsigned long long)stats.hash_bytes);
     APPEND_STAT("hash_is_expanding", "%u", stats.hash_is_expanding);
     if (settings.slab_reassign) {
+        APPEND_STAT("slab_reassign_rescues", "%llu", stats.slab_reassign_rescues);
+        APPEND_STAT("slab_reassign_evictions", "%llu", stats.slab_reassign_evictions);
+        APPEND_STAT("slab_reassign_busy_items", "%llu", stats.slab_reassign_busy_items);
         APPEND_STAT("slab_reassign_running", "%u", stats.slab_reassign_running);
         APPEND_STAT("slabs_moved", "%llu", stats.slabs_moved);
     }

--- a/memcached.c
+++ b/memcached.c
@@ -2630,7 +2630,8 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     APPEND_STAT("hash_is_expanding", "%u", stats.hash_is_expanding);
     if (settings.slab_reassign) {
         APPEND_STAT("slab_reassign_rescues", "%llu", stats.slab_reassign_rescues);
-        APPEND_STAT("slab_reassign_evictions", "%llu", stats.slab_reassign_evictions);
+        APPEND_STAT("slab_reassign_evictions_nomem", "%llu", stats.slab_reassign_evictions_nomem);
+        APPEND_STAT("slab_reassign_evictions_samepage", "%llu", stats.slab_reassign_evictions_samepage);
         APPEND_STAT("slab_reassign_busy_items", "%llu", stats.slab_reassign_busy_items);
         APPEND_STAT("slab_reassign_running", "%u", stats.slab_reassign_running);
         APPEND_STAT("slabs_moved", "%llu", stats.slabs_moved);

--- a/memcached.h
+++ b/memcached.h
@@ -287,7 +287,8 @@ struct stats {
     bool          slab_reassign_running; /* slab reassign in progress */
     uint64_t      slabs_moved;       /* times slabs were moved around */
     uint64_t      slab_reassign_rescues; /* items rescued during slab move */
-    uint64_t      slab_reassign_evictions; /* valid items lost during slab move */
+    uint64_t      slab_reassign_evictions_nomem; /* valid items lost during slab move */
+    uint64_t      slab_reassign_evictions_samepage; /* valid items lost during slab move */
     uint64_t      slab_reassign_busy_items; /* valid temporarily unmovable */
     uint64_t      lru_crawler_starts; /* Number of item crawlers kicked off */
     bool          lru_crawler_running; /* crawl in progress */
@@ -529,7 +530,8 @@ struct slab_rebalance {
     int d_clsid;
     uint32_t busy_items;
     uint32_t rescues;
-    uint32_t evictions;
+    uint32_t evictions_nomem;
+    uint32_t evictions_samepage;
     uint8_t done;
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -527,7 +527,9 @@ struct slab_rebalance {
     void *slab_pos;
     int s_clsid;
     int d_clsid;
-    int busy_items;
+    uint32_t busy_items;
+    uint32_t rescues;
+    uint32_t evictions;
     uint8_t done;
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -78,6 +78,7 @@
 /* Slab sizing definitions. */
 #define POWER_SMALLEST 1
 #define POWER_LARGEST  256 /* actual cap is 255 */
+#define SLAB_GLOBAL_PAGE_POOL 0 /* magic slab class for storing pages for reassignment */
 #define CHUNK_ALIGN_BYTES 8
 /* slab class max is a 6-bit number, -1. */
 #define MAX_NUMBER_OF_SLAB_CLASSES (63 + 1)

--- a/memcached.h
+++ b/memcached.h
@@ -288,7 +288,7 @@ struct stats {
     uint64_t      slabs_moved;       /* times slabs were moved around */
     uint64_t      slab_reassign_rescues; /* items rescued during slab move */
     uint64_t      slab_reassign_evictions_nomem; /* valid items lost during slab move */
-    uint64_t      slab_reassign_evictions_samepage; /* valid items lost during slab move */
+    uint64_t      slab_reassign_inline_reclaim; /* valid items lost during slab move */
     uint64_t      slab_reassign_busy_items; /* valid temporarily unmovable */
     uint64_t      lru_crawler_starts; /* Number of item crawlers kicked off */
     bool          lru_crawler_running; /* crawl in progress */
@@ -531,7 +531,7 @@ struct slab_rebalance {
     uint32_t busy_items;
     uint32_t rescues;
     uint32_t evictions_nomem;
-    uint32_t evictions_samepage;
+    uint32_t inline_reclaim;
     uint8_t done;
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -285,6 +285,9 @@ struct stats {
     uint64_t      evicted_unfetched; /* items evicted but never touched */
     bool          slab_reassign_running; /* slab reassign in progress */
     uint64_t      slabs_moved;       /* times slabs were moved around */
+    uint64_t      slab_reassign_rescues; /* items rescued during slab move */
+    uint64_t      slab_reassign_evictions; /* valid items lost during slab move */
+    uint64_t      slab_reassign_busy_items; /* valid temporarily unmovable */
     uint64_t      lru_crawler_starts; /* Number of item crawlers kicked off */
     bool          lru_crawler_running; /* crawl in progress */
     uint64_t      lru_maintainer_juggles; /* number of LRU bg pokes */

--- a/slabs.c
+++ b/slabs.c
@@ -747,10 +747,10 @@ static void slab_rebalance_finish(void) {
      * We always kill the "first"/"oldest" slab page in the slab_list, so
      * shuffle the page list backwards and decrement.
      */
+    s_cls->slabs--;
     for (x = 0; x < s_cls->slabs; x++) {
         s_cls->slab_list[x] = s_cls->slab_list[x+1];
     }
-    s_cls->slabs--;
 
     memset(slab_rebal.slab_start, 0, (size_t)settings.item_size_max);
 

--- a/slabs.c
+++ b/slabs.c
@@ -232,7 +232,6 @@ static int do_slabs_newslab(const unsigned int id) {
     split_slab_page_into_freelist(ptr, id);
 
     p->slab_list[p->slabs++] = ptr;
-    mem_malloced += len;
     MEMCACHED_SLABS_SLABCLASS_ALLOCATE(id);
 
     return 1;
@@ -430,6 +429,7 @@ static void *memory_allocate(size_t size) {
             mem_avail = 0;
         }
     }
+    mem_malloced += size;
 
     return ret;
 }

--- a/slabs.c
+++ b/slabs.c
@@ -659,7 +659,7 @@ static int slab_rebalance_move(void) {
                     save_item = 0;
                 } else if (s_cls->sl_curr < 1) {
                     save_item = 0;
-                    slab_rebal.evictions++;
+                    slab_rebal.evictions_nomem++;
                 } else {
                     save_item = 1;
                     /* BIT OF A HACK: if sl_curr is > 0 alloc won't try to
@@ -675,7 +675,7 @@ static int slab_rebalance_move(void) {
                          */
                         do_slabs_free(new_it, ntotal, slab_rebal.s_clsid);
                         save_item = 0;
-                        slab_rebal.evictions++;
+                        slab_rebal.evictions_samepage++;
                     }
                 }
                 pthread_mutex_unlock(&slabs_lock);
@@ -743,7 +743,8 @@ static void slab_rebalance_finish(void) {
     slabclass_t *d_cls;
     int x;
     uint32_t rescues;
-    uint32_t evictions;
+    uint32_t evictions_nomem;
+    uint32_t evictions_samepage;
 
     pthread_mutex_lock(&slabs_lock);
 
@@ -787,9 +788,11 @@ static void slab_rebalance_finish(void) {
     slab_rebal.slab_start = NULL;
     slab_rebal.slab_end   = NULL;
     slab_rebal.slab_pos   = NULL;
-    evictions = slab_rebal.evictions;
+    evictions_nomem    = slab_rebal.evictions_nomem;
+    evictions_samepage = slab_rebal.evictions_samepage;
     rescues   = slab_rebal.rescues;
-    slab_rebal.evictions  = 0;
+    slab_rebal.evictions_nomem    = 0;
+    slab_rebal.evictions_samepage = 0;
     slab_rebal.rescues  = 0;
 
     slab_rebalance_signal = 0;
@@ -800,7 +803,8 @@ static void slab_rebalance_finish(void) {
     stats.slab_reassign_running = false;
     stats.slabs_moved++;
     stats.slab_reassign_rescues += rescues;
-    stats.slab_reassign_evictions += evictions;
+    stats.slab_reassign_evictions_nomem += evictions_nomem;
+    stats.slab_reassign_evictions_samepage += evictions_samepage;
     STATS_UNLOCK();
 
     if (settings.verbose > 1) {

--- a/slabs.c
+++ b/slabs.c
@@ -698,9 +698,10 @@ static int slab_rebalance_move(void) {
                 }
                 item_trylock_unlock(hold_lock);
                 pthread_mutex_lock(&slabs_lock);
-                if (save_item == 0) {
-                    s_cls->requested -= ntotal;
-                }
+                /* Always remove the ntotal, as we added it in during
+                 * do_slabs_alloc() when copying the item.
+                 */
+                s_cls->requested -= ntotal;
             case MOVE_FROM_SLAB:
                 it->refcount = 0;
                 it->it_flags = 0;

--- a/slabs.h
+++ b/slabs.h
@@ -34,7 +34,7 @@ bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 void slabs_stats(ADD_STAT add_stats, void *c);
 
 /* Hints as to freespace in slab class */
-unsigned int slabs_available_chunks(unsigned int id, bool *mem_flag, unsigned int *total_chunks);
+unsigned int slabs_available_chunks(unsigned int id, bool *mem_flag, unsigned int *total_chunks, unsigned int *chunks_perslab);
 
 int start_slab_maintenance_thread(void);
 void stop_slab_maintenance_thread(void);

--- a/slabs.h
+++ b/slabs.h
@@ -19,7 +19,8 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc);
 unsigned int slabs_clsid(const size_t size);
 
 /** Allocate object of given length. 0 on error */ /*@null@*/
-void *slabs_alloc(const size_t size, unsigned int id, unsigned int *total_chunks);
+#define SLABS_ALLOC_NO_NEWPAGE 1
+void *slabs_alloc(const size_t size, unsigned int id, unsigned int *total_chunks, unsigned int flags);
 
 /** Free previously allocated object */
 void slabs_free(void *ptr, size_t size, unsigned int id);

--- a/t/slabs-reassign2.t
+++ b/t/slabs-reassign2.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 5;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -42,7 +42,7 @@ for (1 .. $keycount) {
     } else {
         $body .= scalar(<$sock>) . scalar(<$sock>);
         if ($body ne $expected) {
-            print STDERR "Something terrible has happened: $body\n";
+            print STDERR "Something terrible has happened: $expected\nBODY:\n$body\nDONETEST\n";
         } else {
             $hits++;
         }
@@ -52,10 +52,13 @@ for (1 .. $keycount) {
 
 {
     my $stats = mem_stats($sock);
-    cmp_ok($stats->{evictions}, '<', 1000, 'evictions were less than 1000');
+    cmp_ok($stats->{evictions}, '<', 2000, 'evictions were less than 2000');
 #    for ('evictions', 'reclaimed', 'curr_items', 'cmd_set', 'bytes') {
 #        print STDERR "$_: ", $stats->{$_}, "\n";
 #    }
 }
 
 cmp_ok($hits, '>', 4000, 'were able to fetch back 2/3rds of 8k keys');
+my $stats_done = mem_stats($sock);
+cmp_ok($stats_done->{slab_reassign_rescues}, '>', 0, 'some reassign rescues happened');
+cmp_ok($stats_done->{slab_reassign_evictions}, '>', 0, 'some reassing evictions happened');

--- a/t/slabs-reassign2.t
+++ b/t/slabs-reassign2.t
@@ -1,0 +1,61 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 3;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached('-m 64 -o slab_reassign,slab_automove=2,lru_crawler,lru_maintainer');
+my $sock = $server->sock;
+
+my $value = "B"x10240;
+my $keycount = 6000;
+
+my $res;
+for (1 .. $keycount) {
+    print $sock "set nfoo$_ 0 0 10240 noreply\r\n$value\r\n";
+}
+
+{
+    my $stats = mem_stats($sock);
+    is($stats->{curr_items}, $keycount, "stored $keycount 10k items");
+#    for ('evictions', 'reclaimed', 'curr_items', 'cmd_set', 'bytes') {
+#        print STDERR "$_: ", $stats->{$_}, "\n";
+#    }
+}
+
+$value = "B"x8096;
+for (1 .. $keycount) {
+    print $sock "set ifoo$_ 0 0 8096 noreply\r\n$value\r\n";
+}
+
+my $missing = 0;
+my $hits = 0;
+for (1 .. $keycount) {
+    print $sock "get ifoo$_\r\n";
+    my $body = scalar(<$sock>);
+    my $expected = "VALUE ifoo$_ 0 8096\r\n$value\r\nEND\r\n";
+    if ($body =~ /^END/) {
+        $missing++;
+    } else {
+        $body .= scalar(<$sock>) . scalar(<$sock>);
+        if ($body ne $expected) {
+            print STDERR "Something terrible has happened: $body\n";
+        } else {
+            $hits++;
+        }
+    }
+}
+#print STDERR "HITS: $hits, MISSES: $missing\n";
+
+{
+    my $stats = mem_stats($sock);
+    cmp_ok($stats->{evictions}, '<', 1000, 'evictions were less than 1000');
+#    for ('evictions', 'reclaimed', 'curr_items', 'cmd_set', 'bytes') {
+#        print STDERR "$_: ", $stats->{$_}, "\n";
+#    }
+}
+
+cmp_ok($hits, '>', 4000, 'were able to fetch back 2/3rds of 8k keys');

--- a/t/slabs-reassign2.t
+++ b/t/slabs-reassign2.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 11;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -75,6 +75,11 @@ for ($tries = 20; $tries > 0; $tries--) {
 }
 cmp_ok($tries, '>', 0, 'reclaimed 61 pages before timeout');
 
+{
+    my $stats = mem_stats($sock, "slabs");
+    is($stats->{total_malloced}, 68157440, "total_malloced is what we expect");
+}
+
 # Set into an entirely new class. Overload a bit to try to cause problems.
 $value = "B"x4096;
 for (1 .. $keycount * 4) {
@@ -85,4 +90,9 @@ for (1 .. $keycount * 4) {
     my $stats = mem_stats($sock);
     is($stats->{curr_items}, 14490, "stored 14490 4k items");
     is($stats->{slab_global_page_pool}, 0, "drained the global page pool");
+}
+
+{
+    my $stats = mem_stats($sock, "slabs");
+    is($stats->{total_malloced}, 68157440, "total_malloced is same after re-assignment");
 }

--- a/t/slabs-reassign2.t
+++ b/t/slabs-reassign2.t
@@ -61,7 +61,7 @@ for (1 .. $keycount) {
 cmp_ok($hits, '>', 4000, 'were able to fetch back 2/3rds of 8k keys');
 my $stats_done = mem_stats($sock);
 cmp_ok($stats_done->{slab_reassign_rescues}, '>', 0, 'some reassign rescues happened');
-cmp_ok($stats_done->{slab_reassign_evictions}, '>', 0, 'some reassing evictions happened');
+cmp_ok($stats_done->{slab_reassign_evictions_nomem}, '>', 0, 'some reassing evictions happened');
 
 print $sock "flush_all\r\n";
 is(scalar <$sock>, "OK\r\n", "did flush_all");


### PR DESCRIPTION
**This PR is release-candidate ready**

Use start options like: `-o slab_reassign,slab_automove,lru_crawler,lru_maintainer`

The slab rebalancer and automover have sat as a first-pass and proof of concept for several years.

This changeset aims to improve both to the point where it can be enabled by default in future versions as well as generally be more useful to people. The old automover would only move one page every 10-60 seconds, and did so very conservatively. Without an automover, long running instances of memcached can utilize memory poorly if the average size of items changes after the memory is full.

1. Slab rebalancer is improved to attempt to "rescue" items while moving a page. If free memory is available in the source slab class, copy and re-link items which are still valid, instead of silently evicting them.
2. New automover default mode will aggressively return pages to a "global pool" if there is more than 2*pagesize free chunks available in a slab class. Pages will then distribute as-needed back into any slab class.
3. Returned an experimental automove=2 mode, which aggressively requests random memory be assigned to a slab class on any eviction.
4. One more forthcoming patch to optionally make automove decisions even if all memory is full (based on eviction pressure, most likely).

Some work remains for this branch:
- [ ] automove=3 mode + tunables for automoving while classes are full. [may not do this, see below]
- [x] Review for cleanups, extra counters, or verbose logging. [partly done]
- [x] Documentation of new tunables and variables.

## automove=3

Will likely punt on this for now. I cannot determine the _value_ of an object being evicted, so it is difficult to write an algorithm to generically move pages between slab classes when all memory is full and there are nothing but evictions. The right choice there is very dependent on the use case. I'll discuss some options below.

### pull pages in from other classes if free chunks are below a watermark (ie; half a page)

 * Still need to decide how to pull pages from other classes most effectively. Could do it randomly, or pull from the one with the most pages at the moment.

### Weighted shuffling of pages between slab classes to amortize evictions

 * If class 2 has 5 evictions per second, and class 1 has 2 evictions per second, slowly move pages from class 1 to 2.
 * If class 2 has 5 evictions per second and class 1 has 0 evictions per second, slowly move pages from class 1 to 2.
 * If class 2 has evictions where the item has _been fetched before_, and class 1 has either 0 evictions, or evictions where the items _have not been fetched before_, slowly move pages from 1 to 2.
  * Weakness: if pages are moving through class 1 so quickly they never get a chance to be fetched. Could slew against the number of overall sets or evictions.
 * If class 2 has evictions where the item has _been fetched before_, and class 1 has either 0 evictions, evictions where the item _has not been fetched before_, and/or the last accessed time on class 2 is significantly lower then class 1, slowly move pages from 1 to 2.
  * Similar problem as the option above.

If you need to have memory always evicting but still rebalance the slab pages, there is still the option of manually running the reassign command. centralized or per-host daemons can monitor the various `stats` commands once per N seconds and reassign pages in a way that fits the needs of the particular usage scenario.

The other changes in this branch related to rescuing items when possible should make it less traumatic for the hit ratio to arbitrarily move pages. What would improve this even more is a way to signal to the system to evict items from the tail before moving a slab page, if the slab class is full in the first place. Then items could always be rescued and force evictions at the tail rather than simply be evicted if no free chunks are available.