### PR TITLE
Fix eviction accumulation in item_stats_evictions().

### DIFF
--- a/items.c
+++ b/items.c
@@ -481,6 +481,7 @@ char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, u
 void item_stats_evictions(uint64_t *evicted) {
     int n;
     for (n = 0; n < MAX_NUMBER_OF_SLAB_CLASSES; n++) {
+        evicted[n] = 0;
         int i;
         int x;
         for (x = 0; x < 4; x++) {


### PR DESCRIPTION
item_stats_evictions() doesn't reset the array before adding sub LRU's. This causes slab_automove to not do anything at all or select slabs at random.

This PR fixes this issue and makes slab_automove work as expected.