### PR TITLE
Documentation: update manpage for -I (slabsize) parameter

### DIFF
--- a/doc/memcached.1
+++ b/doc/memcached.1
@@ -126,8 +126,9 @@ specify the protocol clients must speak.  Possible options are "auto"
 (the default, autonegotiation behavior), "ascii" and "binary".
 .TP
 .B \-I <size>
-Override the default size of each slab page. Default is 1mb. Default is 1m,
-minimum is 1k, max is 128m. Adjusting this value changes the item size limit.
+Override the default size of each slab page. The default size is 1mb. Default
+value for this parameter is 1m, minimum is 1k, max is 128m.
+Adjusting this value changes the item size limit.
 Beware that this also increases the number of slabs (use -v to view), and the
 overal memory usage of memcached.
 .TP


### PR DESCRIPTION
Update documentation to more accurately reflect the value that should be passed along as the parameter via command line.

I found myself interpreting the current text as if I should write ```memcached -I 10mb``` but it should really be ```memcached -I 10m```. I'm hoping this PR makes that more clear.