### PR TITLE
Dump command learned to handle no-expire keys

### DIFF
--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -79,6 +79,25 @@ die "Couldn't connect to $addr\n" unless $sock;
 if ($mode eq 'dump') {
     my %items;
     my $totalitems;
+    my $uptime;
+    my $time;
+    my $noexpiretime;
+
+    print $sock "stats\r\n";
+
+    while(<$sock>) {
+        last if /^END/;
+
+        if (/^STAT uptime (\d*)/) {
+            $uptime = $1;
+        }
+
+        if (/^STAT time (\d*)/) {
+            $time = $1;
+        }
+    }
+
+    $noexpiretime = $time - $uptime;
 
     print $sock "stats items\r\n";
 
@@ -102,7 +121,11 @@ if ($mode eq 'dump') {
             # return format looks like this
             # ITEM foo [6 b; 1176415152 s]
             if (/^ITEM (\S+) \[.* (\d+) s\]/) {
-                $keyexp{$1} = $2;
+                if ($2 == $noexpiretime) {
+                    $keyexp{$1} = 0;
+                } else {
+                    $keyexp{$1} = $2;
+                }
             }
         }
 


### PR DESCRIPTION
memcache internals can use the timestamp generated by time - uptime from
stats to signal a no-expire key.  The dump command didn't account for
this.  This meant that a dump could not be imported into another memcached
instance with a guarantee that the data would be the same With this change, 
the dump command now uses the stats command's output to generate the 
no-expire timestamp.  Any exported timestamp that matches this no-expire 
timestamp is replaced with a 0 instead, so that when reimporting the data, 
the key is properly set as a no-expire key.