### PR TITLE
Fail to build on GNU/Hurd

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4119,7 +4119,7 @@ static void drive_machine(conn *c) {
                 STATS_UNLOCK();
             } else {
                 dispatch_conn_new(sfd, conn_new_cmd, EV_READ | EV_PERSIST,
-                                     DATA_BUFFER_SIZE, tcp_transport);
+                                     DATA_BUFFER_SIZE, c->transport);
             }
 
             stop = true;

--- a/memcached.c
+++ b/memcached.c
@@ -50,7 +50,7 @@
 
 /* FreeBSD 4.x doesn't have IOV_MAX exposed. */
 #ifndef IOV_MAX
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__GNU__)
 # define IOV_MAX 1024
 #endif
 #endif
@@ -5712,12 +5712,15 @@ int main (int argc, char **argv) {
     /* create the listening socket, bind it, and init */
     if (settings.socketpath == NULL) {
         const char *portnumber_filename = getenv("MEMCACHED_PORT_FILENAME");
-        char temp_portnumber_filename[PATH_MAX];
+        char *temp_portnumber_filename = NULL;
+        size_t len;
         FILE *portnumber_file = NULL;
 
         if (portnumber_filename != NULL) {
+            len = strlen(portnumber_filename)+4+1;
+            temp_portnumber_filename = malloc(len);
             snprintf(temp_portnumber_filename,
-                     sizeof(temp_portnumber_filename),
+                     len,
                      "%s.lck", portnumber_filename);
 
             portnumber_file = fopen(temp_portnumber_filename, "a");
@@ -5752,6 +5755,7 @@ int main (int argc, char **argv) {
         if (portnumber_file) {
             fclose(portnumber_file);
             rename(temp_portnumber_filename, portnumber_filename);
+            free(temp_portnumber_filename);
         }
     }
 

--- a/memcached.c
+++ b/memcached.c
@@ -52,6 +52,11 @@
 #ifndef IOV_MAX
 #if defined(__FreeBSD__) || defined(__APPLE__) || defined(__GNU__)
 # define IOV_MAX 1024
+/* GNU/Hurd don't set MAXPATHLEN
+ * http://www.gnu.org/software/hurd/hurd/porting/guidelines.html#PATH_MAX_tt_MAX_PATH_tt_MAXPATHL */
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 4096
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
The first easy step was to define missing macros **IOV_MAX, PATH_MAX & MAXPATHLEN**.
Patch that dynamic alloc buffer instead of harcode PATH_MAX is used in the Debian package (http://anonscm.debian.org/cgit/collab-maint/memcached.git/tree/debian/patches/03_fix_ftbfs4hurd.patch, all credits to Svante Signell).
For MAXPATHLEN, i haven't touched the code, just define it if undefined.

The second step was about using UNIX domain sockets on GNU/Hurd.
The transport was hardcoded to tcp in *drive_machine()* when calling *dispatch_conn_new()* and *getpeername(2)* was always called even if transport is not tcp. After using *c->transport*, there is still a problem : *t/stats-conn.t* verify that the socket name appears in "stats conn" output, which is not the case at least on GNU/Hurd (and *BSD, according to docs) but only "<AF 1>". *conn_to_str()* calls *getsockname(2)* which always return an empty string for UNIX domain sockets.