### PR TITLE
Allow compilation with -Werror on gcc 4.4.7

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1283,7 +1283,7 @@ static void process_bin_get_or_touch(conn *c) {
 
     if (settings.verbose > 1) {
         fprintf(stderr, "<%d %s ", c->sfd, should_touch ? "TOUCH" : "GET");
-        fwrite(key, 1, nkey, stderr);
+        if (fwrite(key, 1, nkey, stderr)) {}
         fputc('\n', stderr);
     }
 


### PR DESCRIPTION
gcc 4.4.7 with -Werror fails without this change:

```
memcached.c: In function ‘process_bin_get_or_touch’:
memcached.c:1286: error: ignoring return value of ‘fwrite’, declared with attribute warn_unused_result
```