### PR TITLE
fix build with musl libc

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -14,8 +14,8 @@
 #include "memcached.h"
 #include <sys/stat.h>
 #include <sys/socket.h>
-#include <sys/signal.h>
 #include <sys/resource.h>
+#include <signal.h>
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <errno.h>

--- a/items.c
+++ b/items.c
@@ -2,13 +2,13 @@
 #include "memcached.h"
 #include <sys/stat.h>
 #include <sys/socket.h>
-#include <sys/signal.h>
 #include <sys/resource.h>
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <signal.h>
 #include <string.h>
 #include <time.h>
 #include <assert.h>

--- a/slabs.c
+++ b/slabs.c
@@ -10,7 +10,6 @@
 #include "memcached.h"
 #include <sys/stat.h>
 #include <sys/socket.h>
-#include <sys/signal.h>
 #include <sys/resource.h>
 #include <fcntl.h>
 #include <netinet/in.h>
@@ -18,6 +17,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <signal.h>
 #include <assert.h>
 #include <pthread.h>
 


### PR DESCRIPTION
musl libc will warn if you include sys/signal.h instead of signal.h as
specified by posix. Build will fail due to -Werror explicitly beeing
set.

Fix it by use the posix location.

fixes #138