### PR TITLE
fix zero hash items eviction

### DIFF
--- a/items.c
+++ b/items.c
@@ -85,7 +85,7 @@ void item_stats_reset(void) {
 }
 
 static int lru_pull_tail(const int orig_id, const int cur_lru,
-        const unsigned int total_chunks, const bool do_evict, const uint32_t cur_hv);
+        const unsigned int total_chunks, const bool do_evict);
 static int lru_crawler_start(uint32_t id, uint32_t remaining);
 
 /* Get the next CAS id for a new item. */
@@ -152,8 +152,7 @@ static size_t item_make_header(const uint8_t nkey, const int flags, const int nb
 }
 
 item *do_item_alloc(char *key, const size_t nkey, const int flags,
-                    const rel_time_t exptime, const int nbytes,
-                    const uint32_t cur_hv) {
+                    const rel_time_t exptime, const int nbytes) {
     int i;
     uint8_t nsuffix;
     item *it = NULL;
@@ -177,18 +176,18 @@ item *do_item_alloc(char *key, const size_t nkey, const int flags,
     for (i = 0; i < 5; i++) {
         /* Try to reclaim memory first */
         if (!settings.lru_maintainer_thread) {
-            lru_pull_tail(id, COLD_LRU, 0, false, cur_hv);
+            lru_pull_tail(id, COLD_LRU, 0, false);
         }
         it = slabs_alloc(ntotal, id, &total_chunks, 0);
         if (settings.expirezero_does_not_evict)
             total_chunks -= noexp_lru_size(id);
         if (it == NULL) {
             if (settings.lru_maintainer_thread) {
-                lru_pull_tail(id, HOT_LRU, total_chunks, false, cur_hv);
-                lru_pull_tail(id, WARM_LRU, total_chunks, false, cur_hv);
-                lru_pull_tail(id, COLD_LRU, total_chunks, true, cur_hv);
+                lru_pull_tail(id, HOT_LRU, total_chunks, false);
+                lru_pull_tail(id, WARM_LRU, total_chunks, false);
+                lru_pull_tail(id, COLD_LRU, total_chunks, true);
             } else {
-                lru_pull_tail(id, COLD_LRU, 0, true, cur_hv);
+                lru_pull_tail(id, COLD_LRU, 0, true);
             }
         } else {
             break;
@@ -748,7 +747,7 @@ item *do_item_touch(const char *key, size_t nkey, uint32_t exptime,
 /* Returns number of items remove, expired, or evicted.
  * Callable from worker threads or the LRU maintainer thread */
 static int lru_pull_tail(const int orig_id, const int cur_lru,
-        const unsigned int total_chunks, const bool do_evict, const uint32_t cur_hv) {
+        const unsigned int total_chunks, const bool do_evict) {
     item *it = NULL;
     int id = orig_id;
     int removed = 0;
@@ -777,7 +776,7 @@ static int lru_pull_tail(const int orig_id, const int cur_lru,
         uint32_t hv = hash(ITEM_key(search), search->nkey);
         /* Attempt to hash item lock the "search" item. If locked, no
          * other callers can incr the refcount. Also skip ourselves. */
-        if (hv == cur_hv || (hold_lock = item_trylock(hv)) == NULL)
+        if ((hold_lock = item_trylock(hv)) == NULL)
             continue;
         /* Now see if the item is refcount locked */
         if (refcount_incr(&search->refcount) != 2) {
@@ -923,11 +922,11 @@ static int lru_maintainer_juggle(const int slabs_clsid) {
     /* Juggle HOT/WARM up to N times */
     for (i = 0; i < 1000; i++) {
         int do_more = 0;
-        if (lru_pull_tail(slabs_clsid, HOT_LRU, total_chunks, false, 0) ||
-            lru_pull_tail(slabs_clsid, WARM_LRU, total_chunks, false, 0)) {
+        if (lru_pull_tail(slabs_clsid, HOT_LRU, total_chunks, false) ||
+            lru_pull_tail(slabs_clsid, WARM_LRU, total_chunks, false)) {
             do_more++;
         }
-        do_more += lru_pull_tail(slabs_clsid, COLD_LRU, total_chunks, false, 0);
+        do_more += lru_pull_tail(slabs_clsid, COLD_LRU, total_chunks, false);
         if (do_more == 0)
             break;
         did_moves++;

--- a/items.h
+++ b/items.h
@@ -2,7 +2,7 @@
 uint64_t get_cas_id(void);
 
 /*@null@*/
-item *do_item_alloc(char *key, const size_t nkey, const int flags, const rel_time_t exptime, const int nbytes, const uint32_t cur_hv);
+item *do_item_alloc(char *key, const size_t nkey, const int flags, const rel_time_t exptime, const int nbytes);
 void item_free(item *it);
 bool item_size_ok(const size_t nkey, const int flags, const int nbytes);
 

--- a/memcached.c
+++ b/memcached.c
@@ -2386,7 +2386,7 @@ enum store_item_type do_store_item(item *it, int comm, conn *c, const uint32_t h
 
                 flags = (int) strtol(ITEM_suffix(old_it), (char **) NULL, 10);
 
-                new_it = do_item_alloc(key, it->nkey, flags, old_it->exptime, it->nbytes + old_it->nbytes - 2 /* CRLF */, hv);
+                new_it = do_item_alloc(key, it->nkey, flags, old_it->exptime, it->nbytes + old_it->nbytes - 2 /* CRLF */);
 
                 if (new_it == NULL) {
                     failed_alloc = 1;
@@ -3338,7 +3338,7 @@ enum delta_result_type do_add_delta(conn *c, const char *key, const size_t nkey,
         do_item_update(it);
     } else if (it->refcount > 1) {
         item *new_it;
-        new_it = do_item_alloc(ITEM_key(it), it->nkey, atoi(ITEM_suffix(it) + 1), it->exptime, res + 2, hv);
+        new_it = do_item_alloc(ITEM_key(it), it->nkey, atoi(ITEM_suffix(it) + 1), it->exptime, res + 2);
         if (new_it == 0) {
             do_item_remove(it);
             return EOM;

--- a/thread.c
+++ b/thread.c
@@ -524,7 +524,7 @@ int is_listen_thread() {
 item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbytes) {
     item *it;
     /* do_item_alloc handles its own locks */
-    it = do_item_alloc(key, nkey, flags, exptime, nbytes, 0);
+    it = do_item_alloc(key, nkey, flags, exptime, nbytes);
     return it;
 }
 


### PR DESCRIPTION
If all hash values of five tail items are zero on the specified slab
class, expire check is unintentionally skipped and items stay without
being evicted. Consequently, new item allocation consume memory space
every time an item is set, that leads to slab OOM errors.

----

## Details of the Problem

Version: 1.4.19 to 1.4.25
How reproducible: 100%

### Steps to Reproduce:

```
# set the items whose jenkins hash(ENDIAN_LITTLE) values are zero with exptime 1 sec
printf "set 0wYuLiaUdfgTZCUsz8mRR1WJVk 0 1 4\r\ndata\r\n" | nc localhost 11211
printf "set 9NxjWkBnSfD0LShqUBZAqv3jKI 0 1 4\r\ndata\r\n" | nc localhost 11211
printf "set wRL2lvUMyPnbiImZdi9CTXbsJ6 0 1 4\r\ndata\r\n" | nc localhost 11211
printf "set vOgpzFNo2pGpYLKxUWXfI6PDXq 0 1 4\r\ndata\r\n" | nc localhost 11211
printf "set aTogASrWNRQSA1uh2ySgv6HwaU 0 1 4\r\ndata\r\n" | nc localhost 11211

# wait for exptime
sleep 2

# another innocent key set
# normally, the five items expire here
printf "set innocentkey 0 1 4\r\ndata\r\n" | nc localhost 11211

echo "stats items" | nc localhost 11211
```
Actual results:
```
STORED
STORED
STORED
STORED
STORED
STORED
STAT items:1:number 6
STAT items:1:age 2
STAT items:1:evicted 0
STAT items:1:evicted_nonzero 0
STAT items:1:evicted_time 0
STAT items:1:outofmemory 0
STAT items:1:tailrepairs 0
STAT items:1:reclaimed 0
STAT items:1:expired_unfetched 0
STAT items:1:evicted_unfetched 0
STAT items:1:crawler_reclaimed 0
STAT items:1:crawler_items_checked 0
STAT items:1:lrutail_reflocked 0
END
```
Expected results:
```
STORED
STORED
STORED
STORED
STORED
STORED
STAT items:1:number 1
STAT items:1:age 0
STAT items:1:evicted 0
STAT items:1:evicted_nonzero 0
STAT items:1:evicted_time 0
STAT items:1:outofmemory 0
STAT items:1:tailrepairs 0
STAT items:1:reclaimed 5
STAT items:1:expired_unfetched 5
STAT items:1:evicted_unfetched 0
STAT items:1:crawler_reclaimed 0
STAT items:1:crawler_items_checked 0
STAT items:1:lrutail_reflocked 0
END
```
