### PR TITLE
Fix typo of pid path

### DIFF
--- a/scripts/memcached.sysv
+++ b/scripts/memcached.sysv
@@ -43,7 +43,7 @@ stop () {
     echo
     if [ $RETVAL -eq 0 ] ; then
         rm -f /var/lock/subsys/memcached
-        rm -f /var/run/memcached.pid
+        rm -f /var/run/memcached/memcached.pid
     fi
 }
 


### PR DESCRIPTION
I tried daemon stop with memcached.sysv script.
So process was stopped, but remained the PID file.
Check this commit.