### PR TITLE
fix logger.c snprintf compile error on centos 6.8

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <poll.h>


### PR DESCRIPTION
add #include <stdio.h> to fix error: implicit declaration of function ‘snprintf’