### PR TITLE
Online stats sizes and specifying exact slab class sizes

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -720,6 +720,8 @@ other stats command.
 |                   | bool     | If yes, items with 0 exptime cannot evict    |
 | idle_time         | 0        | Drop connections that are idle this many     |
 |                   |          | seconds (0 disables)                         |
+| track_sizes       | bool     | If yes, a "stats sizes" histogram is being   |
+|                   |          | dymamically tracked.                         |
 |-------------------+----------+----------------------------------------------|
 
 
@@ -793,9 +795,8 @@ future.
 
 The "stats" command with the argument of "sizes" returns information about the
 general size and count of all items stored in the cache.
-WARNING: This command WILL lock up your cache! It iterates over *every item*
-and examines the size. While the operation is fast, if you have many items
-you could prevent memcached from serving requests for several seconds.
+WARNING: In versions prior to 1.4.27 this command causes the cache server to
+lock while it iterates the items. 1.4.27 and greater are safe.
 
 The data is returned in the following format:
 
@@ -814,6 +815,36 @@ factor would save memory overhead. For example: generating more classes in the
 lower range could allow items to fit more snugly into their slab classes, if
 most of your items are less than 200 bytes in size.
 
+In 1.4.27 and after, this feature must be manually enabled.
+
+A "stats" command with the argument of "sizes_enable" will enable the
+histogram at runtime. This has a small overhead to every store or delete
+operation. If you don't want to incur this, leave it off.
+
+A "stats" command with the argument of "sizes_disable" will disable the
+histogram.
+
+It can also be enabled at starttime with "-o track_sizes"
+
+If disabled, "stats sizes" will return:
+
+STAT sizes_status disabled\r\n
+
+"stats sizes_enable" will return:
+
+STAT sizes_status enabled\r\n
+
+"stats sizes_disable" will return:
+
+STAT sizes_status disabled\r\n
+
+If an error happens, it will return:
+
+STAT sizes_status error\r\n
+STAT sizes_error [error_message]\r\n
+
+CAVEAT: If CAS support is disabled, you cannot enable/disable this feature at
+runtime.
 
 Slab statistics
 ---------------

--- a/items.c
+++ b/items.c
@@ -61,6 +61,9 @@ static item *tails[LARGEST_ID];
 static crawler crawlers[LARGEST_ID];
 static itemstats_t itemstats[LARGEST_ID];
 static unsigned int sizes[LARGEST_ID];
+static unsigned int *stats_sizes_hist = NULL;
+static rel_time_t stats_sizes_time = 0;
+static int stats_sizes_buckets = 0;
 static crawlerstats_t crawlerstats[MAX_NUMBER_OF_SLAB_CLASSES];
 
 static int crawler_count = 0;
@@ -74,6 +77,7 @@ static pthread_cond_t  lru_crawler_cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t lru_crawler_stats_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t lru_maintainer_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t cas_id_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t stats_sizes_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void item_stats_reset(void) {
     int i;
@@ -87,6 +91,9 @@ void item_stats_reset(void) {
 static int lru_pull_tail(const int orig_id, const int cur_lru,
         const unsigned int total_chunks, const bool do_evict, const uint32_t cur_hv);
 static int lru_crawler_start(uint32_t id, uint32_t remaining);
+
+static void item_stats_sizes_add(item *it);
+static void item_stats_sizes_remove(item *it);
 
 /* Get the next CAS id for a new item. */
 /* TODO: refactor some atomics for this. */
@@ -338,6 +345,7 @@ int do_item_link(item *it, const uint32_t hv) {
     assoc_insert(it, hv);
     item_link_q(it);
     refcount_incr(&it->refcount);
+    item_stats_sizes_add(it);
 
     return 1;
 }
@@ -350,6 +358,7 @@ void do_item_unlink(item *it, const uint32_t hv) {
         stats.curr_bytes -= ITEM_ntotal(it);
         stats.curr_items -= 1;
         STATS_UNLOCK();
+        item_stats_sizes_remove(it);
         assoc_delete(ITEM_key(it), it->nkey, hv);
         item_unlink_q(it);
         do_item_remove(it);
@@ -365,6 +374,7 @@ void do_item_unlink_nolock(item *it, const uint32_t hv) {
         stats.curr_bytes -= ITEM_ntotal(it);
         stats.curr_items -= 1;
         STATS_UNLOCK();
+        item_stats_sizes_remove(it);
         assoc_delete(ITEM_key(it), it->nkey, hv);
         do_item_unlink_q(it);
         do_item_remove(it);
@@ -617,6 +627,54 @@ void item_stats(ADD_STAT add_stats, void *c) {
     add_stats(NULL, 0, NULL, 0, c);
 }
 
+void item_stats_sizes_enable(ADD_STAT add_stats, void *c) {
+    mutex_lock(&stats_sizes_lock);
+    if (stats_sizes_hist == NULL) {
+        stats_sizes_buckets = settings.item_size_max / 32 + 1;
+        stats_sizes_hist = calloc(stats_sizes_buckets, sizeof(int));
+        stats_sizes_time = current_time + 1; /* would be more accurate with CAS */
+        if (stats_sizes_hist != NULL) {
+            APPEND_STAT("sizes_enabled", "ok", "");
+        } else {
+            APPEND_STAT("sizes_error", "no_memory", "");
+        }
+    } else {
+        APPEND_STAT("sizes_enabled", "ok", "");
+    }
+    mutex_unlock(&stats_sizes_lock);
+}
+
+void item_stats_sizes_disable(ADD_STAT add_stats, void *c) {
+    mutex_lock(&stats_sizes_lock);
+    if (stats_sizes_hist != NULL) {
+        free(stats_sizes_hist);
+        stats_sizes_hist = NULL;
+    }
+    APPEND_STAT("sizes_disabled", "ok", "");
+    mutex_unlock(&stats_sizes_lock);
+}
+
+static void item_stats_sizes_add(item *it) {
+    if (stats_sizes_hist == NULL || stats_sizes_time > it->time)
+        return;
+    int ntotal = ITEM_ntotal(it);
+    int bucket = ntotal / 32;
+    if ((ntotal % 32) != 0) bucket++;
+    if (bucket < stats_sizes_buckets) stats_sizes_hist[bucket]++;
+}
+
+/* I think there's no way for this to be accurate without using the CAS value.
+ * Since items getting their time value bumped will pass this validation.
+ */
+static void item_stats_sizes_remove(item *it) {
+    if (stats_sizes_hist == NULL || stats_sizes_time > it->time)
+        return;
+    int ntotal = ITEM_ntotal(it);
+    int bucket = ntotal / 32;
+    if ((ntotal % 32) != 0) bucket++;
+    if (bucket < stats_sizes_buckets) stats_sizes_hist[bucket]--;
+}
+
 /** dumps out a list of objects of each size, with granularity of 32 bytes */
 /*@null@*/
 /* Locks are correct based on a technicality. Holds LRU lock while doing the
@@ -624,39 +682,23 @@ void item_stats(ADD_STAT add_stats, void *c) {
  * which don't change.
  */
 void item_stats_sizes(ADD_STAT add_stats, void *c) {
+    mutex_lock(&stats_sizes_lock);
 
-    /* max 1MB object, divided into 32 bytes size buckets */
-    const int num_buckets = 32768;
-    unsigned int *histogram = calloc(num_buckets, sizeof(int));
-
-    if (histogram != NULL) {
+    if (stats_sizes_hist != NULL) {
         int i;
-
-        /* build the histogram */
-        for (i = 0; i < LARGEST_ID; i++) {
-            pthread_mutex_lock(&lru_locks[i]);
-            item *iter = heads[i];
-            while (iter) {
-                int ntotal = ITEM_ntotal(iter);
-                int bucket = ntotal / 32;
-                if ((ntotal % 32) != 0) bucket++;
-                if (bucket < num_buckets) histogram[bucket]++;
-                iter = iter->next;
-            }
-            pthread_mutex_unlock(&lru_locks[i]);
-        }
-
-        /* write the buffer */
-        for (i = 0; i < num_buckets; i++) {
-            if (histogram[i] != 0) {
+        for (i = 0; i < stats_sizes_buckets; i++) {
+            if (stats_sizes_hist[i] != 0) {
                 char key[8];
                 snprintf(key, sizeof(key), "%d", i * 32);
-                APPEND_STAT(key, "%u", histogram[i]);
+                APPEND_STAT(key, "%u", stats_sizes_hist[i]);
             }
         }
-        free(histogram);
+    } else {
+        APPEND_STAT("sizes_status", "disabled", "");
     }
+
     add_stats(NULL, 0, NULL, 0, c);
+    mutex_unlock(&stats_sizes_lock);
 }
 
 /** wrapper around assoc_find which does the lazy expiration logic */

--- a/items.h
+++ b/items.h
@@ -22,8 +22,12 @@ void item_stats(ADD_STAT add_stats, void *c);
 void item_stats_totals(ADD_STAT add_stats, void *c);
 /*@null@*/
 void item_stats_sizes(ADD_STAT add_stats, void *c);
+void item_stats_sizes_init(void);
 void item_stats_sizes_enable(ADD_STAT add_stats, void *c);
 void item_stats_sizes_disable(ADD_STAT add_stats, void *c);
+void item_stats_sizes_add(item *it);
+void item_stats_sizes_remove(item *it);
+bool item_stats_sizes_status(void);
 
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv, conn *c);

--- a/items.h
+++ b/items.h
@@ -22,6 +22,8 @@ void item_stats(ADD_STAT add_stats, void *c);
 void item_stats_totals(ADD_STAT add_stats, void *c);
 /*@null@*/
 void item_stats_sizes(ADD_STAT add_stats, void *c);
+void item_stats_sizes_enable(ADD_STAT add_stats, void *c);
+void item_stats_sizes_disable(ADD_STAT add_stats, void *c);
 
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv, conn *c);

--- a/memcached.c
+++ b/memcached.c
@@ -2820,6 +2820,7 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("warm_lru_pct", "%d", settings.warm_lru_pct);
     APPEND_STAT("expirezero_does_not_evict", "%s", settings.expirezero_does_not_evict ? "yes" : "no");
     APPEND_STAT("idle_timeout", "%d", settings.idle_timeout);
+    APPEND_STAT("track_sizes", "%s", item_stats_sizes_status() ? "yes" : "no");
 }
 
 static void conn_to_str(const conn *c, char *buf) {
@@ -3439,8 +3440,12 @@ enum delta_result_type do_add_delta(conn *c, const char *key, const size_t nkey,
     if (res + 2 <= it->nbytes && it->refcount == 2) { /* replace in-place */
         /* When changing the value without replacing the item, we
            need to update the CAS on the existing item. */
+        /* We also need to fiddle it in the sizes tracker in case the tracking
+         * was enabled at runtime, since it relies on the CAS value to know
+         * whether to remove an item or not. */
+        item_stats_sizes_remove(it);
         ITEM_set_cas(it, (settings.use_cas) ? get_cas_id() : 0);
-
+        item_stats_sizes_add(it);
         memcpy(ITEM_data(it), buf, res);
         memset(ITEM_data(it) + res, ' ', it->nbytes - res - 2);
         do_item_update(it);
@@ -5073,6 +5078,7 @@ static void usage(void) {
            "                (requires lru_maintainer)\n"
            "              - idle_timeout: Timeout for idle connections\n"
            "              - modern: Enables 'modern' defaults. See release notes (higly recommended!).\n"
+           "              - track_sizes: Enable dynamic reports for 'stats sizes' command.\n"
            );
     return;
 }
@@ -5364,6 +5370,7 @@ int main (int argc, char **argv) {
         NOEXP_NOEVICT,
         IDLE_TIMEOUT,
         SLAB_SIZES,
+        TRACK_SIZES,
         MODERN
     };
     char *const subopts_tokens[] = {
@@ -5382,6 +5389,7 @@ int main (int argc, char **argv) {
         [NOEXP_NOEVICT] = "expirezero_does_not_evict",
         [IDLE_TIMEOUT] = "idle_timeout",
         [SLAB_SIZES] = "slab_sizes",
+        [TRACK_SIZES] = "track_sizes",
         [MODERN] = "modern",
         NULL
     };
@@ -5760,6 +5768,9 @@ int main (int argc, char **argv) {
                 } else {
                     return 1;
                 }
+                break;
+            case TRACK_SIZES:
+                item_stats_sizes_init();
                 break;
             case MODERN:
                 /* Modernized defaults. Need to add equivalent no_* flags

--- a/slabs.c
+++ b/slabs.c
@@ -337,6 +337,10 @@ bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c) {
             slabs_stats(add_stats, c);
         } else if (nz_strcmp(nkey, stat_type, "sizes") == 0) {
             item_stats_sizes(add_stats, c);
+        } else if (nz_strcmp(nkey, stat_type, "sizes_enable") == 0) {
+            item_stats_sizes_enable(add_stats, c);
+        } else if (nz_strcmp(nkey, stat_type, "sizes_disable") == 0) {
+            item_stats_sizes_disable(add_stats, c);
         } else {
             ret = false;
         }

--- a/slabs.h
+++ b/slabs.h
@@ -8,7 +8,7 @@
     3rd argument specifies if the slab allocator should allocate all memory
     up front (if true), or allocate memory in chunks as it is needed (if false)
 */
-void slabs_init(const size_t limit, const double factor, const bool prealloc);
+void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes);
 
 
 /**


### PR DESCRIPTION
This two-parter PR is handy for folks wanting to tune their slab class sizes.

The `stats sizes` command was generally off limits as it used to hang the cache. More recently it just hangs that particular worker thread and hammers the locks.

With this update a passive system can be enabled or disabled live which will track a histogram of item sizes as they're added or removed from the cache. This allows temporarily enabling it, or simply enable and leave it running if you don't mind the overhead. The command then dumps just the pre-created histogram on demand.

`stats sizes_enable` and `stats sizes_disable` enable and disable the feature.

If your `-f` and `-n` options can be tuned to give less memory overhead, that's great. However, what if you have a cluster where items only exist at exact sizes, or the factorial is never quite close enough?

You can now specify the slab classes manually via `-o slab_sizes=100-200-300-400-500`. Which will create 5 slab classes around those sizes, plus a sixth at the max item size.

TODO:

- [x] Update documentation and -h.
- [x] Decide on requiring CAS being enabled for stats sizes to work.
- [x] Start option for enabling stats_sizes

Optional:

- [ ] Automated tests (a nice to have since they weren't here before either)