### PR TITLE
cache_memlimit command for tuning runtime maxbytes

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -614,7 +614,7 @@ integers separated by a colon (treat this as a floating point number).
 |                       |         | from network                              |
 | bytes_written         | 64u     | Total number of bytes sent by this server |
 |                       |         | to network                                |
-| limit_maxbytes        | 32u     | Number of bytes this server is allowed to |
+| limit_maxbytes        | size_t  | Number of bytes this server is allowed to |
 |                       |         | use for storage.                          |
 | accepting_conns       | bool    | Whether or not server is accepting conns  |
 | listen_disabled_num   | 64u     | Number of times server has stopped        |
@@ -948,6 +948,12 @@ The delay option allows you to have them reset in e.g. 10 second
 intervals (by passing 0 to the first, 10 to the second, 20 to the
 third, etc. etc.).
 
+"cache_memlimit" is a command with a numeric argument. This allows runtime
+adjustments of the cache memory limit. It returns "OK\r\n" or an error (unless
+"noreply" is given as the last parameter). If the new memory limit is higher
+than the old one, the server may start requesting more memory from the OS. If
+the limit is lower, and slabs_reassign+automove are enabled, free memory may
+be released back to the OS asynchronously.
 
 "version" is a command with no arguments:
 

--- a/memcached.c
+++ b/memcached.c
@@ -3601,6 +3601,31 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
     }
 }
 
+static void process_memlimit_command(conn *c, token_t *tokens, const size_t ntokens) {
+    uint32_t memlimit;
+    assert(c != NULL);
+
+    set_noreply_maybe(c, tokens, ntokens);
+
+    if (!safe_strtoul(tokens[1].value, &memlimit)) {
+        out_string(c, "ERROR");
+    } else {
+        if (memlimit < 8) {
+            out_string(c, "MEMLIMIT_TOO_SMALL cannot set maxbytes to less than 8m");
+        } else {
+            if (slabs_adjust_mem_limit(memlimit * 1024 * 1024)) {
+                if (settings.verbose > 0) {
+                    fprintf(stderr, "maxbytes adjusted to %llum\n", (unsigned long long)memlimit);
+                }
+
+                out_string(c, "OK");
+            } else {
+                out_string(c, "MEMLIMIT_ADJUST_FAILED out of bounds or unable to adjust");
+            }
+        }
+    }
+}
+
 static void process_command(conn *c, char *command) {
 
     token_t tokens[MAX_TOKENS];
@@ -3844,6 +3869,8 @@ static void process_command(conn *c, char *command) {
         }
     } else if (ntokens > 1 && strcmp(tokens[COMMAND_TOKEN].value, "watch") == 0) {
         process_watch_command(c, tokens, ntokens);
+    } else if ((ntokens == 3 || ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "cache_memlimit") == 0)) {
+        process_memlimit_command(c, tokens, ntokens);
     } else if ((ntokens == 3 || ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "verbosity") == 0)) {
         process_verbosity_command(c, tokens, ntokens);
     } else {

--- a/slabs.h
+++ b/slabs.h
@@ -28,6 +28,9 @@ void slabs_free(void *ptr, size_t size, unsigned int id);
 /** Adjust the stats for memory requested */
 void slabs_adjust_mem_requested(unsigned int id, size_t old, size_t ntotal);
 
+/** Adjust global memory limit up or down */
+bool slabs_adjust_mem_limit(size_t new_mem_limit);
+
 /** Return a datum for stats in binary protocol */
 bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 

--- a/t/dyn-maxbytes.t
+++ b/t/dyn-maxbytes.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+# Test the 'stats items' evictions counters.
+
+use strict;
+use Test::More tests => 309;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached("-m 3 -o modern");
+my $sock = $server->sock;
+my $value = "B"x66560;
+my $key = 0;
+
+# These aren't set to expire.
+for ($key = 0; $key < 40; $key++) {
+    print $sock "set key$key 0 0 66560\r\n$value\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored key$key");
+}
+
+my $stats  = mem_stats($sock, "items");
+my $evicted = $stats->{"items:31:evicted"};
+isnt($evicted, "0", "check evicted");
+
+# We're past the memory limit. Try adjusting maxbytes upward.
+$stats = mem_stats($sock, "settings");
+my $pre_maxbytes = $stats->{"maxbytes"};
+print $sock "cache_memlimit 8\r\n";
+is(scalar <$sock>, "OK\r\n", "bumped maxbytes from 3m to 8m");
+
+# Confirm maxbytes updated.
+$stats = mem_stats($sock, "settings");
+isnt($stats->{"maxbytes"}, $pre_maxbytes, "stats settings maxbytes updated");
+
+# Check for total_malloced increasing as new memory is added
+$stats = mem_stats($sock, "slabs");
+my $t_malloc = $stats->{"total_malloced"};
+
+print $sock "set toast 0 0 66560\r\n$value\r\n";
+is(scalar <$sock>, "STORED\r\n", "stored toast");
+$stats = mem_stats($sock, "slabs");
+cmp_ok($stats->{"total_malloced"}, '>', $t_malloc, "stats slabs total_malloced increased");
+
+$stats = mem_stats($sock, "items");
+my $new_evicted = $stats->{"items:31:evicted"};
+cmp_ok($new_evicted, '==', $evicted, "no new evictions");
+
+# Bump up to 16, fill a bit more, then delete everything.
+print $sock "cache_memlimit 16\r\n";
+is(scalar <$sock>, "OK\r\n", "bumped maxbytes from 8m to 16m");
+for (;$key < 150; $key++) {
+    print $sock "set key$key 0 0 66560\r\n$value\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored key$key");
+}
+
+# Grab total_malloced after filling everything up.
+$stats = mem_stats($sock, "slabs");
+$t_malloc = $stats->{"total_malloced"};
+print $sock "cache_memlimit 8\r\n";
+is(scalar <$sock>, "OK\r\n", "bumped maxbytes from 16m to 8m");
+
+# Remove all of the keys, allowing the slab rebalancer to push pages toward
+# the global page pool.
+for ($key = 0; $key < 150; $key++) {
+    print $sock "delete key$key\r\n";
+    like(scalar <$sock>, qr/(DELETED|NOT_FOUND)\r\n/, "deleted key$key");
+}
+
+# If memory limit is lower, it should free those pages back to the OS.
+my $reduced = 0;
+for (my $tries = 0; $tries < 6; $tries++) {
+    sleep 1;
+    $stats = mem_stats($sock, "slabs");
+    $reduced = $stats->{"total_malloced"} if ($t_malloc > $stats->{"total_malloced"});
+    last if $reduced;
+}
+
+isnt($reduced, 0, "total_malloced reduced to $reduced");


### PR DESCRIPTION
Allows dynamically increasing the memory limit of a running system, if memory
isn't being preallocated.

`cache_memlimit N` where N is a value in megabytes. Value can go up or down.

If `-o modern` is in use, can also dynamically lower memory usage. pages are
free()'ed back to the OS via the slab rebalancer as memory is freed up. Does
not guarantee the OS will actually give the memory back for other applications
to use, that depends on how the OS handles memory.