### PR TITLE
Fix undefined behavior in vlen check

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3234,11 +3234,11 @@ static void process_update_command(conn *c, token_t *tokens, const size_t ntoken
         }
     }
 
-    vlen += 2;
-    if (vlen < 0 || vlen - 2 < 0) {
+    if (vlen < 0 || vlen > (INT_MAX - 2)) {
         out_string(c, "CLIENT_ERROR bad command line format");
         return;
     }
+    vlen += 2;
 
     if (settings.detail_enabled) {
         stats_prefix_record_set(key, nkey);


### PR DESCRIPTION
The size check for vlen in process_get_command was relying on
undefined behavior (signed integer overflow) to check to see
if vlen was greater than 2^31-2. This made certain compilers
optimize out part of the conditional and prevent memcache from
erroring when the specified size was exactly 2^31-1, leading to
an incorrect error message and a core dump. This patch does that
overflow test in a not-undefined-behavior way.