### PR TITLE
Logging refactor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -535,6 +535,19 @@ AC_TRY_LINK([],[
   AC_DEFINE(HAVE_GCC_ATOMICS, 1, [GCC Atomics available])])
 AC_MSG_RESULT($have_gcc_atomics)
 
+dnl Check for usage of 64bit atomics
+dnl 32bit systems shouldn't have these.
+have_gcc_64atomics=no
+AC_MSG_CHECKING(for GCC 64bit atomics)
+AC_TRY_LINK([],[
+  uint64_t a;
+  uint64_t b;
+  b = __sync_add_and_fetch(&a, 1);
+  b = __sync_sub_and_fetch(&a, 2);
+  ],[have_gcc_64atomics=yes
+  AC_DEFINE(HAVE_GCC_64ATOMICS, 1, [GCC 64bit Atomics available])])
+AC_MSG_RESULT($have_gcc_64atomics)
+
 dnl Check for the requirements for running memcached with less privileges
 dnl than the default privilege set. On Solaris we need setppriv and priv.h
 dnl If you want to add support for other platforms you should check for

--- a/logger.c
+++ b/logger.c
@@ -30,7 +30,7 @@ pthread_mutex_t logger_stack_lock = PTHREAD_MUTEX_INITIALIZER;
 
 pthread_key_t logger_key;
 
-#if !defined(HAVE_GCC_ATOMICS) && !defined(__sun)
+#if !defined(HAVE_GCC_64ATOMICS) && !defined(__sun)
 pthread_mutex_t logger_atomics_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
@@ -93,7 +93,7 @@ static bool logger_uriencode(const char *src, char *dst, const size_t srclen, co
  */
 static uint64_t logger_get_gid(void) {
     static uint64_t logger_gid = 0;
-#ifdef HAVE_GCC_ATOMICS
+#ifdef HAVE_GCC_64ATOMICS
     return __sync_add_and_fetch(&logger_gid, 1);
 #elif defined(__sun)
     return atomic_inc_64_nv(&logger_gid);

--- a/t/watcher.t
+++ b/t/watcher.t
@@ -34,8 +34,15 @@ for (1 .. 80000) {
 
 # Let the logger thread catch up before we start reading.
 sleep 1;
+my $do_fetch = 0;
 #print STDERR "RESULT: $res\n";
 while (my $log = <$watcher>) {
+    # The "skipped" line won't actually print until some space frees up in the
+    # buffer, so we need to occasionally cause new lines to generate.
+    if (($do_fetch++ % 100) == 0) {
+         print $client "get foo\n";
+         $res = <$client>;
+    }
     next unless $log =~ m/skipped/;
     like($log, qr/skipped=/, "skipped some lines");
     # This should unjam more of the text.


### PR DESCRIPTION
In a rush to finish 1.4.26 logging_parse_entry grew out of shape. This smooths out the logic and splits the function up in a much better way.

This is just about ready for the conversion of all the settings.verbose endpoints.