### PR TITLE
Update memcached.c to allow stats cachedump on slab 63

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -2960,7 +2960,7 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
             return;
         }
 
-        if (id >= MAX_NUMBER_OF_SLAB_CLASSES-1) {
+        if (id >= MAX_NUMBER_OF_SLAB_CLASSES) {
             out_string(c, "CLIENT_ERROR Illegal slab id");
             return;
         }


### PR DESCRIPTION
It's returning an error when we try to cachedump the slab 63