### PR TITLE
Chunked (large) item support

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1364,14 +1364,19 @@ static void complete_update_bin(conn *c) {
     } else {
         assert(c->ritem);
         item_chunk *ch = (item_chunk *) c->ritem;
+        if (ch->size == ch->used)
+            ch = ch->next;
         //fprintf(stderr, "BINPROT: WRITING DELIMITER INTO CHUNK TAIL\n");
-        if (ch->used > 1) {
-            ch->data[ch->used - 2] = '\r';
-            ch->data[ch->used - 1] = '\n';
+        if (ch->size - ch->used > 1) {
+            ch->data[ch->used + 1] = '\r';
+            ch->data[ch->used + 2] = '\n';
+            ch->used += 2;
         } else {
-            assert(ch->used == 1);
-            ch->prev->data[ch->prev->used - 1] = '\r';
-            ch->data[ch->used - 1] = '\n';
+            ch->data[ch->used + 1] = '\r';
+            ch->next->data[0] = '\n';
+            ch->used++;
+            ch->next->used++;
+            assert(ch->size == ch->used);
         }
     }
 

--- a/memcached.c
+++ b/memcached.c
@@ -1868,7 +1868,8 @@ static void process_bin_sasl_auth(conn *c) {
 
     item *it = item_alloc(key, nkey, 0, 0, vlen);
 
-    if (it == 0) {
+    /* Can't use a chunked item for SASL authentication. */
+    if (it == 0 || (it->it_flags & ITEM_CHUNKED)) {
         write_bin_error(c, PROTOCOL_BINARY_RESPONSE_ENOMEM, NULL, vlen);
         c->write_and_go = conn_swallow;
         return;

--- a/memcached.h
+++ b/memcached.h
@@ -444,6 +444,7 @@ typedef struct _strchunk {
     unsigned short   refcount;  /* used? */
     uint8_t          nsuffix;   /* unused */
     uint8_t          it_flags;  /* ITEM_* above. */
+    uint8_t          slabs_clsid; /* Same as above. */
     char data[];
 } item_chunk;
 

--- a/memcached.h
+++ b/memcached.h
@@ -287,6 +287,7 @@ struct stats {
     uint64_t      slab_reassign_rescues; /* items rescued during slab move */
     uint64_t      slab_reassign_evictions_nomem; /* valid items lost during slab move */
     uint64_t      slab_reassign_inline_reclaim; /* valid items lost during slab move */
+    uint64_t      slab_reassign_chunk_rescues; /* chunked-item chunks recovered */
     uint64_t      slab_reassign_busy_items; /* valid temporarily unmovable */
     uint64_t      lru_crawler_starts; /* Number of item crawlers kicked off */
     uint64_t      lru_maintainer_juggles; /* number of LRU bg pokes */
@@ -578,6 +579,7 @@ struct slab_rebalance {
     uint32_t rescues;
     uint32_t evictions_nomem;
     uint32_t inline_reclaim;
+    uint32_t chunk_rescues;
     uint8_t done;
 };
 

--- a/slabs.c
+++ b/slabs.c
@@ -254,7 +254,7 @@ static void *do_slabs_alloc_chunked(const size_t size, slabclass_t *p, unsigned 
     unsigned int chunks_req = size / csize;
     if (size % csize != 0)
         chunks_req++;
-    fprintf(stderr, "LARGE ITEM [%lu] CHUNKS REQUESTED [%d]\n", size, chunks_req);
+    //fprintf(stderr, "LARGE ITEM [%lu] CHUNKS REQUESTED [%d]\n", size, chunks_req);
     while (p->sl_curr < chunks_req) {
         if (do_slabs_newslab(id) == 0)
             break;
@@ -370,7 +370,7 @@ static void do_slabs_free_chunked(item *it, const size_t size, unsigned int id,
     unsigned int chunks_req = realsize / p->size;
     if (realsize % p->size != 0)
         chunks_req++;
-    fprintf(stderr, "FREEING CHUNKED ITEM INTO SLABS: SIZE: [%lu] REALSIZE: [%lu] CHUNKS_REQ: [%d]\n", size, realsize, chunks_req);
+    //fprintf(stderr, "FREEING CHUNKED ITEM INTO SLABS: SIZE: [%lu] REALSIZE: [%lu] CHUNKS_REQ: [%d]\n", size, realsize, chunks_req);
 
     it->it_flags = ITEM_SLABBED;
     it->slabs_clsid = 0;

--- a/slabs.h
+++ b/slabs.h
@@ -20,7 +20,7 @@ unsigned int slabs_clsid(const size_t size);
 
 /** Allocate object of given length. 0 on error */ /*@null@*/
 #define SLABS_ALLOC_NO_NEWPAGE 1
-void *slabs_alloc(const size_t size, unsigned int id, unsigned int *total_chunks, unsigned int flags);
+void *slabs_alloc(const size_t size, unsigned int id, uint64_t *total_bytes, unsigned int flags);
 
 /** Free previously allocated object */
 void slabs_free(void *ptr, size_t size, unsigned int id);
@@ -38,7 +38,7 @@ bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 void slabs_stats(ADD_STAT add_stats, void *c);
 
 /* Hints as to freespace in slab class */
-unsigned int slabs_available_chunks(unsigned int id, bool *mem_flag, unsigned int *total_chunks, unsigned int *chunks_perslab);
+unsigned int slabs_available_chunks(unsigned int id, bool *mem_flag, uint64_t *total_bytes, unsigned int *chunks_perslab);
 
 int start_slab_maintenance_thread(void);
 void stop_slab_maintenance_thread(void);

--- a/t/binary.t
+++ b/t/binary.t
@@ -121,7 +121,7 @@ $empty->('x');
 $empty->('y');
 
 {
-    # diag "Same chunked item tests";
+    # diag "Some chunked item tests";
     my $s2 = new_memcached('-o slab_chunk_max=4096');
     ok($s2, "started the server");
     my $m2 = MC::Client->new($s2);

--- a/t/binary.t
+++ b/t/binary.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3735;
+use Test::More tests => 4942;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -119,6 +119,23 @@ $set->('y', 5, 17, "somevaluey");
 $mc->flush;
 $empty->('x');
 $empty->('y');
+
+{
+    # diag "Same chunked item tests";
+    my $s2 = new_memcached('-o slab_chunk_max=4096');
+    ok($s2, "started the server");
+    my $m2 = MC::Client->new($s2);
+    # Specifically trying to cross the chunk boundary when internally
+    # appending CLRF.
+    for my $k (7900..8100) {
+        my $val = 'd' x $k;
+        $val .= '123';
+        $m2->set('t', $val, 0, 0);
+        # Ensure we get back the same value. Bugs can chop chars.
+        my (undef, $gval, undef) = $m2->get('t');
+        ok($gval eq $val, $gval . " = " . $val);
+    }
+}
 
 {
     # diag "Add";

--- a/t/chunked-items.t
+++ b/t/chunked-items.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+# Networked logging tests.
+
+use strict;
+use warnings;
+
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached('-m 48');
+my $sock = $server->sock;
+
+# We're testing to ensure item chaining doesn't corrupt or poorly overlap
+# data, so create a non-repeating pattern.
+my @parts = ();
+for (1 .. 4000) {
+    push(@parts, $_);
+}
+my $pattern = join(':', @parts);
+
+my $plen = length($pattern);
+print STDERR "PATTERN LENGTH: $plen\n";
+
+print $sock "set pattern 0 0 $plen\r\n$pattern\r\n";
+is(scalar <$sock>, "STORED\r\n", "stored pattern successfully");
+
+mem_get_is($sock, "pattern", $pattern);
+
+for (1..5) {
+    my $size = 400 * 1024;
+    my $data = "x" x $size;
+    print $sock "set foo$_ 0 0 $size\r\n$data\r\n";
+    my $res = <$sock>;
+    is($res, "STORED\r\n", "stored some big items");
+}
+
+{
+    my $max = 1024 * 1024;
+    my $big = "a big value that's > .5M and < 1M. ";
+    while (length($big) * 2 < $max) {
+        $big = $big . $big;
+    }
+    my $biglen = length($big);
+
+    for (1..100) {
+        print $sock "set toast$_ 0 0 $biglen\r\n$big\r\n";
+        is(scalar <$sock>, "STORED\r\n", "stored big");
+        mem_get_is($sock, "toast$_", $big);
+    }
+}
+
+done_testing();

--- a/t/item_size_max.t
+++ b/t/item_size_max.t
@@ -27,25 +27,25 @@ eval {
 ok($@ && $@ =~ m/^Failed/, "Shouldn't start with > 128m item max");
 
 # Minimum.
-$server = new_memcached('-I 1024');
+$server = new_memcached('-I 1024 -o slab_chunk_max=1024');
 my $stats = mem_stats($server->sock, ' settings');
 is($stats->{item_size_max}, 1024);
 $server->stop();
 
 # Reasonable but unreasonable.
-$server = new_memcached('-I 1049600');
+$server = new_memcached('-I 2097152');
 my $stats = mem_stats($server->sock, ' settings');
-is($stats->{item_size_max}, 1049600);
+is($stats->{item_size_max}, 2097152);
 $server->stop();
 
 # Suffix kilobytes.
-$server = new_memcached('-I 512k');
+$server = new_memcached('-I 512k -o slab_chunk_max=16384');
 my $stats = mem_stats($server->sock, ' settings');
 is($stats->{item_size_max}, 524288);
 $server->stop();
 
 # Suffix megabytes.
-$server = new_memcached('-I 32m');
+$server = new_memcached('-m 256 -I 32m');
 my $stats = mem_stats($server->sock, ' settings');
 is($stats->{item_size_max}, 33554432);
 $server->stop();

--- a/t/slabs-reassign-chunked.t
+++ b/t/slabs-reassign-chunked.t
@@ -1,0 +1,129 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 8;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached('-m 60 -o slab_reassign,slab_automove,lru_crawler,lru_maintainer,slab_chunk_max=4096');
+my $sock = $server->sock;
+
+sub dump_stats {
+    my $s = shift;
+    my $filter = shift || '';
+    for my $k (sort keys %$s) {
+        if ($filter) {
+            next unless $k =~ m/$filter/;
+        }
+        print STDERR "STAT: $k = ", $s->{$k}, "\n";
+    }
+}
+
+my $value;
+{
+    my @chars = ("C".."Z");
+    for (1 .. 11000) {
+        $value .= $chars[rand @chars];
+    }
+}
+my $keycount = 5100;
+
+my $res;
+for (1 .. $keycount) {
+#    print STDERR "HI $_\n";
+    print $sock "set nfoo$_ 0 0 11000 noreply\r\n$value\r\n";
+#    print $sock "set nfoo$_ 0 0 11000\r\n$value\r\n";
+#    my $res = scalar <$sock>;
+#    print STDERR "RES: $res\n";
+}
+
+my $todelete = 0;
+{
+    my $stats = mem_stats($sock);
+    cmp_ok($stats->{curr_items}, '>', 4000, "stored at least 4000 11k items");
+    $todelete = $stats->{curr_items} / 2;
+#    for ('evictions', 'reclaimed', 'curr_items', 'cmd_set', 'bytes') {
+#        print STDERR "$_: ", $stats->{$_}, "\n";
+#    }
+}
+
+for (my $x = 0; $x < 3; $x++) {
+    print $sock "slabs reassign 17 0\r\n";
+    my $res = scalar <$sock>;
+    chomp $res;
+#    print STDERR "SLABS REASSIGN RESULT: $res\n";
+    sleep 1;
+}
+
+# Make room in old class so rescues can happen when we switch slab classes.
+#for (1 .. $todelete) {
+#    print $sock "delete nfoo$_ noreply\r\n";
+#}
+
+# Give  LRU mover some time to reclaim slab chunks.
+#sleep 1;
+
+{
+    my $stats = mem_stats($sock);
+    cmp_ok($stats->{slab_global_page_pool}, '>', 0, 'global page pool > 0');
+    cmp_ok($stats->{slab_reassign_chunk_rescues}, '>', 0, 'some chunk rescues happened');
+}
+
+{
+    my $hits = 0;
+    for (1 .. $keycount) {
+        print $sock "get nfoo$_\r\n";
+        my $body = scalar(<$sock>);
+        my $expected = "VALUE nfoo$_ 0 11000\r\n$value\r\nEND\r\n";
+        if ($body =~ /^END/) {
+            next;
+        } else {
+            $body .= scalar(<$sock>) . scalar(<$sock>);
+            if ($body ne $expected) {
+                die "Something terrible has happened: $expected\nBODY:\n$body\nDONETEST\n";
+            }
+            $hits++;
+        }
+    }
+    cmp_ok($hits, '>', 0, "fetched back $hits values after reassignment");
+}
+
+$value = "A"x3000;
+for (1 .. $keycount) {
+    print $sock "set ifoo$_ 0 0 3000 noreply\r\n$value\r\n";
+}
+
+my $missing = 0;
+my $hits = 0;
+for (1 .. $keycount) {
+    print $sock "get ifoo$_\r\n";
+    my $body = scalar(<$sock>);
+    my $expected = "VALUE ifoo$_ 0 3000\r\n$value\r\nEND\r\n";
+    if ($body =~ /^END/) {
+        $missing++;
+    } else {
+        $body .= scalar(<$sock>) . scalar(<$sock>);
+        if ($body ne $expected) {
+            print STDERR "Something terrible has happened: $expected\nBODY:\n$body\nDONETEST\n";
+        } else {
+            $hits++;
+        }
+    }
+}
+#print STDERR "HITS: $hits, MISSES: $missing\n";
+
+{
+    my $stats = mem_stats($sock);
+    cmp_ok($stats->{evictions}, '<', 2000, 'evictions were less than 2000');
+#    for ('evictions', 'reclaimed', 'curr_items', 'cmd_set', 'bytes') {
+#        print STDERR "$_: ", $stats->{$_}, "\n";
+#    }
+}
+
+cmp_ok($hits, '>', 4000, 'were able to fetch back 2/3rds of 8k keys');
+my $stats_done = mem_stats($sock);
+cmp_ok($stats_done->{slab_reassign_rescues}, '>', 0, 'some reassign rescues happened');
+cmp_ok($stats_done->{slab_reassign_evictions_nomem}, '>', 0, 'some reassign evictions happened');
+

--- a/t/slabs-reassign-chunked.t
+++ b/t/slabs-reassign-chunked.t
@@ -49,12 +49,21 @@ my $todelete = 0;
 #    }
 }
 
-for (my $x = 0; $x < 3; $x++) {
-    print $sock "slabs reassign 17 0\r\n";
-    my $res = scalar <$sock>;
-    chomp $res;
-#    print STDERR "SLABS REASSIGN RESULT: $res\n";
-    sleep 1;
+{
+    my $s = mem_stats($sock, 'slabs');
+    my $sid;
+    # Find the highest ID to source from.
+    for my $k (keys %$s) {
+        next unless $k =~ m/^(\d+):/;
+        $sid = $s->{$k} if $s->{$k} > $1;
+    }
+    for (my $x = 0; $x < 3; $x++) {
+        print $sock "slabs reassign 17 0\r\n";
+        my $res = scalar <$sock>;
+        chomp $res;
+    #    print STDERR "SLABS REASSIGN RESULT: $res\n";
+        sleep 1;
+    }
 }
 
 # Make room in old class so rescues can happen when we switch slab classes.


### PR DESCRIPTION
Work in progress PR for chunked item support. As of writing this is largely functional, but is incomplete and may need a refactor.

---
 * What is large item support?

Items have always required a single chunk large enough to hold its header, key, and data. This is done via a slab allocator, which is split into many sized slabs. The "largest available slab", became the largest item you could store into memcached. This is where the 1 megabyte limit came in.

The larger the item size limit, the less efficient the slab allocator is, as there is more space between slab classes.

With this change, the max slab chunk size is decoupled from the max item size, and items larger than the max chunk size now consist of multiple chunks chained together.

This has a number of benefits:
 * Performance is nearly identical, as larger items will fill bandwidth much earlier than small items.
 * The max slab class size can be much smaller (I've been settling toward 16k after testing), down from 1mb. This means the rest of the slab classes can be closer together.
 * Since larger items use data at a much smaller granularity (ie 16k), they have less memory overhead than before.
 * The item size max can be hundreds of megabytes without any major impact.

There are some downsides:
 * It complicates the slab allocator a bit and adds a few extra code paths in reading/writing items.
 * Freeing a single item no longer guarantees enough memory to store a new single item. Pulling chunked items to free will need some careful tuning. This may not be awful considering very small items will continue to be 1:1, and the number of loops necessary to free memory for large items is reasonable given the bandwidth required to store them.

---
 * The current status

This largely works. It's been bench tested but not torture tested. Some tests have been written and I've fiddled with it manually for a while. There's a decent amount of code left to write, and I feel like it might need a little rewriting or simplification. This implementation is making the deep slab allocator more aware of how items are structured which feels like a layer violation: items.c should instead ask the slab allocator for a specific number of chunks, but then we might have to loop through them twice, or pass a callback function into the slab allocator to initialize the chunks. Moving more of the implementation up to the item layer would allow it to more intelligently garbage collect when freeing up chunks for a new chunked item as well.

Could use some feedback on any obvious bugs I've left in.

Work remaining:

- [x] Write more tests (+ fix more existing tests + tests for 00-startup.t)
- [x] Protect binary sasl auth from getting a chunked item
- [x] Implement chunked-aware append/prepend commands
- [x] Implement chunked-aware slab page mover. This is also complicated.
- [x] Run burn-in test
- [x] Clean out debug code

Punting or doing later:

- [ ] Test using readv to reduce number of read() syscalls on store.

~~Run burn-in tests on very large items (hundreds of megabytes)~~
~~Any useful stats that could be added? Something to indicate how many large items have been seen, at least.~~