### PR TITLE
Add missing parameters and escape hypens as minus

### DIFF
--- a/doc/memcached.1
+++ b/doc/memcached.1
@@ -23,6 +23,9 @@ is included below.
 .B \-s <file>
 Unix socket path to listen on (disables network support).
 .TP
+.B \-A
+Enable ascii "shutdown" command.
+.TP
 .B \-a <perms>
 Permissions (in octal format) for Unix socket created with \-s option.
 .TP
@@ -98,6 +101,9 @@ Be verbose during the event loop; print out errors and warnings.
 Be even more verbose; same as \-v but also print client commands and
 responses.
 .TP
+.B \-vvv
+Be extremely verbose; same of the above and also print internal state transitions.
+.TP
 .B \-i
 Print memcached and libevent licenses.
 .TP
@@ -108,7 +114,8 @@ Print pidfile to <filename>, only used under \-d option.
 Number of threads to use to process incoming requests. This option is only
 meaningful if memcached was compiled with thread support enabled. It is
 typically not useful to set this higher than the number of CPU cores on the
-memcached server. The default is 4.
+memcached server. Setting a high number (64 or more) of worker
+threads is not recommended. The default is 4.
 .TP
 .B \-D <char>
 Use <char> as the delimiter between key prefixes and IDs. This is used for
@@ -135,7 +142,7 @@ specify the protocol clients must speak.  Possible options are "auto"
 Override the default size of each slab page. The default size is 1mb. Default
 value for this parameter is 1m, minimum is 1k, max is 128m.
 Adjusting this value changes the item size limit.
-Beware that this also increases the number of slabs (use -v to view), and the
+Beware that this also increases the number of slabs (use \-v to view), and the
 overal memory usage of memcached.
 .TP
 .B \-S
@@ -147,8 +154,11 @@ Disables the "flush_all" command. The cmd_flush counter will increment, but
 clients will receive an error message and the flush will not occur.
 .TP
 .B \-o <options>
-Comma separated list of extended or experimental options. See -h or wiki for
+Comma separated list of extended or experimental options. See \-h or wiki for
 up to date list.
+.TP
+.B \-V
+print version and exit
 .br
 .SH LICENSE
 The memcached daemon is copyright Danga Interactive and is distributed under


### PR DESCRIPTION
* -A, -vvv and -V were missing
* Precision on -t
* Escape hyphen as minus (old versions of groff)