### PR TITLE
Add MemoryDenyWriteExecute to the systemd service

### DIFF
--- a/scripts/memcached.service
+++ b/scripts/memcached.service
@@ -34,5 +34,9 @@ PrivateDevices=true
 # Required for dropping privileges and running as a different user
 CapabilityBoundingSet=CAP_SETGID CAP_SETUID
 
+# Attempts to create memory mappings that are writable and executable at the same time,
+# or to change existing memory mappings to become executable are prohibited.
+MemoryDenyWriteExecute=true
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
MemoryDenyWriteExecute=true will prevent attempts to create memory mappings that are both writable and executable at the same time. This option improves service security, as it makes harder for software exploits to change running code dynamically.

This option was added in systemd 231. Since systemd ignores unknown options, it will have no effect on (but will also cause no problems for) users of systemd < 231.