### PR TITLE
Inaccurate binary protocol examples for getk/getkq, flush

### DIFF
--- a/doc/protocol-binary.xml
+++ b/doc/protocol-binary.xml
@@ -1199,6 +1199,8 @@ Total body   (8-11) : 0x00000000
 Opaque       (12-15): 0x00000000
 CAS          (16-23): 0x0000000000000000
 Extras              : None
+Key                 : None
+Value               : None
             </artwork>
           </figure>
           <figure>
@@ -1402,7 +1404,7 @@ Status       (6,7)  : 0x0000
 Total body   (8-11) : 0x00000007
 Opaque       (12-15): 0x00000000
 CAS          (16-23): 0x0000000000000000
-Exstras             : None
+Extras              : None
 Key                 : The textual string "pid"
 Value               : The textual string "3078"
             </artwork>

--- a/doc/protocol-binary.xml
+++ b/doc/protocol-binary.xml
@@ -1083,7 +1083,7 @@ Total body   (8-11) : 0x00000004
 Opaque       (12-15): 0x00000000
 CAS          (16-23): 0x0000000000000000
 Extras              :
-   Expiry    (24-27): 0x000e10
+   Expiry    (24-27): 0x00000e10
 Key                 : None
 Value               : None
           </artwork>

--- a/doc/protocol-binary.xml
+++ b/doc/protocol-binary.xml
@@ -537,7 +537,7 @@ Key length   (2,3)  : 0x0005
 Extra length (4)    : 0x04
 Data type    (5)    : 0x00
 Status       (6,7)  : 0x0000
-Total body   (8-11) : 0x00000009
+Total body   (8-11) : 0x0000000a
 Opaque       (12-15): 0x00000000
 CAS          (16-23): 0x0000000000000001
 Extras              :


### PR DESCRIPTION
I have been going through the binary protocol document to implement it in rust, and I identified a few inaccuracies in the example packets provided.
- The length of the body for the example getk/getkq response should be 14 (4 + 5 + 5) bytes long.
- The length of the expirey provided in the flush request is three bytes not four. 

I also noticed a few slight typos/inconsistencies in formatting.

It seems that Github doesn't support making PRs for wiki entries, but these should be updated at https://github.com/memcached/memcached/wiki/BinaryProtocolRevamped as well.
