### PR TITLE
printf format string fix for long long time_t

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,10 @@ if BUILD_SOLARIS_PRIVS
 memcached_SOURCES += solaris_priv.c
 endif
 
+if BUILD_OPENBSD_PRIVS
+memcached_SOURCES += openbsd_priv.c
+endif
+
 if ENABLE_SASL
 memcached_SOURCES += sasl_defs.c
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -564,6 +564,16 @@ AC_CHECK_FUNCS(setppriv, [
 
 AM_CONDITIONAL([BUILD_SOLARIS_PRIVS],[test "$build_solaris_privs" = "yes"])
 
+AC_CHECK_FUNCS(pledge, [
+   AC_CHECK_HEADER(unistd.h, [
+      AC_DEFINE([HAVE_DROP_PRIVILEGES], 1,
+         [Define this if you have an implementation of drop_privileges()])
+      build_openbsd_privs=yes
+   ], [])
+],[])
+
+AM_CONDITIONAL([BUILD_OPENBSD_PRIVS],[test "$build_openbsd_privs" = "yes"])
+
 AC_CHECK_HEADER(umem.h, [
    AC_DEFINE([HAVE_UMEM_H], 1,
          [Define this if you have umem.h])

--- a/items.c
+++ b/items.c
@@ -484,10 +484,10 @@ char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, u
         /* Copy the key since it may not be null-terminated in the struct */
         strncpy(key_temp, ITEM_key(it), it->nkey);
         key_temp[it->nkey] = 0x00; /* terminate */
-        len = snprintf(temp, sizeof(temp), "ITEM %s [%d b; %lu s]\r\n",
+        len = snprintf(temp, sizeof(temp), "ITEM %s [%d b; %llu s]\r\n",
                        key_temp, it->nbytes - 2,
                        it->exptime == 0 ? 0 :
-                       (unsigned long)it->exptime + process_started);
+                       (unsigned long long)it->exptime + process_started);
         if (bufcurr + len + 6 > memlimit)  /* 6 is END\r\n\0 */
             break;
         memcpy(buffer + bufcurr, temp, len);

--- a/items.c
+++ b/items.c
@@ -484,10 +484,10 @@ char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, u
         /* Copy the key since it may not be null-terminated in the struct */
         strncpy(key_temp, ITEM_key(it), it->nkey);
         key_temp[it->nkey] = 0x00; /* terminate */
-        len = snprintf(temp, sizeof(temp), "ITEM %s [%d b; %llu s]\r\n",
+        len = snprintf(temp, sizeof(temp), "ITEM %s [%d b; %lu s]\r\n",
                        key_temp, it->nbytes - 2,
                        it->exptime == 0 ? 0 :
-                       (unsigned long long)it->exptime + process_started);
+                       (unsigned long)it->exptime + process_started);
         if (bufcurr + len + 6 > memlimit)  /* 6 is END\r\n\0 */
             break;
         memcpy(buffer + bufcurr, temp, len);

--- a/memcached.c
+++ b/memcached.c
@@ -6414,7 +6414,7 @@ int main (int argc, char **argv) {
     }
 
     /* Drop privileges no longer needed */
-    drop_privileges();
+    drop_privileges(pid_file);
 
     /* Initialize the uriencode lookup table. */
     uriencode_init();

--- a/memcached.h
+++ b/memcached.h
@@ -663,7 +663,7 @@ void append_stat(const char *name, ADD_STAT add_stats, conn *c,
 enum store_item_type store_item(item *item, int comm, conn *c);
 
 #if HAVE_DROP_PRIVILEGES
-extern void drop_privileges(void);
+extern void drop_privileges(const char *pid_file);
 #else
 #define drop_privileges()
 #endif

--- a/openbsd_priv.c
+++ b/openbsd_priv.c
@@ -1,0 +1,42 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "memcached.h"
+
+/*
+ * this section of code will drop all (OpenBSD) privileges including
+ * those normally granted to all userland process (basic privileges). The
+ * effect of this is that after running this code, the process will not able
+ * to fork(), exec(), etc.  See pledge(2) for more information.
+ */
+void drop_privileges(const char *pid_file) {
+    extern char *__progname;
+
+    if (settings.socketpath != NULL) {
+        if (pid_file != NULL) {
+           if (pledge("stdio cpath unix", NULL) == -1) {
+              fprintf(stderr, "%s: pledge: %s\n", __progname, strerror(errno));
+              exit(EXIT_FAILURE);
+           }
+        } else {
+           if (pledge("stdio unix", NULL) == -1) {
+              fprintf(stderr, "%s: pledge: %s\n", __progname, strerror(errno));
+              exit(EXIT_FAILURE);
+           }
+        }
+    } else {
+        if (pid_file != NULL) {
+           if (pledge("stdio cpath inet", NULL) == -1) {
+              fprintf(stderr, "%s: pledge: %s\n", __progname, strerror(errno));
+              exit(EXIT_FAILURE);
+           }
+        } else {
+           if (pledge("stdio inet", NULL) == -1) {
+              fprintf(stderr, "%s: pledge: %s\n", __progname, strerror(errno));
+              exit(EXIT_FAILURE);
+           }
+        }
+     }
+}

--- a/solaris_priv.c
+++ b/solaris_priv.c
@@ -9,7 +9,7 @@
  * effect of this is that after running this code, the process will not able
  * to fork(), exec(), etc.  See privileges(5) for more information.
  */
-void drop_privileges(void) {
+void drop_privileges(const char *pid_file) {
    priv_set_t *privs = priv_str_to_set("basic", ",", NULL);
 
    if (privs == NULL) {


### PR DESCRIPTION
If time_t is defined as long long it should not be printed with %lu format string.