### PR TITLE
printf format string fix for long long time_t

### DIFF
--- a/items.c
+++ b/items.c
@@ -484,10 +484,10 @@ char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, u
         /* Copy the key since it may not be null-terminated in the struct */
         strncpy(key_temp, ITEM_key(it), it->nkey);
         key_temp[it->nkey] = 0x00; /* terminate */
-        len = snprintf(temp, sizeof(temp), "ITEM %s [%d b; %lu s]\r\n",
+        len = snprintf(temp, sizeof(temp), "ITEM %s [%d b; %llu s]\r\n",
                        key_temp, it->nbytes - 2,
                        it->exptime == 0 ? 0 :
-                       (unsigned long)it->exptime + process_started);
+                       (unsigned long long)it->exptime + process_started);
         if (bufcurr + len + 6 > memlimit)  /* 6 is END\r\n\0 */
             break;
         memcpy(buffer + bufcurr, temp, len);


### PR DESCRIPTION
If time_t is declared as long long %llu should be used in printf(3) format string.