### PR TITLE
Add a feature to restrict writing to local host only

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -321,8 +321,8 @@ static void *conn_timeout_thread(void *arg) {
         for (i = 0; i < max_fds; i++) {
             if ((i % CONNS_PER_SLICE) == 0) {
                 if (settings.verbose > 2)
-                    fprintf(stderr, "idle timeout thread sleeping for %dus\n",
-                        timeslice);
+                    fprintf(stderr, "idle timeout thread sleeping for %luus\n",
+                        (unsigned long)timeslice);
                 usleep(timeslice);
             }
 

--- a/memcached.h
+++ b/memcached.h
@@ -369,6 +369,8 @@ struct settings {
     int idle_timeout;       /* Number of seconds to let connections idle */
     unsigned int logger_watcher_buf_size; /* size of logger's per-watcher buffer */
     unsigned int logger_buf_size; /* size of per-thread logger buffer */
+    bool local_write_only;
+    bool anonymous_reads;
 };
 
 extern struct stats stats;
@@ -488,6 +490,7 @@ struct conn {
     char   *rcurr;  /** but if we parsed some already, this is where we stopped */
     int    rsize;   /** total allocated size of rbuf */
     int    rbytes;  /** how much data, starting from rcur, do we have unparsed */
+    bool local; /** connection via local loopback **/
 
     char   *wbuf;
     char   *wcurr;
@@ -597,7 +600,7 @@ enum delta_result_type do_add_delta(conn *c, const char *key,
                                     const int64_t delta, char *buf,
                                     uint64_t *cas, const uint32_t hv);
 enum store_item_type do_store_item(item *item, int comm, conn* c, const uint32_t hv);
-conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size, enum network_transport transport, struct event_base *base);
+conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size, enum network_transport transport, struct event_base *base, bool local);
 void conn_worker_readd(conn *c);
 extern int daemonize(int nochdir, int noclose);
 
@@ -622,7 +625,7 @@ extern int daemonize(int nochdir, int noclose);
 
 void memcached_thread_init(int nthreads);
 void redispatch_conn(conn *c);
-void dispatch_conn_new(int sfd, enum conn_states init_state, int event_flags, int read_buffer_size, enum network_transport transport);
+void dispatch_conn_new(int sfd, enum conn_states init_state, int event_flags, int read_buffer_size, enum network_transport transport, bool local);
 void sidethread_conn_close(conn *c);
 
 /* Lock wrappers for cache functions that are called from main loop. */


### PR DESCRIPTION
We have a requirement to have memcached instances that are visible network wide for reading, but can only be written by a process on the local machine for security reasons. We use it as a buffer in front of a datastore server where clients can read data from the cache from the network, but only the local server can push data into it as it is the authoritative source of data.

We also added a small fix to the logging in memcached as the millisecond type is different (unsigned on gcc/linux, unsigned long on Windows/msys2/gcc) - casting to unsigned long and adjusting the log format should not have any performance impact in a log line that only gets executed if verbosity is >= 2.