### PR TITLE
Missing necessary header for atomic_inc_64_nv() used in logger.c

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -7,6 +7,10 @@
 #include <poll.h>
 #include <ctype.h>
 
+#if defined(__sun)
+#include <atomic.h>
+#endif
+
 #include "memcached.h"
 #include "bipbuffer.h"
 


### PR DESCRIPTION
logger.c uses atomic_inc_64_nv() function, but doesn't include atomic.h. This breaks compilation on OpenIndiana.