### PR TITLE
LRU-2Q algorithm fixes

### DIFF
--- a/doc/new_lru.txt
+++ b/doc/new_lru.txt
@@ -12,6 +12,7 @@ Now, enabling `-o lru_maintainer` changes all of the behavior below:
  * LRU updates only happen as items reach the bottom of an LRU. If active in
    HOT, stay in HOT, if active in WARM, stay in WARM. If active in COLD, move
    to WARM.
+   The exception is that items hit in COLD are immediately moved to WARM.
  * HOT/WARM each capped at 32% of memory available for that slab class. COLD
    is uncapped (by default, as of this writing).
  * Items flow from HOT/WARM into COLD.
@@ -25,7 +26,7 @@ bottom. Items occasionally active (reaching COLD, but being hit before
 eviction), move to WARM. There they can stay relatively protected.
 
 A secondary goal is to improve latency. The LRU locks are no longer used on
-item reads, only during sets and from the background thread. Also the
+most item reads, largely during sets and from the background thread. Also the
 background thread is likely to find expired items and release them back to the
 slab class asynchronously, which speeds up new allocations.
 
@@ -34,6 +35,9 @@ It is recommended to use this feature with the lru crawler as well:
 slab classes for items with expired TTL's. If your items are always set to
 never expire, you can omit this option safely.
 
-An extra option: `-o expirezero_does_not_evict` (when used with
-lru_maintainer) will make items with an expiration time of 0 unevictable. Take
-caution as this will crowd out memory available for other items.
+An extra option: `-o temporary_ttl=N` (when used with lru_maintainer) will make
+items with a TTL less than or equal to this value use a fourth TEMP LRU. Items
+stored in TEMP are never bumped within its LRU or moved to other LRU's. They
+also cannot be evicted. This can help reduce holes and load on the LRU crawler.
+
+Do not set temporary_ttl too high or memory could become exhausted.

--- a/doc/new_lru.txt
+++ b/doc/new_lru.txt
@@ -9,10 +9,11 @@ Now, enabling `-o lru_maintainer` changes all of the behavior below:
 
  * LRU's are now split between HOT, WARM, and COLD LRU's. New items enter the
    HOT LRU.
+ * Items hit at least twice are considered active.
  * LRU updates only happen as items reach the bottom of an LRU. If active in
-   HOT, stay in HOT, if active in WARM, stay in WARM. If active in COLD, move
+   HOT, move to WARM, if active in WARM, stay in WARM. If active in COLD, move
    to WARM.
-   The exception is that items hit in COLD are immediately moved to WARM.
+   The exception is that items active in COLD are immediately moved to WARM.
  * HOT/WARM each capped at 32% of memory available for that slab class. COLD
    is uncapped (by default, as of this writing).
  * Items flow from HOT/WARM into COLD.

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -747,8 +747,8 @@ other stats command.
 |                   | bool     | Split LRU mode and background threads        |
 | hot_lru_pct       | 32       | Pct of slab memory reserved for HOT LRU      |
 | warm_lru_pct      | 32       | Pct of slab memory reserved for WARM LRU     |
-| expirezero_does_not_evict                                                   |
-|                   | bool     | If yes, items with 0 exptime cannot evict    |
+| temp_lru          | bool     | If yes, items < temporary_ttl use TEMP_LRU   |
+| temporary_ttl     | 32u      | Items with TTL < this are marked  temporary  |
 | idle_time         | 0        | Drop connections that are idle this many     |
 |                   |          | seconds (0 disables)                         |
 | watcher_logbuf_size                                                         |
@@ -792,7 +792,7 @@ number                 Number of items presently stored in this class. Expired
 number_hot             Number of items presently stored in the HOT LRU.
 number_warm            Number of items presently stored in the WARM LRU.
 number_cold            Number of items presently stored in the COLD LRU.
-number_noexp           Number of items presently stored in the NOEXP class.
+number_temp            Number of items presently stored in the TEMPORARY LRU.
 age                    Age of the oldest item in the LRU.
 evicted                Number of times an item had to be evicted from the LRU
                        before it expired.

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -795,6 +795,8 @@ number_hot             Number of items presently stored in the HOT LRU.
 number_warm            Number of items presently stored in the WARM LRU.
 number_cold            Number of items presently stored in the COLD LRU.
 number_temp            Number of items presently stored in the TEMPORARY LRU.
+age_hot                Age of the oldest item in HOT LRU.
+age_warm               Age of the oldest item in WARM LRU.
 age                    Age of the oldest item in the LRU.
 evicted                Number of times an item had to be evicted from the LRU
                        before it expired.

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -747,6 +747,8 @@ other stats command.
 |                   | bool     | Split LRU mode and background threads        |
 | hot_lru_pct       | 32       | Pct of slab memory reserved for HOT LRU      |
 | warm_lru_pct      | 32       | Pct of slab memory reserved for WARM LRU     |
+| hot_max_age       | 32u      | Max idle age of items in HOT LRU             |
+| warm_max_factor   | float    | Set idle age of WARM LRU to COLD age * this  |
 | temp_lru          | bool     | If yes, items < temporary_ttl use TEMP_LRU   |
 | temporary_ttl     | 32u      | Items with TTL < this are marked  temporary  |
 | idle_time         | 0        | Drop connections that are idle this many     |

--- a/items.c
+++ b/items.c
@@ -443,24 +443,30 @@ void do_item_update_nolock(item *it) {
 /* Bump the last accessed time, or relink if we're in compat mode */
 void do_item_update(item *it) {
     MEMCACHED_ITEM_UPDATE(ITEM_key(it), it->nkey, it->nbytes);
-    if (it->time < current_time - ITEM_UPDATE_INTERVAL) {
+
+    /* Hits to COLD_LRU immediately move to WARM. */
+    if (settings.lru_maintainer_thread) {
+        assert((it->it_flags & ITEM_SLABBED) == 0);
+        if ((it->it_flags & ITEM_LINKED) != 0) {
+            // FIXME: do better LRU check.
+            if (it->slabs_clsid >= COLD_LRU && it->slabs_clsid < NOEXP_LRU) {
+                it->time = current_time;
+                item_unlink_q(it);
+                it->slabs_clsid = ITEM_clsid(it);
+                it->slabs_clsid |= WARM_LRU;
+                it->it_flags &= ~ITEM_ACTIVE;
+                item_link_q_warm(it);
+            } else if (it->time < current_time - ITEM_UPDATE_INTERVAL) {
+                it->time = current_time;
+            }
+        }
+    } else if (it->time < current_time - ITEM_UPDATE_INTERVAL) {
         assert((it->it_flags & ITEM_SLABBED) == 0);
 
         if ((it->it_flags & ITEM_LINKED) != 0) {
             it->time = current_time;
-            // FIXME: do better LRU check.
-            if (settings.lru_maintainer_thread) {
-                if (it->slabs_clsid >= COLD_LRU && it->slabs_clsid < NOEXP_LRU) {
-                    item_unlink_q(it);
-                    it->slabs_clsid = ITEM_clsid(it);
-                    it->slabs_clsid |= WARM_LRU;
-                    it->it_flags &= ~ITEM_ACTIVE;
-                    item_link_q_warm(it);
-                }
-            } else {
-                item_unlink_q(it);
-                item_link_q(it);
-            }
+            item_unlink_q(it);
+            item_link_q(it);
         }
     }
 }

--- a/items.c
+++ b/items.c
@@ -52,7 +52,6 @@ static int stats_sizes_buckets = 0;
 
 static volatile int do_run_lru_maintainer_thread = 0;
 static int lru_maintainer_initialized = 0;
-static int lru_maintainer_check_clsid = 0;
 static pthread_mutex_t lru_maintainer_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t cas_id_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t stats_sizes_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -1175,9 +1174,13 @@ static pthread_t lru_maintainer_tid;
 static void *lru_maintainer_thread(void *arg) {
     int i;
     useconds_t to_sleep = MIN_LRU_MAINTAINER_SLEEP;
+    useconds_t last_sleep = MIN_LRU_MAINTAINER_SLEEP;
     rel_time_t last_crawler_check = 0;
+    useconds_t next_juggles[MAX_NUMBER_OF_SLAB_CLASSES];
+    useconds_t backoff_juggles[MAX_NUMBER_OF_SLAB_CLASSES];
     struct crawler_expired_data cdata;
     memset(&cdata, 0, sizeof(struct crawler_expired_data));
+    memset(next_juggles, 0, sizeof(next_juggles));
     pthread_mutex_init(&cdata.lock, NULL);
     cdata.crawl_complete = true; // kick off the crawler.
     logger *l = logger_create();
@@ -1190,32 +1193,39 @@ static void *lru_maintainer_thread(void *arg) {
     if (settings.verbose > 2)
         fprintf(stderr, "Starting LRU maintainer background thread\n");
     while (do_run_lru_maintainer_thread) {
-        int did_moves = 0;
         pthread_mutex_unlock(&lru_maintainer_lock);
         if (to_sleep)
             usleep(to_sleep);
         pthread_mutex_lock(&lru_maintainer_lock);
+        /* A sleep of zero counts as a minimum of a 1ms wait */
+        last_sleep = to_sleep > 1000 ? to_sleep : 1000;
+        to_sleep = MAX_LRU_MAINTAINER_SLEEP;
 
         STATS_LOCK();
         stats.lru_maintainer_juggles++;
         STATS_UNLOCK();
-        /* We were asked to immediately wake up and poke a particular slab
-         * class due to a low watermark being hit */
-        if (lru_maintainer_check_clsid != 0) {
-            did_moves = lru_maintainer_juggle(lru_maintainer_check_clsid);
-            lru_maintainer_check_clsid = 0;
-        } else {
-            for (i = POWER_SMALLEST; i < MAX_NUMBER_OF_SLAB_CLASSES; i++) {
-                did_moves += lru_maintainer_juggle(i);
+        /* Each slab class gets its own sleep to avoid hammering locks */
+        for (i = POWER_SMALLEST; i < MAX_NUMBER_OF_SLAB_CLASSES; i++) {
+            next_juggles[i] = next_juggles[i] > last_sleep ? next_juggles[i] - last_sleep : 0;
+
+            // Sleep the thread just for the minimum amount (or not at all)
+            if (next_juggles[i] < to_sleep) {
+                to_sleep = next_juggles[i];
             }
-        }
-        if (did_moves == 0) {
-            if (to_sleep < MAX_LRU_MAINTAINER_SLEEP)
-                to_sleep += 1000;
-        } else if (to_sleep > 0) {
-            to_sleep /= 2;
-            if (to_sleep < MIN_LRU_MAINTAINER_SLEEP)
-                to_sleep = 0;
+            if (next_juggles[i] > 0)
+                continue;
+
+            int did_moves = lru_maintainer_juggle(i);
+            if (did_moves == 0) {
+                if (backoff_juggles[i] < MAX_LRU_MAINTAINER_SLEEP)
+                    backoff_juggles[i] += 1000;
+            } else if (backoff_juggles[i] > 0) {
+                backoff_juggles[i] /= 2;
+                if (backoff_juggles[i] < MIN_LRU_MAINTAINER_SLEEP) {
+                    backoff_juggles[i] = 0;
+                }
+            }
+            next_juggles[i] = backoff_juggles[i];
         }
         /* Once per second at most */
         if (settings.lru_crawler && last_crawler_check != current_time) {

--- a/items.c
+++ b/items.c
@@ -193,10 +193,9 @@ item *do_item_alloc(char *key, const size_t nkey, const unsigned int flags,
 
         if (it == NULL) {
             if (settings.lru_maintainer_thread) {
-                //lru_pull_tail(id, HOT_LRU, total_bytes, 0);
-                //lru_pull_tail(id, WARM_LRU, total_bytes, 0);
-                if (lru_pull_tail(id, COLD_LRU, total_bytes, LRU_PULL_EVICT) <= 0)
-                    break;
+                if (lru_pull_tail(id, COLD_LRU, total_bytes, LRU_PULL_EVICT) <= 0) {
+                    lru_pull_tail(id, HOT_LRU, total_bytes, 0);
+                }
             } else {
                 if (lru_pull_tail(id, COLD_LRU, 0, LRU_PULL_EVICT) <= 0)
                     break;
@@ -1170,7 +1169,7 @@ static void lru_maintainer_crawler_check(struct crawler_expired_data *cdata, log
 
 static pthread_t lru_maintainer_tid;
 
-#define MAX_LRU_MAINTAINER_SLEEP 1000000
+#define MAX_LRU_MAINTAINER_SLEEP 500000
 #define MIN_LRU_MAINTAINER_SLEEP 1000
 
 static void *lru_maintainer_thread(void *arg) {

--- a/items.c
+++ b/items.c
@@ -1145,7 +1145,7 @@ static void lru_maintainer_crawler_check(struct crawler_expired_data *cdata, log
         }
     }
     if (do_run) {
-        lru_crawler_start(todo, 0, CRAWLER_EXPIRED, cdata, NULL, 0);
+        lru_crawler_start(todo, settings.lru_crawler_tocrawl, CRAWLER_EXPIRED, cdata, NULL, 0);
     }
 }
 

--- a/items.c
+++ b/items.c
@@ -447,8 +447,7 @@ void do_item_update(item *it) {
     if (settings.lru_maintainer_thread) {
         assert((it->it_flags & ITEM_SLABBED) == 0);
         if ((it->it_flags & ITEM_LINKED) != 0) {
-            // FIXME: do better LRU check.
-            if (it->slabs_clsid >= COLD_LRU && it->slabs_clsid < TEMP_LRU) {
+            if (ITEM_lruid(it) == COLD_LRU) {
                 it->time = current_time;
                 item_unlink_q(it);
                 it->slabs_clsid = ITEM_clsid(it);

--- a/items.h
+++ b/items.h
@@ -1,7 +1,7 @@
 #define HOT_LRU 0
 #define WARM_LRU 64
 #define COLD_LRU 128
-#define NOEXP_LRU 192
+#define TEMP_LRU 192
 
 #define CLEAR_LRU(id) (id & ~(3<<6))
 

--- a/memcached.c
+++ b/memcached.c
@@ -3890,6 +3890,38 @@ static void process_temporary_ttl_command(conn *c, token_t *tokens, const size_t
     }
 }
 
+static void process_lru_command(conn *c, token_t *tokens, const size_t ntokens) {
+    uint32_t pct_hot;
+    uint32_t pct_warm;
+    uint32_t hot_age;
+    double factor;
+
+    set_noreply_maybe(c, tokens, ntokens);
+
+    if (strcmp(tokens[1].value, "tune") == 0 && ntokens >= 7) {
+        if (!safe_strtoul(tokens[2].value, &pct_hot) ||
+            !safe_strtoul(tokens[3].value, &pct_warm) ||
+            !safe_strtoul(tokens[4].value, &hot_age) ||
+            !safe_strtod(tokens[5].value, &factor)) {
+            out_string(c, "ERROR");
+        } else {
+            if (pct_hot + pct_warm > 80) {
+                out_string(c, "ERROR hot and warm pcts must not exceed 80");
+            } else if (factor <= 0) {
+                out_string(c, "ERROR cold age factor must be greater than 0");
+            } else {
+                settings.hot_lru_pct = pct_hot;
+                settings.warm_lru_pct = pct_warm;
+                settings.hot_max_age = hot_age;
+                settings.warm_max_factor = factor;
+                out_string(c, "OK");
+            }
+        }
+    } else {
+        out_string(c, "ERROR");
+    }
+}
+
 static void process_command(conn *c, char *command) {
 
     token_t tokens[MAX_TOKENS];
@@ -4175,6 +4207,8 @@ static void process_command(conn *c, char *command) {
         process_temporary_ttl_command(c, tokens, ntokens);
     } else if ((ntokens == 3 || ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "verbosity") == 0)) {
         process_verbosity_command(c, tokens, ntokens);
+    } else if (ntokens >= 3 && strcmp(tokens[COMMAND_TOKEN].value, "lru") == 0) {
+        process_lru_command(c, tokens, ntokens);
     } else {
         out_string(c, "ERROR");
     }

--- a/memcached.h
+++ b/memcached.h
@@ -367,6 +367,8 @@ struct settings {
     uint32_t lru_crawler_tocrawl; /* Number of items to crawl per run */
     int hot_lru_pct; /* percentage of slab space for HOT_LRU */
     int warm_lru_pct; /* percentage of slab space for WARM_LRU */
+    uint32_t hot_max_age; /* max idle time before move from HOT_LRU */
+    double warm_max_factor; /* WARM tail age relative to COLD tail */
     int crawls_persleep; /* Number of LRU crawls to run before sleeping */
     bool inline_ascii_response; /* pre-format the VALUE line for ASCII responses */
     bool temp_lru; /* TTL < temporary_ttl uses TEMP_LRU */

--- a/memcached.h
+++ b/memcached.h
@@ -114,6 +114,7 @@
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
 #define ITEM_clsid(item) ((item)->slabs_clsid & ~(3<<6))
+#define ITEM_lruid(item) ((item)->slabs_clsid & (3<<6))
 
 #define STAT_KEY_LEN 128
 #define STAT_VAL_LEN 128

--- a/memcached.h
+++ b/memcached.h
@@ -369,6 +369,7 @@ struct settings {
     int crawls_persleep; /* Number of LRU crawls to run before sleeping */
     bool expirezero_does_not_evict; /* exptime == 0 goes into NOEXP_LRU */
     bool inline_ascii_response; /* pre-format the VALUE line for ASCII responses */
+    uint32_t transient_ttl; /* transient LRU threshold */
     int idle_timeout;       /* Number of seconds to let connections idle */
     unsigned int logger_watcher_buf_size; /* size of logger's per-watcher buffer */
     unsigned int logger_buf_size; /* size of per-thread logger buffer */

--- a/memcached.h
+++ b/memcached.h
@@ -367,9 +367,9 @@ struct settings {
     int hot_lru_pct; /* percentage of slab space for HOT_LRU */
     int warm_lru_pct; /* percentage of slab space for WARM_LRU */
     int crawls_persleep; /* Number of LRU crawls to run before sleeping */
-    bool expirezero_does_not_evict; /* exptime == 0 goes into NOEXP_LRU */
     bool inline_ascii_response; /* pre-format the VALUE line for ASCII responses */
-    uint32_t transient_ttl; /* transient LRU threshold */
+    bool temp_lru; /* TTL < temporary_ttl uses TEMP_LRU */
+    uint32_t temporary_ttl; /* temporary LRU threshold */
     int idle_timeout;       /* Number of seconds to let connections idle */
     unsigned int logger_watcher_buf_size; /* size of logger's per-watcher buffer */
     unsigned int logger_buf_size; /* size of per-thread logger buffer */

--- a/t/lru-maintainer.t
+++ b/t/lru-maintainer.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 225;
+use Test::More tests => 226;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -53,7 +53,8 @@ for (my $key = 0; $key < 100; $key++) {
             last;
         }
         isnt($stats->{"items:31:moves_to_cold"}, 0, "moved some items to cold");
-        # Fetch the canary once, so it's now marked as active.
+        # Items need two fetches to become active
+        mem_get_is($sock, "canary", $value);
         mem_get_is($sock, "canary", $value);
     }
     print $sock "set key$key 0 0 66560\r\n$value\r\n";
@@ -64,7 +65,8 @@ for (my $key = 0; $key < 100; $key++) {
     my $stats = mem_stats($sock);
     isnt($stats->{evictions}, 0, "some evictions happened");
     my $istats = mem_stats($sock, "items");
-    isnt($stats->{"items:31:number_warm"}, 0, "our canary moved to warm");
+    isnt($istats->{"items:31:number_warm"}, 0, "our canary moved to warm");
+    use Data::Dumper qw/Dumper/;
 }
 
 # Key should've been saved to the WARM_LRU, and still exists.

--- a/util.c
+++ b/util.c
@@ -134,6 +134,23 @@ bool safe_strtol(const char *str, int32_t *out) {
     return false;
 }
 
+bool safe_strtod(const char *str, double *out) {
+    assert(out != NULL);
+    errno = 0;
+    *out = 0;
+    char *endptr;
+    double d = strtod(str, &endptr);
+    if ((errno == ERANGE) || (str == endptr)) {
+        return false;
+    }
+
+    if (xisspace(*endptr) || (*endptr == '\0' && endptr != str)) {
+        *out = d;
+        return true;
+    }
+    return false;
+}
+
 void vperror(const char *fmt, ...) {
     int old_errno = errno;
     char buf[1024];

--- a/util.h
+++ b/util.h
@@ -15,6 +15,7 @@ bool safe_strtoull(const char *str, uint64_t *out);
 bool safe_strtoll(const char *str, int64_t *out);
 bool safe_strtoul(const char *str, uint32_t *out);
 bool safe_strtol(const char *str, int32_t *out);
+bool safe_strtod(const char *str, double *out);
 
 #ifndef HAVE_HTONLL
 extern uint64_t htonll(uint64_t);


### PR DESCRIPTION
This PR is now complete. Will be doing separate PR's for further work.

Update 1) Now named "temporary" to hopefully be less confusing. Most major fixes done, should go for the bonus.

Update 2) Going to punt on inline reclaim. Will get better results from work elsewhere. This is ready for any reviews/tests before merging to next.

Update 3) Think I want to fine-tune this slightly more: There's another bug where promotion from probationary queue should get hit twice (is currently just once from cold), also I think re-linking within HOT is a poor usage of that space. Finally, hot|warm defaults of 32% were meant to be tuned and I don't want to flip this as a default without some kind of auto-tuning. I believe HOT -> 32% of memory or max-age of 3600s by default, WARM -> 32% of memory or max-age of double average of COLD. This should help shrink back HOT and WARM unless actually being used. Can then expose tunables for the max-age as well as cap-pct, but the defaults are better.

When I implemented the 2Q algorithm a few years ago there were a couple omissions. This series should repair that.

It's been bothering me for a long time that the hit ratio of the newer algorithm isn't better than what I've been seeing. Much of the benefit people get is with its ability to reclaim memory early while moving inbetween LRU's.

 - I'd described the algo as keeping ACTIVE flagged items within HOT|WARM, or move from COLD|WARM. However the algorithm was preferencing moving items (even ACTIVE ones) from HOT|WARM into COLD if the former were over their size limit. Direct reclaim also always pulled the item from COLD's tail. It looks as though I had intended to add watermarks but never finished the code (ie; if they are oversize by 1%, or COLD is too small, force empties).

In by-hand testing or light usage this isn't measureable due to the LRU maintainer thread frequently poking the LRU tails. Under high traffic it would now be racing to find items before they're shoveled away.

It's undesirable to have to deal with ACTIVE items during direct reclaim as well, which is part of why there are many retries in the allocator. The adjustments (plus a bonus) are:

- Allow the LRU thread to reach a zero sleep (immediate wakeup)
- A hit in COLD does an immediate inline relink to WARM. Very active items stick in HOT|WARM so the contention from COLD is low (plus repeated hits from there stay in WARM and do not relink). This prevents active items from reaching the bottom of COLD to begin with.
- Don't prefer to remove ACTIVE items if an LRU is too large.
- No longer pull from HOT|WARM every time we try to evict. (performance/useless)
- Migrate NOEXP_LRU (0 expire is unevictable) to be a more-potentially useful "transient" LRU. Items with TTL's below this go directly into the 4th LRU. The LRU thread will poke the tail for expired items but not crawl up it and items within it will never relink into other LRU's. Potentially lowers contention and relieves stress on the LRU crawler.
- Items need to be fetched twice to be considered active. After two hits and a move to WARM, needs one more hit to remain active.
- Active items at bottom of HOT move to WARM, rather than stay in HOT.

The effect seems to be dramatic under higher workloads. Would be happy for anyone willing to test the branch.

WIP TODO:

 - [x] Fix broken/racy tests.
 - [x] Need relief thresholds to prevent extreme workloads from draining COLD. Could potentially just evict from WARM or HOT if COLD is empty.
   (might modify this one more time; flag to force move from HOT->COLD)
 - [x] Rename NOEXP and update documentation.
 - [x] Code cleanup and any documentation updates (including the lru.txt doc/ file)
 - [x] Bonus: LRU thread to get per-LRU sleep scheduling. Don't hard-loop through every tail when most of the work is in a few particular classes. (performance)
 - [ ] Bonus: restore inline memory reclaiming during direct reclaim (potentially a different PR). (performance)
 - [x] Extra: Promote from COLD to WARM only if hit twice (add ACTIVE flag only if FETCHED flag exists)
 - [x] Never relink within HOT. If ACTIVE|FETCHED move directly to WARM. Reduce churn in HOT
 - [x] HOT is 32% of memory or max age of 3600s by default. Add new tunable for max-age of HOT
 - [x] WARM is 32% of memory or max age of double COLD. Add new tunable for age-multiplier.
 - [ ] Super Bonus: Allow runtime switching between LRU mechanisms. [doing in separate PR]
 - [x] Runtime tuning command for percents and maximums.