### PR TITLE
Make item-inlined ASCII response header optional

### DIFF
--- a/LICENSE.itoa_ljust
+++ b/LICENSE.itoa_ljust
@@ -1,0 +1,39 @@
+Copyright (c) 2016, Arturo Martin-de-Nicolas
+arturomdn@gmail.com
+https://github.com/amdn/itoa_ljust/
+All rights reserved.
+
+This implementation is loosely based on the structure of FastInt32ToBufferLeft
+in:
+
+Protocol Buffers - Google's data interchange format
+Copyright 2008 Google Inc.  All rights reserved.
+https://developers.google.com/protocol-buffers/
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,8 @@ memcached_SOURCES = memcached.c memcached.h \
                     trace.h cache.h sasl_defs.h \
                     bipbuffer.c bipbuffer.h \
                     logger.c logger.h \
-                    crawler.c crawler.h
+                    crawler.c crawler.h \
+                    itoa_ljust.c itoa_ljust.h
 
 if BUILD_CACHE
 memcached_SOURCES += cache.c

--- a/cache.h
+++ b/cache.h
@@ -101,6 +101,7 @@ void cache_destroy(cache_t* handle);
  *         the allocation cannot be satisfied.
  */
 void* cache_alloc(cache_t* handle);
+void* do_cache_alloc(cache_t* handle);
 /**
  * Return an object back to the cache.
  *
@@ -111,6 +112,7 @@ void* cache_alloc(cache_t* handle);
  * @param ptr pointer to the object to return.
  */
 void cache_free(cache_t* handle, void* ptr);
+void do_cache_free(cache_t* handle, void* ptr);
 #endif
 
 #endif

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -758,6 +758,10 @@ other stats command.
 |                   |          | which the background thread reads from.      |
 | track_sizes       | bool     | If yes, a "stats sizes" histogram is being   |
 |                   |          | dymamically tracked.                         |
+| inline_ascii_response                                                       |
+|                   | bool     | If yes, stores numbers from VALUE response   |
+|                   |          | inside an item, using up to 24 bytes.        |
+|                   |          | Small slowdown for ASCII get, faster sets.   |
 |-------------------+----------+----------------------------------------------|
 
 

--- a/items.c
+++ b/items.c
@@ -138,8 +138,12 @@ static unsigned int noexp_lru_size(int slabs_clsid) {
  */
 static size_t item_make_header(const uint8_t nkey, const unsigned int flags, const int nbytes,
                      char *suffix, uint8_t *nsuffix) {
-    /* suffix is defined at 40 chars elsewhere.. */
-    *nsuffix = (uint8_t) snprintf(suffix, 40, " %u %d\r\n", flags, nbytes - 2);
+    if (settings.inline_ascii_response) {
+        /* suffix is defined at 40 chars elsewhere.. */
+        *nsuffix = (uint8_t) snprintf(suffix, 40, " %u %d\r\n", flags, nbytes - 2);
+    } else {
+        *nsuffix = sizeof(flags);
+    }
     return sizeof(item) + nkey + *nsuffix + nbytes;
 }
 
@@ -242,7 +246,11 @@ item *do_item_alloc(char *key, const size_t nkey, const unsigned int flags,
     it->nbytes = nbytes;
     memcpy(ITEM_key(it), key, nkey);
     it->exptime = exptime;
-    memcpy(ITEM_suffix(it), suffix, (size_t)nsuffix);
+    if (settings.inline_ascii_response) {
+        memcpy(ITEM_suffix(it), suffix, (size_t)nsuffix);
+    } else {
+        memcpy(ITEM_suffix(it), &flags, sizeof(flags));
+    }
     it->nsuffix = nsuffix;
 
     /* Need to shuffle the pointer stored in h_next into it->data. */

--- a/itoa_ljust.c
+++ b/itoa_ljust.c
@@ -107,7 +107,7 @@ static inline char* itoa(uint32_t u, char* p, int d, int n) {
 }
 
 char* itoa_u32(uint32_t u, char* p) {
-    int d,n;
+    int d = 0,n;
          if (u >=100000000) n = digits(u, 100000000, &d, &p, 10);
     else if (u <       100) n = digits(u,         1, &d, &p,  2);
     else if (u <     10000) n = digits(u,       100, &d, &p,  4);

--- a/itoa_ljust.c
+++ b/itoa_ljust.c
@@ -1,0 +1,149 @@
+//=== itoa_ljust.cpp - Fast integer to ascii conversion           --*- C++ -*-//
+//
+// Substantially simplified (and slightly faster) version
+// based on the following functions in Google's protocol buffers:
+//
+//    FastInt32ToBufferLeft()
+//    FastUInt32ToBufferLeft()
+//    FastInt64ToBufferLeft()
+//    FastUInt64ToBufferLeft()
+//
+// Differences:
+//    1) Greatly simplified
+//    2) Avoids GOTO statements - uses "switch" instead and relies on
+//       compiler constant folding and propagation for high performance
+//    3) Avoids unary minus of signed types - undefined behavior if value
+//       is INT_MIN in platforms using two's complement representation
+//    4) Uses memcpy to store 2 digits at a time - lets the compiler
+//       generate a 2-byte load/store in platforms that support
+//       unaligned access, this is faster (and less code) than explicitly
+//       loading and storing each byte
+//
+// Copyright (c) 2016 Arturo Martin-de-Nicolas
+// arturomdn@gmail.com
+// https://github.com/amdn/itoa_ljust/
+//
+// Released under the BSD 3-Clause License, see Google's original copyright
+// and license below.
+//===----------------------------------------------------------------------===//
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//===----------------------------------------------------------------------===//
+
+#include "itoa_ljust.h"
+#include <string.h>
+
+static const char lut[201] =
+    "0001020304050607080910111213141516171819"
+    "2021222324252627282930313233343536373839"
+    "4041424344454647484950515253545556575859"
+    "6061626364656667686970717273747576777879"
+    "8081828384858687888990919293949596979899";
+
+#define dd(u) ((const uint16_t)(lut[u]))
+
+static inline char* out2(const int d, char* p) {
+    memcpy(p, &((uint16_t *)lut)[d], 2);
+    return p + 2;
+}
+
+static inline char* out1(const char in, char* p) {
+    memcpy(p, &in, 1);
+    return p + 1;
+}
+
+static inline int digits( uint32_t u, unsigned k, int* d, char** p, int n ) {
+    if (u < k*10) {
+        *d = u / k;
+        *p = out1('0'+*d, *p);
+        --n;
+    }
+    return n;
+}
+
+static inline char* itoa(uint32_t u, char* p, int d, int n) {
+    switch(n) {
+    case 10: d  = u / 100000000; p = out2( d, p );
+    case  9: u -= d * 100000000;
+    case  8: d  = u /   1000000; p = out2( d, p );
+    case  7: u -= d *   1000000;
+    case  6: d  = u /     10000; p = out2( d, p );
+    case  5: u -= d *     10000;
+    case  4: d  = u /       100; p = out2( d, p );
+    case  3: u -= d *       100;
+    case  2: d  = u /         1; p = out2( d, p );
+    case  1: ;
+    }
+    *p = '\0';
+    return p;
+}
+
+char* itoa_u32(uint32_t u, char* p) {
+    int d,n;
+         if (u >=100000000) n = digits(u, 100000000, &d, &p, 10);
+    else if (u <       100) n = digits(u,         1, &d, &p,  2);
+    else if (u <     10000) n = digits(u,       100, &d, &p,  4);
+    else if (u <   1000000) n = digits(u,     10000, &d, &p,  6);
+    else                    n = digits(u,   1000000, &d, &p,  8);
+    return itoa( u, p, d, n );
+}
+
+char* itoa_32(int32_t i, char* p) {
+    uint32_t u = i;
+    if (i < 0) {
+        *p++ = '-';
+        u = -u;
+    }
+    return itoa_u32(u, p);
+}
+
+char* itoa_u64(uint64_t u, char* p) {
+    int d;
+
+    uint32_t lower = (uint32_t)u;
+    if (lower == u) return itoa_u32(lower, p);
+
+    uint64_t upper = u / 1000000000;
+    p = itoa_u64(upper, p);
+    lower = u - (upper * 1000000000);
+    d = lower / 100000000;
+    p = out1('0'+d,p);
+    return itoa( lower, p, d, 9 );
+}
+
+char* itoa_64(int64_t i, char* p) {
+    uint64_t u = i;
+    if (i < 0) {
+        *p++ = '-';
+        u = -u;
+    }
+    return itoa_u64(u, p);
+}

--- a/itoa_ljust.h
+++ b/itoa_ljust.h
@@ -1,0 +1,28 @@
+#ifndef ITOA_LJUST_H
+#define ITOA_LJUST_H
+
+//=== itoa_ljust.h - Fast integer to ascii conversion
+//
+// Fast and simple integer to ASCII conversion:
+//
+//   - 32 and 64-bit integers
+//   - signed and unsigned
+//   - user supplied buffer must be large enough for all decimal digits
+//     in value plus minus sign if negative
+//   - left-justified
+//   - NUL terminated
+//   - return value is pointer to NUL terminator
+//
+// Copyright (c) 2016 Arturo Martin-de-Nicolas
+// arturomdn@gmail.com
+// https://github.com/amdn/itoa_ljust/
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+
+char* itoa_u32(uint32_t u, char* buffer);
+char* itoa_32( int32_t i, char* buffer);
+char* itoa_u64(uint64_t u, char* buffer);
+char* itoa_64( int64_t i, char* buffer);
+
+#endif // ITOA_LJUST_H

--- a/memcached.c
+++ b/memcached.c
@@ -622,7 +622,7 @@ static void conn_release_items(conn *c) {
 
     if (c->suffixleft != 0) {
         for (; c->suffixleft > 0; c->suffixleft--, c->suffixcurr++) {
-            cache_free(c->thread->suffix_cache, *(c->suffixcurr));
+            do_cache_free(c->thread->suffix_cache, *(c->suffixcurr));
         }
     }
 
@@ -3275,7 +3275,7 @@ static inline void process_get_command(conn *c, token_t *tokens, size_t ntokens,
                     }
                   }
 
-                  suffix = cache_alloc(c->thread->suffix_cache);
+                  suffix = do_cache_alloc(c->thread->suffix_cache);
                   if (suffix == NULL) {
                       STATS_LOCK();
                       stats.malloc_fails++;

--- a/memcached.h
+++ b/memcached.h
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <assert.h>
 
+#include "itoa_ljust.h"
 #include "protocol_binary.h"
 #include "cache.h"
 #include "logger.h"

--- a/memcached.h
+++ b/memcached.h
@@ -37,9 +37,8 @@
 #define UDP_MAX_PAYLOAD_SIZE 1400
 #define UDP_HEADER_SIZE 8
 #define MAX_SENDBUF_SIZE (256 * 1024 * 1024)
-/* I'm told the max length of a 64-bit num converted to string is 20 bytes.
- * Plus a few for spaces, \r\n, \0 */
-#define SUFFIX_SIZE 24
+/* Up to 3 numbers (2 32bit, 1 64bit), spaces, newlines, null 0 */
+#define SUFFIX_SIZE 50
 
 /** Initial size of list of items being returned by "get". */
 #define ITEM_LIST_INITIAL 200
@@ -369,6 +368,7 @@ struct settings {
     int warm_lru_pct; /* percentage of slab space for WARM_LRU */
     int crawls_persleep; /* Number of LRU crawls to run before sleeping */
     bool expirezero_does_not_evict; /* exptime == 0 goes into NOEXP_LRU */
+    bool inline_ascii_response; /* pre-format the VALUE line for ASCII responses */
     int idle_timeout;       /* Number of seconds to let connections idle */
     unsigned int logger_watcher_buf_size; /* size of logger's per-watcher buffer */
     unsigned int logger_buf_size; /* size of per-thread logger buffer */

--- a/t/inline_asciihdr.t
+++ b/t/inline_asciihdr.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+# Ensure get and gets can mirror flags + CAS properly when not inlining the
+# ascii response header.
+
+use strict;
+use Test::More tests => 17;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached('-o no_inline_ascii_resp');
+my $sock = $server->sock;
+
+# 0 flags and size
+print $sock "set foo 0 0 0\r\n\r\n";
+is(scalar <$sock>, "STORED\r\n", "stored");
+
+mem_get_is($sock, "foo", "");
+
+for my $flags (0, 123, 2**16-1, 2**31, 2**32-1) {
+    print $sock "set foo $flags 0 6\r\nfooval\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored foo");
+    mem_get_is({ sock => $sock,
+                 flags => $flags }, "foo", "fooval", "got flags $flags back");
+    my @res = mem_gets($sock, "foo");
+    mem_gets_is({ sock => $sock,
+                  flags => $flags }, $res[0], "foo", "fooval", "got flags $flags back");
+
+}
+
+

--- a/t/issue_42.t
+++ b/t/issue_42.t
@@ -18,4 +18,5 @@ for ($key = 0; $key < 10; $key++) {
 
 my $first_stats = mem_stats($sock, "slabs");
 my $req = $first_stats->{"1:mem_requested"};
-ok ($req == "640" || $req == "800", "Check allocated size");
+print STDERR "REQ: $req\n";
+ok ($req == "640" || $req == "800" || $req == "770", "Check allocated size");


### PR DESCRIPTION
This is a fun one. Since time forgotten, memcached has rendered the client flags and item byte size into the item itself (along with some spaces and \r\n). This is then directly streamed along with the item during the ASCII response. However, this leads to:

 - Several sprintf's during SET's (checking the item size, storing the item)
 - strtoul's and sprintf's during incr/decr/append/prepend
 - strtoul's during binary protocol responses (turning the ASCII flags back into an integer)
 - Useless sprintf's during binprot sets.
 - Potentially significant memory overhead if you are trying to tightly pack very small items.
 - GETS (cas get) has always done a funny inline sprintf anyway.

So this branch attempts to replace this with a very fast print routine. Much thanks to the author of the itoa routine, which was ported from CPP and appears to perform well under some initial tests.

As-is, sets are a bit faster, and massive multigets are 8% slower (24M keys/sec vs 26M keys/sec on 20 worker threads). This will very likely end up in `-o modern`

WIP TODO:

 - [x] Test cleanup
 - [x] More comprehensive performance tests with a range of small/large client flags
 - [x] More comprehensive set and mixed set/get performance tests
 - [x] Potential performance fixes to add_iov (which seems to be slower than the itoa) (done in different PR)
 - [ ] Potentially use a bipbuf or c->wbuf instead of the per-worker-thread suffix cache, relieving some freelist management. [punting for larger refactor later. freelist management did not measure to much]
 - [ ] Fast itoa requires -O3 compilation for best performance. Make that work somehow. [punting for another change]
 - [x] Any missing documentation.