### PR TITLE
+status check routine

### DIFF
--- a/scripts/memcached-init
+++ b/scripts/memcached-init
@@ -85,7 +85,18 @@ case "$1" in
         echo "$NAME."
         rm -f $PIDFILE
         ;;
-
+    status)
+        [ $# -lt 2 ] && NAME=$DAEMONNAME
+        PIDFILE="/var/run/$NAME.pid"
+        set +e
+        start-stop-daemon --status --pidfile $PIDFILE
+        case $? in
+            0) echo "$DESC: $NAME (pid $(cat $PIDFILE)) is running" && exit 0;;
+            1) echo "$DESC: $NAME is not running thro' the pid file exists" && rm -f $PIDFILE && exit 1;;
+            3) echo "$DESC: $NAME is not running" && exit 3;;
+            4) echo "$DESC: $NAME status is unclear, sorry" && exit 4;; 
+        esac
+        ;;
     restart|force-reload)
     #
     #   If the "reload" option is implemented, move the "force-reload"
@@ -102,7 +113,7 @@ case "$1" in
     *)
         N=/etc/init.d/$NAME
     # echo "Usage: $N {start|stop|restart|reload|force-reload}" >&2
-        echo "Usage: $N {start|stop|restart|force-reload}" >&2
+        echo "Usage: $N {start|stop|status|restart|force-reload}" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
one can check status of sole memcached daemon if there’re no instances configured (this is default behaviour on request made in common way w/o xtra args) or check status of some instance from bunch

an outcome is short diagnostic message along w/ appropriate ret code

**status of sole memcached daemon**
/etc/init.d/memcached status
/sbin/service memcached status

**status of memcached instance ’instance001’**
/etc/init.d/memcached status instance001
/sbin/service memcached status instance001

**status of memcached instance ’instance014’**
/etc/init.d/memcached status instance014
/sbin/service memcached status instance014