### PR TITLE
Frontend performance fixes

### DIFF
--- a/items.c
+++ b/items.c
@@ -760,7 +760,7 @@ void item_stats_sizes(ADD_STAT add_stats, void *c) {
 }
 
 /** wrapper around assoc_find which does the lazy expiration logic */
-item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c) {
+item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c, const bool do_update) {
     item *it = assoc_find(key, nkey, hv);
     if (it != NULL) {
         refcount_incr(&it->refcount);
@@ -825,6 +825,9 @@ item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c
             was_found = 3;
         } else {
             it->it_flags |= ITEM_FETCHED|ITEM_ACTIVE;
+            if (do_update) {
+                do_item_update(it);
+            }
             DEBUG_REFCNT(it, '+');
         }
     }
@@ -840,7 +843,7 @@ item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c
 
 item *do_item_touch(const char *key, size_t nkey, uint32_t exptime,
                     const uint32_t hv, conn *c) {
-    item *it = do_item_get(key, nkey, hv, c);
+    item *it = do_item_get(key, nkey, hv, c, DO_UPDATE);
     if (it != NULL) {
         it->exptime = exptime;
     }

--- a/items.h
+++ b/items.h
@@ -42,7 +42,7 @@ void item_stats_sizes_add(item *it);
 void item_stats_sizes_remove(item *it);
 bool item_stats_sizes_status(void);
 
-item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c);
+item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c, const bool do_update);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv, conn *c);
 void item_stats_reset(void);
 extern pthread_mutex_t lru_locks[POWER_LARGEST];

--- a/memcached.h
+++ b/memcached.h
@@ -652,8 +652,8 @@ void *item_trylock(uint32_t hv);
 void item_trylock_unlock(void *arg);
 void item_unlock(uint32_t hv);
 void pause_threads(enum pause_thread_types type);
-unsigned short refcount_incr(unsigned short *refcount);
-unsigned short refcount_decr(unsigned short *refcount);
+#define refcount_incr(it) ++(it->refcount)
+#define refcount_decr(it) --(it->refcount)
 void STATS_LOCK(void);
 void STATS_UNLOCK(void);
 void threadlocal_stats_reset(void);

--- a/memcached.h
+++ b/memcached.h
@@ -44,7 +44,7 @@
 #define ITEM_LIST_INITIAL 200
 
 /** Initial size of list of CAS suffixes appended to "gets" lines. */
-#define SUFFIX_LIST_INITIAL 20
+#define SUFFIX_LIST_INITIAL 100
 
 /** Initial size of the sendmsg() scatter/gather array. */
 #define IOV_LIST_INITIAL 400

--- a/memcached.h
+++ b/memcached.h
@@ -638,13 +638,14 @@ conn *conn_from_freelist(void);
 bool  conn_add_to_freelist(conn *c);
 void  conn_close_idle(conn *c);
 item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbytes);
-item *item_get(const char *key, const size_t nkey, conn *c);
+#define DO_UPDATE true
+#define DONT_UPDATE false
+item *item_get(const char *key, const size_t nkey, conn *c, const bool do_update);
 item *item_touch(const char *key, const size_t nkey, uint32_t exptime, conn *c);
 int   item_link(item *it);
 void  item_remove(item *it);
 int   item_replace(item *it, item *new_it, const uint32_t hv);
 void  item_unlink(item *it);
-void  item_update(item *it);
 
 void item_lock(uint32_t hv);
 void *item_trylock(uint32_t hv);

--- a/slabs.c
+++ b/slabs.c
@@ -823,7 +823,7 @@ static int slab_rebalance_move(void) {
                 if ((hold_lock = item_trylock(hv)) == NULL) {
                     status = MOVE_LOCKED;
                 } else {
-                    refcount = refcount_incr(&it->refcount);
+                    refcount = refcount_incr(it);
                     if (refcount == 2) { /* item is linked but not busy */
                         /* Double check ITEM_LINKED flag here, since we're
                          * past a memory barrier from the mutex. */
@@ -844,7 +844,7 @@ static int slab_rebalance_move(void) {
                     }
                     /* Item lock must be held while modifying refcount */
                     if (status == MOVE_BUSY) {
-                        refcount_decr(&it->refcount);
+                        refcount_decr(it);
                         item_trylock_unlock(hold_lock);
                     }
                 }
@@ -935,7 +935,7 @@ static int slab_rebalance_move(void) {
 #ifdef DEBUG_SLAB_MOVER
                         memcpy(ITEM_key((item *)ch), "deadbeef", 8);
 #endif
-                        refcount_decr(&it->refcount);
+                        refcount_decr(it);
                         requested_adjust = s_cls->size;
                     }
                 } else {

--- a/thread.c
+++ b/thread.c
@@ -79,36 +79,6 @@ static pthread_cond_t init_cond;
 
 static void thread_libevent_process(int fd, short which, void *arg);
 
-unsigned short refcount_incr(unsigned short *refcount) {
-#ifdef HAVE_GCC_ATOMICS
-    return __sync_add_and_fetch(refcount, 1);
-#elif defined(__sun)
-    return atomic_inc_ushort_nv(refcount);
-#else
-    unsigned short res;
-    mutex_lock(&atomics_mutex);
-    (*refcount)++;
-    res = *refcount;
-    mutex_unlock(&atomics_mutex);
-    return res;
-#endif
-}
-
-unsigned short refcount_decr(unsigned short *refcount) {
-#ifdef HAVE_GCC_ATOMICS
-    return __sync_sub_and_fetch(refcount, 1);
-#elif defined(__sun)
-    return atomic_dec_ushort_nv(refcount);
-#else
-    unsigned short res;
-    mutex_lock(&atomics_mutex);
-    (*refcount)--;
-    res = *refcount;
-    mutex_unlock(&atomics_mutex);
-    return res;
-#endif
-}
-
 /* item_lock() must be held for an item before any modifications to either its
  * associated hash bucket, or the structure itself.
  * LRU modifications must hold the item lock, and the LRU lock.

--- a/thread.c
+++ b/thread.c
@@ -543,12 +543,12 @@ item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbyt
  * Returns an item if it hasn't been marked as expired,
  * lazy-expiring as needed.
  */
-item *item_get(const char *key, const size_t nkey, conn *c) {
+item *item_get(const char *key, const size_t nkey, conn *c, const bool do_update) {
     item *it;
     uint32_t hv;
     hv = hash(key, nkey);
     item_lock(hv);
-    it = do_item_get(key, nkey, hv, c);
+    it = do_item_get(key, nkey, hv, c, do_update);
     item_unlock(hv);
     return it;
 }
@@ -607,18 +607,6 @@ void item_unlink(item *item) {
     hv = hash(ITEM_key(item), item->nkey);
     item_lock(hv);
     do_item_unlink(item, hv);
-    item_unlock(hv);
-}
-
-/*
- * Moves an item to the back of the LRU queue.
- */
-void item_update(item *item) {
-    uint32_t hv;
-    hv = hash(ITEM_key(item), item->nkey);
-
-    item_lock(hv);
-    do_item_update(item);
     item_unlock(hv);
 }
 


### PR DESCRIPTION
This series builds on top of the inline_asciihdr PR (https://github.com/memcached/memcached/pull/241)

For multigets and pipelined requests, the cumulative series can potentially be 13.5% faster. Starting from inline_asciihdr PR, with `-o modern -t 20` on a fairly large machine, and mc-crusher's mget test: (in millions of keys per second)

```
    - baseline: 24.2m (no inline)
    - + iov opt: 25.5m
    - + inline LRU bump: 26.8m
    - + bigger suffixlist: 26.9m - more consistent numbers
    - + remove refcount atomics: 28m
```

With inline asciihdr responses enabled (vs dynamic as per the branch) the numbers go even higher. For single-key fetches, I could not measure a difference. Further improvements to the frontend pipeline could make more usage from these optimizations.

I keep putting off a major refactor on the (nearly 11 year old in its current state) frontend code. Now that my internal fiddling is starting to slow down it was worth a shot at some low hanging fruit. When doing the ascii response inlining work I noticed add_iov() taking up a lot of CPU. When reviewing my old notes and the original patch from Steven Grimm it's clear that the pipeline was optimized for (2006-era) UDP traffic. All the extra wrapped code ended up causing a lot of extra work for TCP sockets.

The rest were cruft accrued during my various lock-splitting patches. IE: re-hashing, locking, them LRU-bumping items after hashing, locking, and fetching them. Also continuing to use atomic incr/decr for reference counting after I'd refactored refcounts to only be adjusted under item locks.

Both are now fixed. The baseline for an non-inlined ascii response header on this test machine was 26m. With the full series memory efficiency for small items and performance ends up increased overall still.

I can also make some big improvements to UDP performance. If UDP performance matters to you please let me know and I will implement it sooner than later.