### PR TITLE
Allow switching LRU algo's at runtime

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -404,6 +404,41 @@ The response should always be "OK\r\n"
   there is an eviction. It is not recommended to run for very long in this
   mode unless your access patterns are very well understood.
 
+LRU Tuning
+----------
+
+Memcached supports multiple LRU algorithms, with a few tunables. Effort is
+made to have sane defaults however you are able to tune while the daemon is
+running.
+
+The traditional model is "flat" mode, which is a single LRU chain per slab
+class. The newer (with `-o modern` or `-o lru_maintainer`) is segmented into
+HOT, WARM, COLD. There is also a TEMP LRU. See doc/new_lru.txt for details.
+
+lru <tune|mode|temp_ttl> <option list>
+
+- "tune" takes numeric arguments "percent hot", "percent warm",
+  "max hot age", "max warm age factor". IE: "lru tune 10 25 3600 2.0".
+  This would cap HOT_LRU at 10% of the cache, or tail is idle longer than
+  3600s. WARM_LRU is up to 25% of cache, or tail is idle longer than 2x
+  COLD_LRU.
+
+- "mode" <flat|segmented>: "flat" is traditional mode. "segmented" uses
+  HOT|WARM|COLD split. "segmented" mode requires `-o lru_maintainer` at start
+  time. If switching from segmented to flat mode, the background thread will
+  pull items from HOT|WARM into COLD queue.
+
+- "temp_ttl" <ttl>: If TTL is less than zero, disable usage of TEMP_LRU. If
+  zero or above, items set with a TTL lower than this will go into TEMP_LRU
+  and be unevictable until they naturally expire or are otherwise deleted or
+  replaced.
+
+The response line could be one of:
+
+- "OK" to indicate a successful update of the settings.
+
+- "ERROR [message]" to indicate a failure or improper arguments.
+
 LRU_Crawler
 -----------
 

--- a/items.c
+++ b/items.c
@@ -249,13 +249,11 @@ item *do_item_alloc(char *key, const size_t nkey, const unsigned int flags,
     /* Items are initially loaded into the HOT_LRU. This is '0' but I want at
      * least a note here. Compiler (hopefully?) optimizes this out.
      */
-    if (settings.lru_segmented) {
-        if (settings.temp_lru &&
-                exptime - current_time <= settings.temporary_ttl) {
-            id |= TEMP_LRU;
-        } else {
-            id |= HOT_LRU;
-        }
+    if (settings.temp_lru &&
+            exptime - current_time <= settings.temporary_ttl) {
+        id |= TEMP_LRU;
+    } else if (settings.lru_segmented) {
+        id |= HOT_LRU;
     } else {
         /* There is only COLD in compat-mode */
         id |= COLD_LRU;

--- a/memcached.c
+++ b/memcached.c
@@ -6371,6 +6371,11 @@ int main (int argc, char **argv) {
         exit(EX_USAGE);
     }
 
+    if (settings.temp_lru && !start_lru_maintainer) {
+        fprintf(stderr, "temporary_ttl requires lru_maintainer to be enabled\n");
+        exit(EX_USAGE);
+    }
+
     if (hash_init(hash_type) != 0) {
         fprintf(stderr, "Failed to initialize hash_algorithm!\n");
         exit(EX_USAGE);

--- a/memcached.h
+++ b/memcached.h
@@ -355,6 +355,7 @@ struct settings {
     bool maxconns_fast;     /* Whether or not to early close connections */
     bool lru_crawler;        /* Whether or not to enable the autocrawler thread */
     bool lru_maintainer_thread; /* LRU maintainer background thread */
+    bool lru_segmented;     /* Use split or flat LRU's */
     bool slab_reassign;     /* Whether or not slab reassignment is allowed */
     int slab_automove;     /* Whether or not to automatically move slabs */
     int hashpower_init;     /* Starting hash power level */


### PR DESCRIPTION
If LRU maintainer thread is started, this allows you to switch between "flat"
and "segmented" modes at runtime. The maintainer thread will drain HOT/WARM
LRU's if put into flat mode, and no new items should fill in.

This was much easier than expected...

- [x] Documentation
- [x] Can temp_lru be controlled separately? (ie; allow flat LRU + temp LRU)
- [x] Tests