### PR TITLE
Typo fixes in doc/protocol-binary.xml

### DIFF
--- a/doc/protocol-binary.xml
+++ b/doc/protocol-binary.xml
@@ -900,7 +900,7 @@ CAS          (16-23): 0x0000000000000000
 Extras              :
   delta      (24-31): 0x0000000000000001
   initial    (32-39): 0x0000000000000000
-  exipration (40-43): 0x00000e10
+  expiration (40-43): 0x00000e10
 Key                 : Textual string "counter"
 Value               : None
               </artwork>


### PR DESCRIPTION
Replaced "exipration" by "expiration" in the "Increment, Decrement"
section example.