### PR TITLE
Fix compiler warning with gcc 7.x

### DIFF
--- a/util.c
+++ b/util.c
@@ -18,7 +18,7 @@ void uriencode_init(void) {
         if (isalnum(x) || x == '-' || x == '.' || x == '_' || x == '~') {
             uriencode_map[x] = NULL;
         } else {
-            snprintf(str, 4, "%%%02X", x);
+            snprintf(str, 4, "%%%02hhX", (unsigned char)x);
             uriencode_map[x] = str;
             str += 3; /* lobbing off the \0 is fine */
         }


### PR DESCRIPTION
Building with gcc 7.0.1, util.c has a warning (or an error with -Werror) in -Wformat-truncation.  The error is bogus (gcc uses heuristics to detect possible truncation), but getting rid of it is simple and should be harmless.

```
util.c: In function 'uriencode_init':
util.c:21:30: error: '__builtin___snprintf_chk' output may be truncated before the last format character [-Werror=format-truncation=]
             snprintf(str, 4, "%%%02X", x);
                              ^~~~~~~~
In file included from /usr/include/stdio.h:939:0,
                 from util.c:1:
/usr/include/bits/stdio2.h:64:10: note: '__builtin___snprintf_chk' output between 4 and 5 bytes into a destination of size 4
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```