### PR TITLE
Sleep more aggressively in some threads

### DIFF
--- a/items.c
+++ b/items.c
@@ -1165,7 +1165,9 @@ static void *lru_maintainer_thread(void *arg) {
         }
         if (did_moves == 0) {
             if (to_sleep < MAX_LRU_MAINTAINER_SLEEP)
-                to_sleep += 1000;
+                to_sleep += to_sleep / 8;
+            if (to_sleep > MAX_LRU_MAINTAINER_SLEEP)
+		to_sleep = MAX_LRU_MAINTAINER_SLEEP;
         } else {
             to_sleep /= 2;
             if (to_sleep < MIN_LRU_MAINTAINER_SLEEP)


### PR DESCRIPTION
The logger and lru maintainer threads both adjust how long they sleep
based on how busy they are. This adjustment should be exponential, to more quickly adjust to workloads.

The logger thread in particular would only adjust 50 microseconds at a
time, and was capped at 100 milliseconds of sleep, causing many
unnecessary wakeups on an otherwise idle dev machine. Adjust this cap to 1 second.