### PR TITLE
check an index of histo

### DIFF
--- a/crawler.c
+++ b/crawler.c
@@ -207,7 +207,9 @@ static void crawler_expired_eval(crawler_module_t *cm, item *search, uint32_t hv
         } else {
             rel_time_t ttl_remain = search->exptime - current_time;
             int bucket = ttl_remain / 60;
-            s->histo[bucket]++;
+            if (bucket <= 60) {
+                s->histo[bucket]++;
+            }
         }
     }
     pthread_mutex_unlock(&d->lock);


### PR DESCRIPTION
I got a segmentation fault in production.

```
segfault at 2284c808 ip 0000000000412301 sp 00007f82c65aae80 error 6 in memcached[400000+20000]
```

The version we are using is 1.4.28. The segmentation fault occurs [here](https://github.com/memcached/memcached/blob/1.4.28/items.c#L1302)

I used memcached over than 6 months and 130 servers. But it occurred only once.

Probably `current_time` will be greather than `search->exptime` at items.c#L1300.
But I couldn't reproduce its phenomenon at 1.4.28 and 1.4.36.
However waiting 1 second before `current_time` subtracted from `search->exptime` did easily reproduced.

So check the `bucket` before using. 