### PR TITLE
Avoid segfault if idle_timeout value is missing.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -6303,6 +6303,10 @@ int main (int argc, char **argv) {
                 settings.temporary_ttl = atoi(subopts_value);
                 break;
             case IDLE_TIMEOUT:
+                if (subopts_value == NULL) {
+                    fprintf(stderr, "Missing numeric argument for idle_timeout\n");
+                    return 1;
+                }
                 settings.idle_timeout = atoi(subopts_value);
                 break;
             case WATCHER_LOGBUF_SIZE:


### PR DESCRIPTION
If memcached is called without a numeric argument for the idle_timeout option, so:
  -o idle_timeout
and not:
  -o idle_timeout=60
it segfaults inside stdlib/strtol_l.c:: ____strtol_l_internal from stdlib.h::atoi from the IDLE_TIMEOUT case.
I am using glibc-2.12 on RHEL6.  I think atoi(NULL) is undefined behaviour.
This change guards against this for the the idle_timeout option, in the same manner as the cases that use the subopts_value, printing that the numeric argument is missing for the idle_timeout option.