### PR TITLE
memcached-tool: handling case where keys are set to have no expiration

### DIFF
--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -86,10 +86,10 @@ if ($mode eq 'dump') {
     while (<$sock>){
         last if /^END/;
         if (/^STAT uptime (\d+)/){
-            $uptime = $1 + 0;
+            $uptime = int($1);
         }
         if (/^STAT time (\d+)/){
-            $time = $1 + 0;
+            $time = int($1);
         }
     }
     my $no_expiration_ts = $time - $uptime;
@@ -116,7 +116,7 @@ if ($mode eq 'dump') {
             # return format looks like this
             # ITEM foo [6 b; 1176415152 s]
             if (/^ITEM (\S+) \[.* (\d+) s\]/) {
-                $keyexp{$1} = ( (($2 + 0) == $no_expiration_ts) ? "0" : $2 )
+                $keyexp{$1} = ( (int($2) == $no_expiration_ts) ? "0" : $2 )
             }
         }
 

--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -79,6 +79,20 @@ die "Couldn't connect to $addr\n" unless $sock;
 if ($mode eq 'dump') {
     my %items;
     my $totalitems;
+    my $uptime;
+    my $time;
+
+    print $sock "stats\r\n";
+    while (<$sock>){
+    last if /^END/;
+        if (/^STAT uptime (\d+)/){
+            $uptime = $1 + 0;
+        }
+        if (/^STAT time (\d+)/){
+            $time = $1 + 0;
+        }
+    }
+    my $no_expiration_ts = $time - $uptime;
 
     print $sock "stats items\r\n";
 
@@ -102,7 +116,7 @@ if ($mode eq 'dump') {
             # return format looks like this
             # ITEM foo [6 b; 1176415152 s]
             if (/^ITEM (\S+) \[.* (\d+) s\]/) {
-                $keyexp{$1} = $2;
+                $keyexp{$1} = ( (($2 + 0) == $no_expiration_ts) ? "0" : $2 )
             }
         }
 

--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -84,7 +84,7 @@ if ($mode eq 'dump') {
 
     print $sock "stats\r\n";
     while (<$sock>){
-    last if /^END/;
+        last if /^END/;
         if (/^STAT uptime (\d+)/){
             $uptime = $1 + 0;
         }


### PR DESCRIPTION
What & Why
--------------
`memcached-tool` did not take into account of the special consideration of how `memcache` represents keys with no expiration date (as seen in `stats cachedump output`) as `time - uptime` in the "expiration" field.

Consequently, keys with no expiration would get dumped out as having an expiration.

This PR should fix this.

Notes on memcached `stats cachedump` output of keys with no expiration date 
--------------------------------------------------------------------------------
Getting `time` and `uptime` of this specific memcached instance.
```
# echo "stats" | nc localhost 11211 | grep -E '(time|uptime)'
STAT uptime 23
STAT time 1496670782
```

Note that `time - uptime = 1496670782`.

Setting a key with no expiration time would result in it being represented as `1496670782` as in `stats cachedump` command.

```
set noexpiration 0 0 7
value

STORED
stats cachedump 1 0
ITEM noexpiration [7 b; 1496670759 s]
END
```

Test of this PR
----------------

Set 3 different keys (one of them is set to have no expiration):
```
$ telnet localhost 11211
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
set expiretwohours 0 7200 7
value

STORED
set noexpiration 0 0 7
value

STORED
set expireinsixtydays 0 1501850871 7
value

STORED
stats cachedump 1 0
ITEM expireinsixtydays [7 b; 1501850871 s]
ITEM noexpiration [7 b; 1496666835 s]
ITEM expiretwohours [7 b; 1496674129 s]
END
```

Dumping out the content via `memcached-tool` in this PR:
```
$ memcached-tool 127.0.0.1 dump | tee /tmp/dump
Dumping memcache contents
  Number of buckets: 1
  Number of items  : 3
Dumping bucket 1 - 3 total items
add expireinsixtydays 0 1501850871 7
value

add noexpiration 0 0 7
value

add expiretwohours 0 1496674129 7
value
```

Clear out the cache (simply by restarting memcached):
```
$ sudo service memcached restart
Stopping memcached:                                        [  OK  ]
Starting memcached: WARNING: Setting item max size above 1MB is not recommended!
 Raising this limit increases the minimum memory requirements
 and will decrease your memory efficiency.
                                                           [  OK  ]
```

Loading the dumped contents back to the new memcached:
```
$ cat /tmp/dump  | nc localhost 11211
STORED
STORED
STORED
```

Dumping the contents back:
```
$ telnet localhost 11211
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
stats cachedump 1 0
ITEM expiretwohours [7 b; 1496674129 s]
ITEM noexpiration [7 b; 1496667056 s]
ITEM expireinsixtydays [7 b; 1501850871 s]
END
stats
STAT pid 31282
STAT uptime 64
STAT time 1496667120
[ TRUNCATED FOR BREVITY ]
END
```

Note that `time - uptime = 1496667056` and `noexpiration` key has the "expiration" time stamp properly set.