### PR TITLE
Add curr_connections_pct to "stats".

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -628,6 +628,8 @@ integers separated by a colon (treat this as a floating point number).
 | bytes                 | 64u     | Current number of bytes used              |
 |                       |         | to store items                            |
 | curr_connections      | 32u     | Number of open connections                |
+| curr_connections_pct  | 32u.32u | Number of open connections as a           |
+|                       |         | percentage of the maximum number allowed  |
 | total_connections     | 32u     | Total number of connections opened since  |
 |                       |         | the server started running                |
 | rejected_connections  | 64u     | Conns rejected in maxconns_fast mode      |

--- a/memcached.c
+++ b/memcached.c
@@ -2919,6 +2919,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
 #endif /* !WIN32 */
 
     APPEND_STAT("curr_connections", "%llu", (unsigned long long)stats_state.curr_conns - 1);
+    APPEND_STAT("curr_connections_pct", "%.2f", ((stats_state.curr_conns - 1.f) / settings.maxconns) * 100.f );
     APPEND_STAT("total_connections", "%llu", (unsigned long long)stats.total_conns);
     if (settings.maxconns_fast) {
         APPEND_STAT("rejected_connections", "%llu", (unsigned long long)stats.rejected_conns);


### PR DESCRIPTION
Thanks for memcached.

This PR is to consider adding "curr_connections_pct" to "stats", so that percentage based threshold monitoring of the number of connections does not have to also query "stats settings" to calculate a percentage.
 
I noticed the "stats" output has had some items added ( https://github.com/memcached/memcached/blame/master/memcached.c#L2988 ), I thought I would chance a PR (maybe for the 1.5 release?).  Thank you for your consideration.

Related:
https://github.com/memcached/memcached/wiki/ServerMaint#important-stats 
https://code.google.com/archive/p/memcached/issues/206
