### PR TITLE
Slab automove algorithm revisit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,8 @@ memcached_SOURCES = memcached.c memcached.h \
                     bipbuffer.c bipbuffer.h \
                     logger.c logger.h \
                     crawler.c crawler.h \
-                    itoa_ljust.c itoa_ljust.h
+                    itoa_ljust.c itoa_ljust.h \
+                    slab_automove.c slab_automove.h
 
 if BUILD_CACHE
 memcached_SOURCES += cache.c

--- a/devtools/slab_loadgen
+++ b/devtools/slab_loadgen
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+# Copyright 2017 Facebook
+# Licensed under the same terms as memcached itself.
+
+import argparse
+import socket
+import sys
+import csv
+from time import sleep
+
+parser = argparse.ArgumentParser(description="daemon for emulating set/get pressure")
+parser.add_argument("--host", help="host to connect to",
+                    type=str, default="localhost:11211")
+parser.add_argument("-s", "--sleep", help="seconds between rounds",
+                    type=int, default="1")
+parser.add_argument("-c", "--config", help="load specification file",
+                    type=str, default="./config")
+
+args = parser.parse_args()
+
+# prefix, size, count, do_gets
+with open(args.config, newline='') as f:
+    reader = csv.reader(f)
+    tests = [row for row in reader]
+
+host, port = args.host.split(':')
+
+c = socket.create_connection((host, port), 5)
+s = c.makefile(mode="rw", buffering=1)
+
+global_counter = 0
+
+while True:
+    # LATER: stat argument file
+    # LATER: reload arg file if necessary
+    for test in tests:
+        prefix = test[0]
+        size = int(test[1])
+        count = int(test[2])
+        do_gets = int(test[3])
+        value = 'x'*size
+        # issue N 'noreply' sets per specified size
+        for i in range(count):
+            s.write('set {}{} 0 0 {} noreply\r\n{}\r\n'.format(prefix,global_counter,size,value))
+            global_counter += 1
+        # TODO: issue N gets per specified size?
+    sleep(args.sleep)

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -775,6 +775,10 @@ other stats command.
 | hashpower_init    | 32       | Starting size multiplier for hash table      |
 | slab_reassign     | bool     | Whether slab page reassignment is allowed    |
 | slab_automove     | bool     | Whether slab page automover is enabled       |
+| slab_automove_ratio                                                         |
+|                   | float    | Ratio limit between young/old slab classes   |
+| slab_automove_window                                                        |
+|                   | 32u      | Internal algo tunable for automove           |
 | slab_chunk_max    | 32       | Max slab class size (avoid unless necessary) |
 | hash_algorithm    | char     | Hash table algorithm in use                  |
 | lru_crawler       | bool     | Whether the LRU crawler is enabled           |

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -726,6 +726,9 @@ integers separated by a colon (treat this as a floating point number).
 | slab_reassign_busy_items                                                    |
 |                       | 64u     | Items busy during page move, requiring a  |
 |                       |         | retry before page can be moved.           |
+| slab_reassign_busy_deletes                                                  |
+|                       | 64u     | Items busy during page move, requiring    |
+|                       |         | deletion before page can be moved.        |
 | log_worker_dropped    | 64u     | Logs a worker never wrote due to full buf |
 | log_worker_written    | 64u     | Logs written by a worker, to be picked up |
 | log_watcher_skipped   | 64u     | Logs not sent to slow watchers.           |

--- a/items.h
+++ b/items.h
@@ -46,6 +46,14 @@ void item_stats_sizes_add(item *it);
 void item_stats_sizes_remove(item *it);
 bool item_stats_sizes_status(void);
 
+/* stats getter for slab automover */
+typedef struct {
+    int64_t evicted;
+    int64_t outofmemory;
+    uint32_t age;
+} item_stats_automove;
+void fill_item_stats_automove(item_stats_automove *am);
+
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c, const bool do_update);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv, conn *c);
 void item_stats_reset(void);

--- a/logger.c
+++ b/logger.c
@@ -51,6 +51,9 @@ static const entry_details default_entries[] = {
     [LOGGER_ITEM_STORE] = {LOGGER_ITEM_STORE_ENTRY, 512, LOG_MUTATIONS, NULL},
     [LOGGER_CRAWLER_STATUS] = {LOGGER_TEXT_ENTRY, 512, LOG_SYSEVENTS,
         "type=lru_crawler crawler=%d lru=%s low_mark=%llu next_reclaims=%llu since_run=%u next_run=%d elapsed=%u examined=%llu reclaimed=%llu"
+    },
+    [LOGGER_SLAB_MOVE] = {LOGGER_TEXT_ENTRY, 512, LOG_SYSEVENTS,
+        "type=slab_move src=%d dst=%d"
     }
 };
 

--- a/logger.h
+++ b/logger.h
@@ -19,6 +19,7 @@ enum log_entry_type {
     LOGGER_ITEM_GET,
     LOGGER_ITEM_STORE,
     LOGGER_CRAWLER_STATUS,
+    LOGGER_SLAB_MOVE,
 };
 
 enum log_entry_subtype {

--- a/memcached.c
+++ b/memcached.c
@@ -2966,6 +2966,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
         APPEND_STAT("slab_reassign_evictions_nomem", "%llu", stats.slab_reassign_evictions_nomem);
         APPEND_STAT("slab_reassign_inline_reclaim", "%llu", stats.slab_reassign_inline_reclaim);
         APPEND_STAT("slab_reassign_busy_items", "%llu", stats.slab_reassign_busy_items);
+        APPEND_STAT("slab_reassign_busy_deletes", "%llu", stats.slab_reassign_busy_deletes);
         APPEND_STAT("slab_reassign_running", "%u", stats_state.slab_reassign_running);
         APPEND_STAT("slabs_moved", "%llu", stats.slabs_moved);
     }

--- a/memcached.h
+++ b/memcached.h
@@ -292,6 +292,7 @@ struct stats {
     uint64_t      slab_reassign_inline_reclaim; /* valid items lost during slab move */
     uint64_t      slab_reassign_chunk_rescues; /* chunked-item chunks recovered */
     uint64_t      slab_reassign_busy_items; /* valid temporarily unmovable */
+    uint64_t      slab_reassign_busy_deletes; /* refcounted items killed */
     uint64_t      lru_crawler_starts; /* Number of item crawlers kicked off */
     uint64_t      lru_maintainer_juggles; /* number of LRU bg pokes */
     uint64_t      time_in_listen_disabled_us;  /* elapsed time in microseconds while server unable to process new connections */
@@ -593,6 +594,8 @@ struct slab_rebalance {
     uint32_t evictions_nomem;
     uint32_t inline_reclaim;
     uint32_t chunk_rescues;
+    uint32_t busy_deletes;
+    uint32_t busy_loops;
     uint8_t done;
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -360,6 +360,8 @@ struct settings {
     bool lru_segmented;     /* Use split or flat LRU's */
     bool slab_reassign;     /* Whether or not slab reassignment is allowed */
     int slab_automove;     /* Whether or not to automatically move slabs */
+    double slab_automove_ratio; /* youngest must be within pct of oldest */
+    unsigned int slab_automove_window; /* window mover for algorithm */
     int hashpower_init;     /* Starting hash power level */
     bool shutdown_command; /* allow shutdown command */
     int tail_repair_time;   /* LRU tail refcount leak repair time */

--- a/scripts/memcached-automove
+++ b/scripts/memcached-automove
@@ -87,7 +87,7 @@ def determine_move(history, diffs, totals):
                 break
 
         # are we the oldest slab class? (and a valid target)
-        if age > oldest[1] and slab['total_pages'] > 5:
+        if age > oldest[1] and slab['total_pages'] > 2:
             oldest = (sid, age)
 
         # are we the youngest evicting slab class?

--- a/scripts/memcached-automove
+++ b/scripts/memcached-automove
@@ -45,18 +45,27 @@ def determine_move(history, diffs, totals):
     - if > 2.5 pages of free space without free chunks reducing for N trials,
       and no evictions for N trials, free to global.
     - use ratio of how far apart age can be between slab classes
-    - if get_hits exists, allowable distance in age from the *youngest* slab
+    - TODO: if get_hits exists, allowable distance in age from the *youngest* slab
       class is based on the percentage of get_hits the class gets, against the
       factored max distance, ie:
       1% max delta. youngest is 900, oldest allowable is 900+90
       if class has 30% of get_hits, it can be 930
     - youngest evicting slab class gets page moved to it, if outside ratio max
+    - use age as average over window. smooths over items falling out of WARM.
+      also gives a little weight: if still evicting, a few more pages than
+      necessary may be moved, pulling the classes closer together. Hopefully
+      avoidnig ping-ponging.
     """
+    # rotate windows
+    history['w'].append({})
+    if (len(history['w']) > args.window):
+        history['w'].pop(0)
     w = history['w'][-1]
     oldest = (-1, 0)
     youngest = (-1, sys.maxsize)
     decision = (-1, -1)
     for sid, slab in diffs.items():
+
         w[sid] = {}
         if 'evicted_d' not in slab or 'total_pages_d' not in slab:
             continue
@@ -67,6 +76,8 @@ def determine_move(history, diffs, totals):
         if slab['evicted_d'] > 0:
             w[sid]['dirty'] = 1
             w[sid]['ev'] = 1
+        w[sid]['age'] = slab['age']
+        age = window_check(history, sid, 'age') / len(history['w'])
 
         # if > 2.5 pages free, and not dirty, reassign to global page pool and
         # break.
@@ -76,26 +87,28 @@ def determine_move(history, diffs, totals):
                 break
 
         # are we the oldest slab class? (and a valid target)
-        if slab['age'] > oldest[1] and slab['total_pages'] > 5:
-            oldest = (sid, slab['age'])
+        if age > oldest[1] and slab['total_pages'] > 5:
+            oldest = (sid, age)
 
         # are we the youngest evicting slab class?
-        if slab['age'] < youngest[1] and window_check(history, sid, 'ev') > args.window / 2:
-            youngest = (sid, slab['age'])
+        ev_total = window_check(history, sid, 'ev')
+        window_min = args.window / 2
+        if age < youngest[1] and ev_total > window_min:
+            youngest = (sid, age)
+            #if args.verbose:
+            #    print("window: {} range: {}".format(ev_total, window_min))
 
     # is the youngest slab class too young?
-    if args.verbose:
-        print("old, young:", oldest, youngest)
     if youngest[0] != -1 and oldest[0] != -1:
-        if youngest[1] < oldest[1] * args.ratio:
+        if args.verbose:
+            print("old:   [class: {}] [age: {:.2f}]\nyoung: [class: {}] [age: {:.2f}]".format(
+                int(oldest[0]), oldest[1], int(youngest[0]), youngest[1]))
+        if youngest[1] < oldest[1] * args.ratio and w[youngest[0]].get('ev'):
             decision = (oldest[0], youngest[0])
 
-    # rotate windows
-    history['w'].append({})
-    # TODO: Configurable window size
-    if (len(history['w']) > args.window):
-        history['w'].pop(0)
-    return decision
+    if (len(history['w']) >= args.window):
+        return decision
+    return (-1, -1)
 
 
 def run_move(s, decision):
@@ -106,6 +119,11 @@ def run_move(s, decision):
 
 
 def diff_stats(before, after):
+    """ fills out "diffs" as deltas between before/after,
+    and "totals" as the sum of all slab classes.
+    "_d" postfix to keys means the delta between before/after.
+    non-postfix keys are total as of 'after's reading.
+    """
     diffs = {}
     totals = {}
     for slabid in after.keys():
@@ -160,16 +178,19 @@ def pct(num, divisor):
 
 
 def show_detail(diffs, totals):
-    print("  {:2s}: {:8s} (pct  ) {:10s} (pct    ) {:6s} (pct)".format('sb',
-                'evicted', 'items', 'pages'))
+    """ just a pretty printer for some extra data """
+    print("\n  {:2s}: {:8s} (pct  ) {:10s} (pct    ) {:6s} (pct)   {:6s}".format('sb',
+                'evicted', 'items', 'pages', 'age'))
 
     for sid, slab in diffs.items():
         if 'evicted_d' not in slab:
             continue
-        print("  {:2d}: {:8d} ({:.2f}%) {:10d} ({:.4f}%) {:6d} ({:.2f}%)".format(
+        print("  {:2d}: {:8d} ({:.2f}%) {:10d} ({:.4f}%) {:6d} ({:.2f}%) {:6d}".format(
               int(sid), slab['evicted_d'], pct(slab['evicted_d'], totals['evicted_d']),
               slab['number'], pct(slab['number'], totals['number']),
-              slab['total_pages'], pct(slab['total_pages'], totals['total_pages'])))
+              slab['total_pages'], pct(slab['total_pages'],
+              totals['total_pages']),
+              slab['age']))
 
 
 stats_pre = {}

--- a/slab_automove.c
+++ b/slab_automove.c
@@ -1,0 +1,150 @@
+/*  Copyright 2017 Facebook.
+ *
+ *  Use and distribution licensed under the BSD license.  See
+ *  the LICENSE file for full text.
+ */
+
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+#include "memcached.h"
+#include "slab_automove.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define MIN_PAGES_FOR_SOURCE 2
+#define MIN_PAGES_FOR_RECLAIM 2.5
+
+struct window_data {
+    uint64_t age;
+    uint64_t dirty;
+    uint64_t evicted;
+};
+
+typedef struct {
+    struct window_data *window_data;
+    uint32_t window_size;
+    uint32_t window_cur;
+    double max_age_ratio;
+    item_stats_automove iam_before[MAX_NUMBER_OF_SLAB_CLASSES];
+    item_stats_automove iam_after[MAX_NUMBER_OF_SLAB_CLASSES];
+    slab_stats_automove sam_before[MAX_NUMBER_OF_SLAB_CLASSES];
+    slab_stats_automove sam_after[MAX_NUMBER_OF_SLAB_CLASSES];
+} slab_automove;
+
+void *slab_automove_init(uint32_t window_size, double max_age_ratio) {
+    slab_automove *a = calloc(1, sizeof(slab_automove));
+    if (a == NULL)
+        return NULL;
+    a->window_data = calloc(window_size * MAX_NUMBER_OF_SLAB_CLASSES, sizeof(struct window_data));
+    a->window_size = window_size;
+    a->max_age_ratio = max_age_ratio;
+    if (a->window_data == NULL) {
+        free(a);
+        return NULL;
+    }
+
+    // do a dry run to fill the before structs
+    fill_item_stats_automove(a->iam_before);
+    fill_slab_stats_automove(a->sam_before);
+
+    return (void *)a;
+}
+
+void slab_automove_free(void *arg) {
+    slab_automove *a = (slab_automove *)arg;
+    free(a->window_data);
+    free(a);
+}
+
+static void window_sum(struct window_data *wd, struct window_data *w, uint32_t size) {
+    int x;
+    for (x = 0; x < size; x++) {
+        struct window_data *d = &wd[x];
+        w->age += d->age;
+        w->dirty += d->dirty;
+        w->evicted += d->evicted;
+    }
+}
+
+// TODO: if oldest is dirty, find next oldest.
+// still need to base ratio off of absolute age
+void slab_automove_run(void *arg, int *src, int *dst) {
+    slab_automove *a = (slab_automove *)arg;
+    int n;
+    struct window_data w_sum;
+    int oldest = -1;
+    uint64_t oldest_age = 0;
+    int youngest = -1;
+    uint64_t youngest_age = ~0;
+    bool youngest_evicting = false;
+    *src = -1;
+    *dst = -1;
+
+    // fill after structs
+    fill_item_stats_automove(a->iam_after);
+    fill_slab_stats_automove(a->sam_after);
+    a->window_cur++;
+
+    // iterate slabs
+    for (n = POWER_SMALLEST; n < MAX_NUMBER_OF_SLAB_CLASSES; n++) {
+        int w_offset = n * a->window_size;
+        struct window_data *wd = &a->window_data[w_offset + (a->window_cur % a->window_size)];
+        memset(wd, 0, sizeof(struct window_data));
+        // summarize the window-up-to-now.
+        memset(&w_sum, 0, sizeof(struct window_data));
+        window_sum(&a->window_data[w_offset], &w_sum, a->window_size);
+
+        // if page delta, or evicted delta, mark window dirty
+        // (or outofmemory)
+        if (a->iam_after[n].evicted - a->iam_before[n].evicted > 0 ||
+            a->iam_after[n].outofmemory - a->iam_before[n].outofmemory > 0) {
+            wd->evicted = 1;
+            wd->dirty = 1;
+        }
+        if (a->sam_after[n].total_pages - a->sam_before[n].total_pages > 0) {
+            wd->dirty = 1;
+        }
+
+        // set age into window
+        wd->age = a->iam_after[n].age;
+
+        // grab age as average of window total
+        uint64_t age = w_sum.age / a->window_size;
+
+        // if > N free chunks and not dirty, make decision.
+        if (a->sam_after[n].free_chunks > a->sam_after[n].chunks_per_page * MIN_PAGES_FOR_RECLAIM) {
+            if (w_sum.dirty == 0) {
+                *src = n;
+                *dst = 0;
+                break;
+            }
+        }
+
+        // if oldest and have enough pages, is oldest
+        if (age > oldest_age && a->sam_after[n].total_pages > MIN_PAGES_FOR_SOURCE) {
+            oldest = n;
+            oldest_age = age;
+        }
+
+        // grab evicted count from window
+        // if > half the window and youngest, mark as youngest
+        if (age < youngest_age && w_sum.evicted > a->window_size / 2) {
+            youngest = n;
+            youngest_age = age;
+            youngest_evicting = wd->evicted ? true : false;
+        }
+    }
+
+    memcpy(a->iam_before, a->iam_after,
+            sizeof(item_stats_automove) * MAX_NUMBER_OF_SLAB_CLASSES);
+    memcpy(a->sam_before, a->sam_after,
+            sizeof(slab_stats_automove) * MAX_NUMBER_OF_SLAB_CLASSES);
+    // if we have a youngest and oldest, and oldest is outside the ratio,
+    // also, only make decisions if window has filled once.
+    if (youngest != -1 && oldest != -1 && a->window_cur > a->window_size) {
+        if (youngest_age < ((double)oldest_age * a->max_age_ratio) && youngest_evicting) {
+            *src = oldest;
+            *dst = youngest;
+        }
+    }
+    return;
+}

--- a/slab_automove.h
+++ b/slab_automove.h
@@ -1,0 +1,8 @@
+#ifndef SLAB_AUTOMOVE_H
+#define SLAB_AUTOMOVE_H
+
+void *slab_automove_init(uint32_t window_size, double max_age_ratio);
+void slab_automove_free(void *arg);
+void slab_automove_run(void *arg, int *src, int *dst);
+
+#endif

--- a/slabs.c
+++ b/slabs.c
@@ -375,6 +375,22 @@ static void do_slabs_free(void *ptr, const size_t size, unsigned int id) {
     return;
 }
 
+/* With refactoring of the various stats code the automover won't need a
+ * custom function here.
+ */
+void fill_slab_stats_automove(slab_stats_automove *am) {
+    int n;
+    pthread_mutex_lock(&slabs_lock);
+    for (n = 0; n < MAX_NUMBER_OF_SLAB_CLASSES; n++) {
+        slabclass_t *p = &slabclass[n];
+        slab_stats_automove *cur = &am[n];
+        cur->chunks_per_page = p->perslab;
+        cur->free_chunks = p->sl_curr;
+        cur->total_pages = p->slabs;
+    }
+    pthread_mutex_unlock(&slabs_lock);
+}
+
 static int nz_strcmp(int nzlength, const char *nz, const char *z) {
     int zlength=strlen(z);
     return (zlength == nzlength) && (strncmp(nz, z, zlength) == 0) ? 0 : -1;

--- a/slabs.h
+++ b/slabs.h
@@ -34,6 +34,13 @@ bool slabs_adjust_mem_limit(size_t new_mem_limit);
 /** Return a datum for stats in binary protocol */
 bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 
+typedef struct {
+    unsigned int chunks_per_page;
+    long int free_chunks;
+    long int total_pages;
+} slab_stats_automove;
+void fill_slab_stats_automove(slab_stats_automove *am);
+
 /** Fill buffer with stats */ /*@null@*/
 void slabs_stats(ADD_STAT add_stats, void *c);
 

--- a/t/dyn-maxbytes.t
+++ b/t/dyn-maxbytes.t
@@ -7,7 +7,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $server = new_memcached("-m 3 -o modern");
+my $server = new_memcached("-m 3 -o modern,slab_automove_window=3");
 my $sock = $server->sock;
 my $value = "B"x66560;
 my $key = 0;

--- a/t/slabhang.t
+++ b/t/slabhang.t
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+plan skip_all => 'Test is flaky. Needs special hooks.';
+
+plan tests => 74;
+
+# start up a server with 10 maximum connections
+my $server = new_memcached("-m 16 -o modern");
+my $sock = $server->sock;
+my $hangsock = $server->new_sock;
+my $value = "B"x260144;
+my $key = 0;
+
+# disable the normal automover.
+print $sock "slabs automove 0\r\n";
+is(scalar <$sock>, "OK\r\n", "automover disabled");
+
+# These aren't set to expire.
+my $mget = '';
+for ($key = 0; $key < 70; $key++) {
+    $mget .= "key$key ";
+    print $sock "set key$key 0 0 260144\r\n$value\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored key$key");
+}
+chop $mget;
+
+# Don't intend to read the results, need to fill the socket.
+print $hangsock "get $mget\r\n";
+#sleep 8;
+my $stats = mem_stats($sock, "slabs");
+my $source = 0;
+for my $key (keys %$stats) {
+    if ($key =~ m/^(\d+):total_pages/) {
+        my $sid = $1;
+        if ($stats->{$key} > 10) {
+            $source = $sid;
+            last;
+        }
+    }
+}
+isnt($source, 0, "found the source slab: $source");
+
+my $busy;
+my $tomove = 4;
+my $reassign = "slabs reassign $source 1\r\n";
+while ($tomove) {
+    $busy = 0;
+    print $sock $reassign;
+    my $res = scalar <$sock>;
+    while ($res =~ m/^BUSY/) {
+        if ($hangsock && $busy > 5) {
+            # unjam the pipeline
+            $hangsock->close;
+        }
+        last if ($busy > 10);
+        sleep 1;
+        $busy++;
+        print $sock $reassign;
+        $res = scalar <$sock>;
+    }
+    last if ($busy > 10);
+    $tomove--;
+}
+
+ok($busy <= 10, "didn't time out moving pages");
+
+$stats = mem_stats($sock);
+isnt($stats->{"slab_reassign_busy_deletes"}, "0", "deleted some busy items");

--- a/t/slabs-reassign2.t
+++ b/t/slabs-reassign2.t
@@ -8,7 +8,7 @@ use lib "$Bin/lib";
 use MemcachedTest;
 use Data::Dumper qw/Dumper/;
 
-my $server = new_memcached('-m 60 -o slab_reassign,slab_automove,lru_crawler,lru_maintainer');
+my $server = new_memcached('-m 60 -o slab_reassign,slab_automove,lru_crawler,lru_maintainer,slab_automove_window=3');
 my $sock = $server->sock;
 
 my $value = "B"x11000;
@@ -40,7 +40,7 @@ for (1 .. $todelete) {
     for ($tries = 20; $tries > 0; $tries--) {
         sleep 1;
         my $stats = mem_stats($sock);
-        if ($stats->{slab_global_page_pool} > 0) {
+        if ($stats->{slab_global_page_pool} > 24) {
             last;
         }
     }


### PR DESCRIPTION
A few fixes:

 * If a slab page move loops too often, delete lockable busy items from the cache to unjam it.
 * Improve page balancer python script, adding test util.
 * Convert python script into C, use as new overall mover algorithm.

This can be tuned for more edge cases but I'd prefer to defer.