### PR TITLE
systemd instancing support & rpm build improvements

### DIFF
--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -1,3 +1,21 @@
+# Set with_systemd on distros that use it, so we can install the service
+# file, otherwise the sysvinit script will be installed
+%if 0%{?fedora} >= 14 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1210
+%global with_systemd 1
+BuildRequires: systemd-units
+
+# Disable some systemd safety features on OSes without a new enough systemd
+# (new enough is systemd >= 233)
+%if 0%{?fedora} < 26 || 0%{?rhel} > 0
+%global safer_systemd 0
+%else
+%global safer_systemd 1
+%endif
+
+%else
+%global with_systemd 0
+%endif
+
 Name:           memcached
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}
@@ -6,16 +24,25 @@ Summary:        High Performance, Distributed Memory Object Cache
 Group:          System Environment/Daemons
 License:        BSD
 URL:            http://memcached.org
-Source0:        http://memcached.org/files/%{name}-@FULLVERSION@.tar.gz
+Source0:        http://memcached.org/files/%{name}-%{version}.tar.gz
+Source1:        memcached.sysconfig
+Source2:        memcached.service
+Source3:        memcached@.service
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  libevent-devel
 BuildRequires:  perl(Test::More)
 BuildRequires:  /usr/bin/prove
 Requires: initscripts
+%if %{with_systemd}
+Requires(post):   systemd-units
+Requires(preun):  systemd-units
+Requires(postun): systemd-units
+%else
 Requires(post): /sbin/chkconfig
 Requires(preun): /sbin/chkconfig, /sbin/service
 Requires(postun): /sbin/service
+%endif
 
 %description
 memcached is a high-performance, distributed memory object caching
@@ -23,7 +50,7 @@ system, generic in nature, but intended for use in speeding up dynamic
 web applications by alleviating database load.
 
 %prep
-%setup -q -n %{name}-@FULLVERSION@
+%setup -q -n %{name}-%{version}
 
 
 %build
@@ -31,53 +58,90 @@ web applications by alleviating database load.
 
 make %{?_smp_mflags}
 
+
 %check
 make test
+
 
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
 
 # remove memcached-debug
-rm -f %{buildroot}/%{_bindir}/memcached-debug
+rm -f %{buildroot}/%{_bindir}/%{name}-debug
 
 # Perl script for monitoring memcached
-install -Dp -m0755 scripts/memcached-tool %{buildroot}%{_bindir}/memcached-tool
+install -Dp -m0755 scripts/memcached-tool %{buildroot}%{_bindir}/%{name}-tool
 
 # Init script
-install -Dp -m0755 scripts/memcached.sysv %{buildroot}%{_initrddir}/memcached
+%if %{with_systemd}
+install -Dp -m0755 scripts/memcached.service %{buildroot}%{_unitdir}/%{name}.service
+install -Dp -m0755 scripts/memcached@.service %{buildroot}%{_unitdir}/%{name}@.service
+
+if [ %{safer_systemd} -gt 0 ]; then
+    sed -e -i 's/^##safer##//g' %{buildroot}%{_unitdir}/%{name}.service %{buildroot}%{_unitdir}/%{name}@.service
+else
+    sed -e -i 's/^##safer##/#/g' %{buildroot}%{_unitdir}/%{name}.service %{buildroot}%{_unitdir}/%{name}@.service
+fi
+%else
+install -Dp -m0755 scripts/memcached.sysv %{buildroot}%{_initrddir}/%{name}
+%endif
 
 # Default configs
-mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
-cat <<EOF >%{buildroot}/%{_sysconfdir}/sysconfig/%{name}
-PORT="11211"
-USER="nobody"
-MAXCONN="1024"
-CACHESIZE="64"
-OPTIONS=""
-EOF
+install -Dp -m0644 scripts/memcached.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 
 # pid directory
-mkdir -p %{buildroot}/%{_localstatedir}/run/memcached
+mkdir -p %{buildroot}/%{_localstatedir}/run/%{name}
+
 
 %clean
 rm -rf %{buildroot}
 
 
 %post
-/sbin/chkconfig --add %{name}
+if [ $1 -eq 1 ]; then
+    # Initial install
+%if %{with_systemd}
+    /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+%else
+    /sbin/chkconfig --add %{name}
+%endif
+fi
+
 
 %preun
 if [ "$1" = 0 ] ; then
-    /sbin/service %{name} stop > /dev/null 2>&1
+    # Removal, not upgrade
+%if %{with_systemd}
+    /bin/systemctl --no-reload disable %{name}.service > /dev/null 2>&1 || :
+    /bin/systemctl --no-reload disable %{name}@\*.service > /dev/null 2>&1 || :
+    /bin/systemctl stop %{name}.service > /dev/null 2>&1 || :
+    /bin/systemctl stop %{name}@\*.service > /dev/null 2>&1 || :
+%else
+    /sbin/service %{name} stop > /dev/null 2&>1 || :
     /sbin/chkconfig --del %{name}
+%endif
 fi
+
 exit 0
 
+
 %postun
-if [ "$1" -ge 1 ]; then
-    /sbin/service %{name} condrestart > /dev/null 2>&1
-fi
+%if %{with_systemd}
+    /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+%endif
+
+# Don't auto-restart memcached on upgrade -- let user control when cache flushes
+# if [ "$1" -ge 1 ]; then
+#    # upgrade, not install
+#    %if %{with_systemd}
+#        /bin/systemctl try-restart %{name}.service
+#        /bin/systemctl try-restart %{name}@\*.service
+#    %else
+#        /sbin/service %named condrestart 2>/dev/null || :
+#    %endif
+#fi
+
 exit 0
 
 
@@ -86,14 +150,24 @@ exit 0
 %doc AUTHORS ChangeLog COPYING NEWS README.md doc/CONTRIBUTORS doc/*.txt
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 
-%dir %attr(750,nobody,nobody) %{_localstatedir}/run/memcached
-%{_bindir}/memcached-tool
-%{_bindir}/memcached
-%{_mandir}/man1/memcached.1*
-%{_initrddir}/memcached
-%{_includedir}/memcached
+%dir %attr(750,nobody,nobody) %{_localstatedir}/run/%{name}
+%{_bindir}/%{name}-tool
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1*
+%{_includedir}/%{name}
+
+%if %{with_systemd}
+%{_unitdir}/%{name}.service
+%{_unitdir}/%{name}@.service
+%else
+%{_initrddir}/%{name}
+%endif
 
 %changelog
+* Wed Jul  5 2017 J. Grizzard <jg-github@lupine.org> - 1.4.39
+- Add systemd-aware build
+- Add both static and instanced versions of memcached unit files
+
 * Mon Nov  2 2009 Dormando <dormando@rydia.net> - 1.4.3-1
 - Fix autogen more.
 
@@ -113,7 +187,7 @@ exit 0
 - above suggestions from Bernard Johnson
 
 * Mon May  7 2007 Paul Lindner <lindner@inuus.com> - 1.2.2-2
-- Tidiness improvements suggested by Ruben Kerkhof in bugzilla #238994
+- Tidyness improvements suggested by Ruben Kerkhof in bugzilla #238994
 
 * Fri May  4 2007 Paul Lindner <lindner@inuus.com> - 1.2.2-1
 - Initial spec file created via rpmdev-newspec

--- a/scripts/memcached.sysconfig
+++ b/scripts/memcached.sysconfig
@@ -1,0 +1,10 @@
+# These defaults will be used by every memcached instance, unless overridden
+# by values in /etc/sysconfig/memcached.<port>
+USER="nobody"
+MAXCONN="1024"
+CACHESIZE="64"
+OPTIONS=""
+
+# The PORT variable will only be used by memcached.service, not by
+# memcached@xxxxx services, which will use the xxxxx
+PORT="11211"

--- a/scripts/memcached@.service
+++ b/scripts/memcached@.service
@@ -7,7 +7,11 @@
 #
 #     [Service]
 #     Environment=OPTIONS="-l 127.0.0.1,::1"
-
+#
+# To use the "instanced" version of this, just start 'memcached@11211' or
+# whatever port you'd like. If /etc/sysconfig/memcached.<port> exists, it
+# will be read first, so you can set different parameters for a given
+# instance.
 
 [Unit]
 Description=memcached daemon
@@ -15,7 +19,8 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/sysconfig/memcached
-ExecStart=/usr/bin/memcached -p ${PORT} -u ${USER} -m ${CACHESIZE} -c ${MAXCONN} $OPTIONS
+EnvironmentFile=-/etc/sysconfig/memcached.%i
+ExecStart=/usr/bin/memcached -p %i -u ${USER} -m ${CACHESIZE} -c ${MAXCONN} $OPTIONS
 
 # Set up a new file system namespace and mounts private /tmp and /var/tmp
 # directories so this service cannot access the global directories and


### PR DESCRIPTION
The major things this does are adding systemd support to the rpm .spec
file, and adding systemd instancing support. This means that it is
possible to run multiple memcached instances without having to do
any additional configuration or hack on init scripts.

To use:
    systemctl start memcached@11211 memcached@11311 memcached@11411

sysconfig files at /etc/sysconfig/memcached.<port> will be read as
appropriate, to allow differing configurations per-port. Defaults
will be read from /etc/sysconfig/memcached before the port-specific
settings are read.

You can also still start memcached the standard way just by doing
"systemctl start memcached". This will read /etc/sysconfig/memcached
and nothing else.

The "enhanced security" lines in the existing systemd unit file have
been commented out, because they ause an error on common older versions
of systemd (like what ships with Redhat/CentOS 7). I'm not sure if we
want to have this file default to "what works everywhere" or "what is
more secure"; I can back out this change if needed.

There are two versions of the .service file included, one for standard
memcached invocations and one for instanced invocations. The two are
very similar, but not identical. Ideally, we'd only have one version
in the source tree and we'd massage it with sed or somesuch during the
rpm build, but couldn't think of a super clean way to do that, so erred
on the side of simplicity.

A decent amount of spec file work was needed to enable this functionality.
In the process, I also cleaned up several additional aspects of the spec
file (like using %{name} in places where it was appropriate). I also
commented out the automatic restart in the %postun section, for two main
reasons:

        1. The try-restart for instanced memcached will produce an error if
        instanced memcached isn't in use, which is probably quite confusing to
        people who aren't using that functionality and are just trying to update
        their package. (There's workarounds for this, but I try to keep pre/post
        scripts as simple as humanly possible)

        2. Automatic restarts on updates means the cache gets flushed, which
        means you can no longer safely use large-scale management tools (like
        puppet or chef) to roll out new versions, at least not without a lot
        of planning first. Not automatically dumping someone's caches feels
        safer, here.