### PR TITLE
flip defaults and add getopt_long

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -477,6 +477,7 @@ AC_CHECK_FUNCS(memcntl)
 AC_CHECK_FUNCS(sigignore)
 AC_CHECK_FUNCS(clock_gettime)
 AC_CHECK_FUNCS([accept4], [AC_DEFINE(HAVE_ACCEPT4, 1, [Define to 1 if support accept4])])
+AC_CHECK_FUNCS([getopt_long], [AC_DEFINE(HAVE_GETOPT_LONG, 1, [Define to 1 if support getopt_long])])
 
 AC_DEFUN([AC_C_ALIGNMENT],
 [AC_CACHE_CHECK(for alignment, ac_cv_c_alignment,

--- a/doc/memcached.1
+++ b/doc/memcached.1
@@ -20,16 +20,16 @@ swapping and always use non-blocking I/O.
 These programs follow the usual GNU command line syntax. A summary of options
 is included below.
 .TP
-.B \-s <file>
+.B \-s, --unix-socket=<file>
 Unix socket path to listen on (disables network support).
 .TP
-.B \-A
+.B \-A, --enable-shutdown
 Enable ascii "shutdown" command.
 .TP
-.B \-a <perms>
+.B \-a, --unix-mask=<perms>
 Permissions (in octal format) for Unix socket created with \-s option.
 .TP
-.B \-l <addr>
+.B \-l, --listen=<addr>
 Listen on <addr>; default to INADDR_ANY. <addr> may be specified as host:port.
 If you don't specify a port number, the value you specified with -p or -U is
 used. You may specify multiple addresses separated by comma or by using -l
@@ -37,50 +37,50 @@ multiple times. This is an important option to consider as there is no other
 way to secure the installation. Binding to an internal or firewalled network
 interface is suggested.
 .TP
-.B \-d
+.B \-d, --daemon
 Run memcached as a daemon.
 .TP
-.B \-u <username>
+.B \-u, --user=<username>
 Assume the identity of <username> (only when run as root).
 .TP
-.B \-m <num>
+.B \-m, --memory-limit=<num>
 Use <num> MB memory max to use for object storage; the default is 64 megabytes.
 .TP
-.B \-c <num>
+.B \-c, --conn-limit=<num>
 Use <num> max simultaneous connections; the default is 1024.
 .TP
-.B \-R <num>
+.B \-R, --max-reqs-per-event=<num>
 This option seeks to prevent client starvation by setting a limit to the
 number of sequential requests the server will process from an individual
 client connection. Once a connection has exceeded this value, the server will
 attempt to process I/O on other connections before handling any further
 request from this connection. The default value for this option is 20.
 .TP
-.B \-k
+.B \-k, --lock-memory
 Lock down all paged memory. This is a somewhat dangerous option with large
 caches, so consult the README and memcached homepage for configuration
 suggestions.
 .TP
-.B \-p <num>
+.B \-p, --port=<num>
 Listen on TCP port <num>, the default is port 11211.
 .TP
-.B \-U <num>
+.B \-U, --udp-port=<num>
 Listen on UDP port <num>, the default is port 11211, 0 is off.
 .TP
-.B \-M
+.B \-M, --disable-evictions
 Disable automatic removal of items from the cache when out of memory.
 Additions will not be possible until adequate space is freed up.
 .TP
-.B \-r
+.B \-r, --enable-coredumps
 Raise the core file size limit to the maximum allowable.
 .TP
-.B \-f <factor>
+.B \-f, --slab-growth-factor=<factor>
 Use <factor> as the multiplier for computing the sizes of memory chunks that
 items are stored in. A lower value may result in less wasted memory depending
 on the total amount of memory available and the distribution of item sizes.
 The default is 1.25.
 .TP
-.B \-n <size>
+.B \-n, --slab-min-size=<size>
 Allocate a minimum of <size> bytes for the item key, value, and flags. The
 default is 48. If you have a lot of small keys and values, you can get a
 significant memory efficiency gain with a lower value. If you use a high
@@ -88,13 +88,13 @@ chunk growth factor (\-f option), on the other hand, you may want to increase
 the size to allow a bigger percentage of your items to fit in the most densely
 packed (smallest) chunks.
 .TP
-.B \-C
+.B \-C, --disable-cas
 Disable the use of CAS (and reduce the per-item size by 8 bytes).
 .TP
-.B \-h
+.B \-h, --help
 Show the version of memcached and a summary of options.
 .TP
-.B \-v
+.B \-v, --verbose
 Be verbose during the event loop; print out errors and warnings.
 .TP
 .B \-vv
@@ -104,13 +104,13 @@ responses.
 .B \-vvv
 Be extremely verbose; same of the above and also print internal state transitions.
 .TP
-.B \-i
+.B \-i, --license
 Print memcached and libevent licenses.
 .TP
-.B \-P <filename>
+.B \-P, --pidfile=<filename>
 Print pidfile to <filename>, only used under \-d option.
 .TP
-.B \-t <threads>
+.B \-t, --threads=<threads>
 Number of threads to use to process incoming requests. This option is only
 meaningful if memcached was compiled with thread support enabled. It is
 typically not useful to set this higher than the number of CPU cores on the
@@ -123,44 +123,42 @@ per-prefix stats reporting. The default is ":" (colon). If this option is
 specified, stats collection is turned on automatically; if not, then it may
 be turned on by sending the "stats detail on" command to the server.
 .TP
-.B \-L
+.B \-L, --enable-largepages
 Try to use large memory pages (if available). Increasing the memory page size
 could reduce the number of TLB misses and improve the performance. In order to
 get large pages from the OS, memcached will allocate the total item-cache in
 one large chunk. Only available if supported on your OS.
 .TP
-.B \-b <num>
+.B \-b, --listen-backlog=<num>
 Set the backlog queue limit to <num> connections. The default is 1024.
 .TP
-.B \-B <proto>
+.B \-B, --protocol=<proto>
 Specify the binding protocol to use.  By default, the server will
 autonegotiate client connections.  By using this option, you can
 specify the protocol clients must speak.  Possible options are "auto"
 (the default, autonegotiation behavior), "ascii" and "binary".
 .TP
-.B \-I <size>
+.B \-I, --max-item-size=<size>
 Override the default size of each slab page. The default size is 1mb. Default
 value for this parameter is 1m, minimum is 1k, max is 128m.
 Adjusting this value changes the item size limit.
-Beware that this also increases the number of slabs (use \-v to view), and the
-overall memory usage of memcached.
 .TP
-.B \-S
+.B \-S, --enable-sasl
 Turn on SASL authentication. This option is only meaningful if memcached was
 compiled with SASL support enabled.
 .TP
-.B \-F
+.B \-F, --disable-flush-all
 Disables the "flush_all" command. The cmd_flush counter will increment, but
 clients will receive an error message and the flush will not occur.
 .TP
-.B \-X
+.B \-X, --disable-dumping
 Disables the "stats cachedump" and "lru_crawler metadump" commands.
 .TP
-.B \-o <options>
+.B \-o, --extended=<options>
 Comma separated list of extended or experimental options. See \-h or wiki for
 up to date list.
 .TP
-.B \-V
+.B \-V, --version
 print version and exit
 .br
 .SH LICENSE

--- a/memcached.c
+++ b/memcached.c
@@ -5548,7 +5548,7 @@ static void usage(void) {
            "-V, --version             print version and exit\n"
            "-P, --pidfile=<file>      save PID in <file>, only used with -d option\n"
            "-f, --slab-growth-factor=<num> chunk size growth factor (default: 1.25)\n"
-           "-n, --slab-min-sizee=<bytes> min space used for key+value+flags (default: 48)\n");
+           "-n, --slab-min-size=<bytes> min space used for key+value+flags (default: 48)\n");
     printf("-L, --enable-largepages  try to use large memory pages (if available)\n");
     printf("-D <char>     Use <char> as the delimiter between key prefixes and IDs.\n"
            "              This is used for per-prefix stats reporting. The default is\n"

--- a/memcached.c
+++ b/memcached.c
@@ -5527,99 +5527,85 @@ static void clock_handler(const int fd, const short which, void *arg) {
 
 static void usage(void) {
     printf(PACKAGE " " VERSION "\n");
-    printf("-p <num>      TCP port number to listen on (default: 11211)\n"
-           "-U <num>      UDP port number to listen on (default: 11211, 0 is off)\n"
-           "-s <file>     UNIX socket path to listen on (disables network support)\n"
-           "-A            enable ascii \"shutdown\" command\n"
-           "-a <mask>     access mask for UNIX socket, in octal (default: 0700)\n"
-           "-l <addr>     interface to listen on (default: INADDR_ANY, all addresses)\n"
-           "              <addr> may be specified as host:port. If you don't specify\n"
-           "              a port number, the value you specified with -p or -U is\n"
-           "              used. You may specify multiple addresses separated by comma\n"
-           "              or by using -l multiple times\n"
-
-           "-d            run as a daemon\n"
-           "-r            maximize core file limit\n"
-           "-u <username> assume identity of <username> (only when run as root)\n"
-           "-m <num>      max memory to use for items in megabytes (default: 64 MB)\n"
-           "-M            return error on memory exhausted (rather than removing items)\n"
-           "-c <num>      max simultaneous connections (default: 1024)\n"
-           "-k            lock down all paged memory.  Note that there is a\n"
-           "              limit on how much memory you may lock.  Trying to\n"
-           "              allocate more than that would fail, so be sure you\n"
-           "              set the limit correctly for the user you started\n"
-           "              the daemon with (not for -u <username> user;\n"
-           "              under sh this is done with 'ulimit -S -l NUM_KB').\n"
-           "-v            verbose (print errors/warnings while in event loop)\n"
-           "-vv           very verbose (also print client commands/responses)\n"
-           "-vvv          extremely verbose (also print internal state transitions)\n"
-           "-h            print this help and exit\n"
-           "-i            print memcached and libevent license\n"
-           "-V            print version and exit\n"
-           "-P <file>     save PID in <file>, only used with -d option\n"
-           "-f <factor>   chunk size growth factor (default: 1.25)\n"
-           "-n <bytes>    minimum space allocated for key+value+flags (default: 48)\n");
-    printf("-L            Try to use large memory pages (if available). Increasing\n"
-           "              the memory page size could reduce the number of TLB misses\n"
-           "              and improve the performance. In order to get large pages\n"
-           "              from the OS, memcached will allocate the total item-cache\n"
-           "              in one large chunk.\n");
+    printf("-p, --port=<num>          TCP port to listen on (default: 11211)\n"
+           "-U, --udp-port=<num>      UDP port to listen on (default: 11211, 0 is off)\n"
+           "-s, --unix-socket=<file>  UNIX socket to listen on (disables network support)\n"
+           "-A, --enable-shutdown     enable ascii \"shutdown\" command\n"
+           "-a, --unix-mask=<mask>    access mask for UNIX socket, in octal (default: 0700)\n"
+           "-l, --listen=<addr>       interface to listen on (default: INADDR_ANY)\n"
+           "-d, --daemon              run as a daemon\n"
+           "-r, --enable-coredumps    maximize core file limit\n"
+           "-u, --user=<user>         assume identity of <username> (only when run as root)\n"
+           "-m, --memory-limit=<num>  item memory in megabytes (default: 64 MB)\n"
+           "-M, --disable-evictions   return error on memory exhausted instead of evicting\n"
+           "-c, --conn-limit=<num>    max simultaneous connections (default: 1024)\n"
+           "-k, --lock-memory         lock down all paged memory\n"
+           "-v, --verbose             verbose (print errors/warnings while in event loop)\n"
+           "-vv                       very verbose (also print client commands/responses)\n"
+           "-vvv                      extremely verbose (internal state transitions)\n"
+           "-h, --help                print this help and exit\n"
+           "-i, --license             print memcached and libevent license\n"
+           "-V, --version             print version and exit\n"
+           "-P, --pidfile=<file>      save PID in <file>, only used with -d option\n"
+           "-f, --slab-growth-factor=<num> chunk size growth factor (default: 1.25)\n"
+           "-n, --slab-min-sizee=<bytes> min space used for key+value+flags (default: 48)\n");
+    printf("-L, --enable-largepages  try to use large memory pages (if available)\n");
     printf("-D <char>     Use <char> as the delimiter between key prefixes and IDs.\n"
            "              This is used for per-prefix stats reporting. The default is\n"
            "              \":\" (colon). If this option is specified, stats collection\n"
            "              is turned on automatically; if not, then it may be turned on\n"
            "              by sending the \"stats detail on\" command to the server.\n");
-    printf("-t <num>      number of threads to use (default: 4)\n");
-    printf("-R            Maximum number of requests per event, limits the number of\n"
-           "              requests process for a given connection to prevent \n"
-           "              starvation (default: 20)\n");
-    printf("-C            Disable use of CAS\n");
-    printf("-b <num>      Set the backlog queue limit (default: 1024)\n");
-    printf("-B            Binding protocol - one of ascii, binary, or auto (default)\n");
-    printf("-I            Override the size of each slab page. Adjusts max item size\n"
-           "              (default: 1mb, min: 1k, max: 128m)\n");
+    printf("-t, --threads=<num>       number of threads to use (default: 4)\n");
+    printf("-R, --max-reqs-per-event  maximum number of requests per event, limits the\n"
+           "                          requests processed per connection to prevent \n"
+           "                          starvation (default: 20)\n");
+    printf("-C, --disable-cas         disable use of CAS\n");
+    printf("-b, --listen-backlog=<num> set the backlog queue limit (default: 1024)\n");
+    printf("-B, --protocol=<name>     protocol - one of ascii, binary, or auto (default)\n");
+    printf("-I, --max-item-size=<num> adjusts max item size\n"
+           "                          (default: 1mb, min: 1k, max: 128m)\n");
 #ifdef ENABLE_SASL
-    printf("-S            Turn on Sasl authentication\n");
+    printf("-S, --enable-sasl         turn on Sasl authentication\n");
 #endif
-    printf("-F            Disable flush_all command\n");
-    printf("-X            Disable stats cachedump and lru_crawler metadump commands\n");
-    printf("-o            Comma separated list of extended or experimental options\n"
-           "              - maxconns_fast: immediately close new\n"
-           "                connections if over maxconns limit\n"
-           "              - hashpower: An integer multiplier for how large the hash\n"
-           "                table should be. Can be grown at runtime if not big enough.\n"
-           "                Set this based on \"STAT hash_power_level\" before a \n"
-           "                restart.\n"
-           "              - tail_repair_time: Time in seconds that indicates how long to wait before\n"
-           "                forcefully taking over the LRU tail item whose refcount has leaked.\n"
-           "                Disabled by default; dangerous option.\n"
-           "              - hash_algorithm: The hash table algorithm\n"
-           "                default is jenkins hash. options: jenkins, murmur3\n"
-           "              - lru_crawler: Enable LRU Crawler background thread\n"
-           "              - lru_crawler_sleep: Microseconds to sleep between items\n"
-           "                default is 100.\n"
-           "              - lru_crawler_tocrawl: Max items to crawl per slab per run\n"
-           "                default is 0 (unlimited)\n"
-           "              - lru_maintainer: Enable new LRU system + background thread\n"
-           "              - hot_lru_pct: Pct of slab memory to reserve for hot lru.\n"
-           "                (requires lru_maintainer)\n"
-           "              - warm_lru_pct: Pct of slab memory to reserve for warm lru.\n"
-           "                (requires lru_maintainer)\n"
-           "              - hot_max_factor: Items idle longer than cold lru age * drop from hot lru.\n"
-           "              - warm_max_factor: Items idle longer than cold lru age * this drop from warm.\n"
-           "              - temporary_ttl: TTL's below this use separate LRU, cannot be evicted.\n"
-           "                (requires lru_maintainer)\n"
-           "              - idle_timeout: Timeout for idle connections\n"
-           "              - (EXPERIMENTAL) slab_chunk_max: Maximum slab size. Do not change without extreme care.\n"
-           "              - watcher_logbuf_size: Size in kilobytes of per-watcher write buffer.\n"
-           "              - worker_logbuf_Size: Size in kilobytes of per-worker-thread buffer\n"
-           "                read by background thread. Which is then written to watchers.\n"
-           "              - track_sizes: Enable dynamic reports for 'stats sizes' command.\n"
-           "              - no_inline_ascii_resp: Save up to 24 bytes per item. Small perf hit in ASCII,\n"
-           "                no perf difference in binary protocol. Speeds up sets.\n"
-           "              - modern: Enables 'modern' defaults. Options that will be default in future.\n"
-           "                enables: slab_chunk_max:512k,slab_reassign,slab_automove=1,maxconns_fast,\n"
-           "                         hash_algorithm=murmur3,lru_crawler,lru_maintainer,no_inline_ascii_resp\n"
+    printf("-F, --disable-flush-all   disable flush_all command\n");
+    printf("-X, --disable-dumping     disable stats cachedump and lru_crawler metadump\n");
+    printf("-o, --extended            comma separated list of extended options\n"
+           "                          most options have a 'no_' prefix to disable\n"
+           "   - maxconns_fast:       immediately close new connections after limit\n"
+           "   - hashpower:           an integer multiplier for how large the hash\n"
+           "                          table should be. normally grows at runtime.\n"
+           "                          set based on \"STAT hash_power_level\"\n"
+           "   - tail_repair_time:    time in seconds for how long to wait before\n"
+           "                          forcefully killing LRU tail item.\n"
+           "                          disabled by default; very dangerous option.\n"
+           "   - hash_algorithm:      the hash table algorithm\n"
+           "                          default is murmur3 hash. options: jenkins, murmur3\n"
+           "   - lru_crawler:         enable LRU Crawler background thread\n"
+           "   - lru_crawler_sleep:   microseconds to sleep between items\n"
+           "                          default is 100.\n"
+           "   - lru_crawler_tocrawl: max items to crawl per slab per run\n"
+           "                          default is 0 (unlimited)\n"
+           "   - lru_maintainer:      enable new LRU system + background thread\n"
+           "   - hot_lru_pct:         pct of slab memory to reserve for hot lru.\n"
+           "                          (requires lru_maintainer)\n"
+           "   - warm_lru_pct:        pct of slab memory to reserve for warm lru.\n"
+           "                          (requires lru_maintainer)\n"
+           "   - hot_max_factor:      items idle > cold lru age * drop from hot lru.\n"
+           "   - warm_max_factor:     items idle > cold lru age * this drop from warm.\n"
+           "   - temporary_ttl:       TTL's below get separate LRU, can't be evicted.\n"
+           "                          (requires lru_maintainer)\n"
+           "   - idle_timeout:        timeout for idle connections\n"
+           "   - slab_chunk_max:      (EXPERIMENTAL) maximum slab size. use extreme care.\n"
+           "   - watcher_logbuf_size: size in kilobytes of per-watcher write buffer.\n"
+           "   - worker_logbuf_size:  size in kilobytes of per-worker-thread buffer\n"
+           "                          read by background thread, then written to watchers.\n"
+           "   - track_sizes:         enable dynamic reports for 'stats sizes' command.\n"
+           "   - no_inline_ascii_resp: save up to 24 bytes per item.\n"
+           "                           small perf hit in ASCII, no perf difference in\n"
+           "                           binary protocol. speeds up all sets.\n"
+           "   - modern:              enables options which will be default in future.\n"
+           "             currently: nothing\n"
+           "   - no_modern:           uses defaults of previous major version (1.4.x)\n"
            );
     return;
 }
@@ -6024,13 +6010,13 @@ int main (int argc, char **argv) {
 #ifdef HAVE_GETOPT_LONG
     const struct option longopts[] = {
         {"unix-mask", required_argument, 0, 'a'},
-        {"enable-shutdown-cmd", no_argument, 0, 'A'},
+        {"enable-shutdown", no_argument, 0, 'A'},
         {"port", required_argument, 0, 'p'},
-        {"unix-socket-path", required_argument, 0, 's'},
+        {"unix-socket", required_argument, 0, 's'},
         {"udp-port", required_argument, 0, 'U'},
         {"memory-limit", required_argument, 0, 'm'},
         {"disable-evictions", no_argument, 0, 'M'},
-        {"max-connections", required_argument, 0, 'c'},
+        {"conn-limit", required_argument, 0, 'c'},
         {"lock-memory", no_argument, 0, 'k'},
         {"help", no_argument, 0, 'h'},
         {"license", no_argument, 0, 'i'},
@@ -6052,7 +6038,7 @@ int main (int argc, char **argv) {
         {"max-item-size", required_argument, 0, 'I'},
         {"enable-sasl", no_argument, 0, 'S'},
         {"disable-flush-all", no_argument, 0, 'F'},
-        {"disable-dump-cmds", no_argument, 0, 'X'},
+        {"disable-dumping", no_argument, 0, 'X'},
         {"extended", required_argument, 0, 'o'},
         {0, 0, 0, 0}
     };

--- a/t/binary.t
+++ b/t/binary.t
@@ -7,7 +7,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $server = new_memcached();
+my $server = new_memcached("-o no_modern");
 ok($server, "started the server");
 
 # Based almost 100% off testClient.py which is:
@@ -122,7 +122,7 @@ $empty->('y');
 
 {
     # diag "Some chunked item tests";
-    my $s2 = new_memcached('-o slab_chunk_max=4096');
+    my $s2 = new_memcached('-o no_modern,slab_chunk_max=4096');
     ok($s2, "started the server");
     my $m2 = MC::Client->new($s2);
     # Specifically trying to cross the chunk boundary when internally

--- a/t/issue_183.t
+++ b/t/issue_183.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $server = new_memcached();
+my $server = new_memcached("-o no_modern");
 my $sock = $server->sock;
 print $sock "set key 0 0 1\r\n1\r\n";
 is (scalar <$sock>, "STORED\r\n", "stored key");

--- a/t/issue_42.t
+++ b/t/issue_42.t
@@ -6,7 +6,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $server = new_memcached();
+my $server = new_memcached("-o no_modern");
 my $sock = $server->sock;
 my $value = "B"x10;
 my $key = 0;

--- a/t/lru-crawler.t
+++ b/t/lru-crawler.t
@@ -7,7 +7,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $server = new_memcached('-m 32');
+my $server = new_memcached('-m 32 -o no_modern');
 {
     my $stats = mem_stats($server->sock, ' settings');
     is($stats->{lru_crawler}, "no");
@@ -76,7 +76,7 @@ is(scalar <$sock>, "OK\r\n", "disabled lru crawler");
 $server->stop;
 
 # Test initializing crawler from starttime.
-$server = new_memcached('-m 32 -o lru_crawler');
+$server = new_memcached('-m 32 -o no_modern,lru_crawler');
 $sock = $server->sock;
 
 for (1 .. 30) {

--- a/t/lru.t
+++ b/t/lru.t
@@ -7,7 +7,7 @@ use lib "$Bin/lib";
 use MemcachedTest;
 
 # assuming max slab is 1M and default mem is 64M
-my $server = new_memcached();
+my $server = new_memcached('-o no_modern');
 my $sock = $server->sock;
 
 # create a big value for the largest slab

--- a/t/stats.t
+++ b/t/stats.t
@@ -24,7 +24,7 @@ my $sock = $server->sock;
 my $stats = mem_stats($sock);
 
 # Test number of keys
-is(scalar(keys(%$stats)), 59, "59 stats values");
+is(scalar(keys(%$stats)), 78, "expected count of stats values");
 
 # Test initial state
 foreach my $key (qw(curr_items total_items bytes cmd_get cmd_set get_hits evictions get_misses get_expired


### PR DESCRIPTION
what was `-o modern` in 1.4.x is default after this change, for 1.5.x. Adds `-o no_modern` to go back in time, within reason. Also adds no_* options where possible. Some of these will deprecate later.

allow getopt_long if it exists. if anyone has feedback for the option names, now's your one and probably only chance :)

-o -> --extended, but some of those options should be top level. can fix in
future iterations.

TODO:
- [x] fix tests (most pass!)
- [x] update -h and manpage for changes and _long.