### PR TITLE
Rework pledge support after seccomp support has been added

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,10 @@ if BUILD_LINUX_PRIVS
 memcached_SOURCES += linux_priv.c
 endif
 
+if BUILD_OPENBSD_PRIVS
+memcached_SOURCES += openbsd_priv.c
+endif
+
 if ENABLE_SASL
 memcached_SOURCES += sasl_defs.c
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -577,8 +577,17 @@ AS_IF([test "x$enable_seccomp" = "xyes" ], [
    ], [])
 ])
 
+AC_CHECK_FUNCS(pledge, [
+   AC_CHECK_HEADER(unistd.h, [
+      AC_DEFINE([HAVE_DROP_PRIVILEGES], 1,
+         [Define this if you have an implementation of drop_privileges()])
+      build_openbsd_privs=yes
+   ], [])
+],[])
+
 AM_CONDITIONAL([BUILD_SOLARIS_PRIVS],[test "$build_solaris_privs" = "yes"])
 AM_CONDITIONAL([BUILD_LINUX_PRIVS],[test "$build_linux_privs" = "yes"])
+AM_CONDITIONAL([BUILD_OPENBSD_PRIVS],[test "$build_openbsd_privs" = "yes"])
 
 AC_CHECK_HEADER(umem.h, [
    AC_DEFINE([HAVE_UMEM_H], 1,

--- a/openbsd_priv.c
+++ b/openbsd_priv.c
@@ -1,0 +1,28 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "memcached.h"
+
+/*
+ * this section of code will drop all (OpenBSD) privileges including
+ * those normally granted to all userland process (basic privileges). The
+ * effect of this is that after running this code, the process will not able
+ * to fork(), exec(), etc.  See pledge(2) for more information.
+ */
+void drop_privileges() {
+    extern char *__progname;
+
+    if (settings.socketpath != NULL) {
+       if (pledge("stdio unix", NULL) == -1) {
+          fprintf(stderr, "%s: pledge: %s\n", __progname, strerror(errno));
+          exit(EXIT_FAILURE);
+       }
+    } else {
+       if (pledge("stdio inet", NULL) == -1) {
+          fprintf(stderr, "%s: pledge: %s\n", __progname, strerror(errno));
+          exit(EXIT_FAILURE);
+       }
+     }
+}


### PR DESCRIPTION
Re-add pledge support,
now that seccomp(2) support has been imported and there is a save_pid(...) function it is even easier because it doesn't need anymore permissions to create pid files.