### PR TITLE
fix gcc warnings

### DIFF
--- a/items.c
+++ b/items.c
@@ -925,7 +925,7 @@ void item_stats_sizes(ADD_STAT add_stats, void *c) {
         int i;
         for (i = 0; i < stats_sizes_buckets; i++) {
             if (stats_sizes_hist[i] != 0) {
-                char key[8];
+                char key[12];
                 snprintf(key, sizeof(key), "%d", i * 32);
                 APPEND_STAT(key, "%u", stats_sizes_hist[i]);
             }

--- a/memcached.c
+++ b/memcached.c
@@ -3338,7 +3338,7 @@ static void process_stats_conns(ADD_STAT add_stats, void *c) {
     int i;
     char key_str[STAT_KEY_LEN];
     char val_str[STAT_VAL_LEN];
-    char conn_name[MAXPATHLEN + sizeof("unix:")];
+    char conn_name[MAXPATHLEN + sizeof("unix:") + sizeof("65535")];
     int klen = 0, vlen = 0;
 
     assert(add_stats);


### PR DESCRIPTION
This patch fixes the following errors, when building memcached on the current Fedora rawhide with a gcc-8.0 prerelease:
```
gcc -DHAVE_CONFIG_H -I.     -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -pie -fpie -pthread -pthread -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -c -o memcached.o memcached.c
memcached.c: In function ‘process_stats_conns.constprop’:
memcached.c:3330:33: error: ‘%u’ directive writing between 1 and 5 bytes into a region of size between 1 and 4099 [-Werror=format-overflow=]
             sprintf(buf, "%s:%s:%u", protoname, addr_text, port);
                                 ^~
memcached.c:3330:26: note: directive argument in the range [1, 65535]
             sprintf(buf, "%s:%s:%u", protoname, addr_text, port);
                          ^~~~~~~~~~
In file included from /usr/include/stdio.h:862,
                 from /usr/include/event2/event.h:195,
                 from /usr/include/event.h:71,
                 from memcached.h:16,
                 from memcached.c:16:
/usr/include/bits/stdio2.h:33:10: note: ‘__builtin___sprintf_chk’ output between 5 and 4107 bytes into a destination of size 4102
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
```
gcc -DHAVE_CONFIG_H -I.  -DNDEBUG   -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -pie -fpie -pthread -pthread -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -c -o memcached-items.o `test -f 'items.c' || echo './'`items.c
items.c: In function ‘item_stats_sizes’:
items.c:929:45: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 8 [-Werror=format-truncation=]
                 snprintf(key, sizeof(key), "%d", i * 32);
                                             ^~
items.c:929:44: note: directive argument in the range [0, 2147483647]
                 snprintf(key, sizeof(key), "%d", i * 32);
                                            ^~~~
In file included from /usr/include/stdio.h:862,
                 from /usr/include/event2/event.h:195,
                 from /usr/include/event.h:71,
                 from memcached.h:16,
                 from items.c:2:
/usr/include/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 2 and 11 bytes into a destination of size 8
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```