### PR TITLE
Slab automover fixes

### DIFF
--- a/scripts/memcached-automove-extstore
+++ b/scripts/memcached-automove-extstore
@@ -295,15 +295,16 @@ while True:
                 (diffs, totals) = diff_stats(stats_pre, stats_post)
                 #if args.verbose:
                 #    show_detail(diffs, totals)
-                if (last_memfree_check < time() - 60) and totals.get('total_pages'):
-                    memfree = memfree_check(s, diffs, totals)
-                    last_memfree_check = time()
-                decision = (-1, -1)
-                decision = determine_move(history, stats, diffs, memfree)
-                if int(decision[0]) > 0 and int(decision[1]) >= 0:
-                    print("moving page from, to:", decision)
-                    if args.automove:
-                        run_move(s, decision)
+                if int(stats['evictions']) > 0:
+                    if (last_memfree_check < time() - 60) and totals.get('total_pages'):
+                        memfree = memfree_check(s, diffs, totals)
+                        last_memfree_check = time()
+                    decision = (-1, -1)
+                    decision = determine_move(history, stats, diffs, memfree)
+                    if int(decision[0]) > 0 and int(decision[1]) >= 0:
+                        print("moving page from, to:", decision)
+                        if args.automove:
+                            run_move(s, decision)
 
                 # Minimize sleeping if we just moved a page to global pool.
                 # Improves responsiveness during flushes/quick changes.

--- a/scripts/memcached-automove-extstore
+++ b/scripts/memcached-automove-extstore
@@ -55,17 +55,17 @@ def window_key_check(history, key):
 def determine_move(history, stats, diffs, memfree):
     """ Figure out of a page move is in order.
 
-    - we should use as much memory as possible to buffer items, reducing
-      the load on flash.
+    - Use as much memory as possible to hold items, reducing the load on
+      flash.
     - tries to keep the global free page pool inbetween poolmin/poolmax.
     - avoids flapping as much as possible:
       - only pull pages off of a class if it hasn't recently evicted or allocated pages.
-      - only pull pages off if a sufficient number of chunks are available.
+      - only pull pages off if a sufficient number of free chunks are available.
       - if global pool is below minimum remove pages from oldest large class.
       - if global pool is above maximum, move pages to youngest large class.
-    - re-adjusts number of free chunks once per minute, based on usage.
-    - age balancing should move memory around large classes, which then
-      adjusts the per-class free chunk minimums.
+    - extstore manages a desired number of free chunks in each slab class.
+    - autmover adjusts above limits once per minute based on current sizes.
+    - if youngest is below the age ratio limit of oldest, move a page to it.
     """
     # rotate windows
     history['w'].append({})
@@ -88,6 +88,7 @@ def determine_move(history, stats, diffs, memfree):
     pool_high = window_key_check(history, 'slab_pool_high')
     for sid, slab in diffs.items():
         small_slab = False
+        free_enough = False
         # Only balance larger slab classes
         if slab['chunk_size'] < args.size:
             small_slab = True
@@ -102,7 +103,9 @@ def determine_move(history, stats, diffs, memfree):
         if slab['evicted_d'] > 0:
             w[sid]['dirty'] = 1
             w[sid]['ev'] = 1
-        if slab['free_chunks'] > memfree[sid] and memfree[sid] > 0:
+        if slab['free_chunks'] > memfree[sid]:
+            free_enough = True
+        if memfree[sid] > 0 and slab['free_chunks'] > (memfree[sid] * 2):
             w[sid]['excess_free'] = 1
         w[sid]['age'] = slab['age']
         age = window_check(history, sid, 'age') / len(history['w'])
@@ -121,24 +124,25 @@ def determine_move(history, stats, diffs, memfree):
                 too_free = True
 
         # are we the oldest slab class? (and a valid target)
+        # don't consider for young if we've recently given it unused memory
         if small_slab == False:
             if age > oldest[1] and slab['total_pages'] > MIN_PAGES_FOR_SOURCE:
                 oldest = (sid, age)
             if age < youngest[1] and slab['total_pages'] > 0 \
-                    and window_check(history, sid, 'excess_free') < len(history['w']):
+                    and window_check(history, sid, 'excess_free') < len(history['w']) \
+                    and not (window_check(history, sid, 'relaxed') and free_enough):
                 youngest = (sid, age)
 
 
     if w.get('slab_pool_high') and youngest[0] != -1:
         # if global pool is too high, feed youngest large class.
-        # decision = (0, youngest[0])
-        # No current way to assign directly from global to a class.
-        # minimize the free chunks limiter and re-check.
-        decision = (youngest[0], -2)
+        if slab['free_chunks'] <= memfree[youngest[0]]:
+            decision = (0, youngest[0])
+        w[youngest[0]]['relaxed'] = 1
     elif too_free == False and pool_low and oldest[0] != -1:
         # if pool is too low, take from oldest large class.
         if args.verbose:
-            print("oldest:  [class: {}] [age: {}]".format(int(oldest[0]), oldest[1]))
+            print("oldest:  [class: {}] [age: {:.2f}]".format(int(oldest[0]), oldest[1]))
         decision = (oldest[0], 0)
     elif too_free == False and youngest[0] != -1 and oldest[0] != -1 and youngest[0] != oldest[0]:
         # youngest is outside of the tolerance ratio, move a page around.
@@ -148,8 +152,10 @@ def determine_move(history, stats, diffs, memfree):
 
         slab = diffs[youngest[0]]
         #print("F:{} L:{} Y:{} R:{}".format(slab['free_chunks'], memfree[youngest[0]], int(youngest[1]), int(oldest[1] * args.ratio)))
-        if (slab['free_chunks'] <= memfree[youngest[0]]) and (youngest[1] < oldest[1] * args.ratio):
-            decision = (oldest[0], youngest[0])
+        if youngest[1] < oldest[1] * args.ratio:
+            w[youngest[0]]['relaxed'] = 1
+            if slab['free_chunks'] <= memfree[youngest[0]]:
+                decision = (0, youngest[0])
 
     if (len(history['w']) >= args.window):
         return decision
@@ -293,23 +299,11 @@ while True:
                     memfree = memfree_check(s, diffs, totals)
                     last_memfree_check = time()
                 decision = (-1, -1)
-                if int(stats['evictions']) > 0:
-                    decision = determine_move(history, stats, diffs, memfree)
-                    if int(decision[0]) > 0 and int(decision[1]) >= 0:
-                        print("moving page from, to:", decision)
-                        if args.automove:
-                            run_move(s, decision)
-                    elif int(decision[0]) > 0 and decision[1] == -2:
-                        # we've been told to zero out the memory limit.
-                        # let the memfree check run "soon".
-                        # this (purposefully) can slowly remove limits on
-                        # multiple classes if global pool stays too high.
-                        last_memfree_check = time() - 58
-                        s.write("extstore free_memchunks {} {}\r\n".format(decision[0], 0))
-                        s.readline()
-                        if args.verbose:
-                            print("relaxing free:", decision[0])
-
+                decision = determine_move(history, stats, diffs, memfree)
+                if int(decision[0]) > 0 and int(decision[1]) >= 0:
+                    print("moving page from, to:", decision)
+                    if args.automove:
+                        run_move(s, decision)
 
                 # Minimize sleeping if we just moved a page to global pool.
                 # Improves responsiveness during flushes/quick changes.

--- a/slab_automove_extstore.c
+++ b/slab_automove_extstore.c
@@ -20,6 +20,7 @@ struct window_data {
     uint64_t dirty;
     uint64_t evicted;
     unsigned int excess_free;
+    unsigned int relaxed;
 };
 
 struct window_global {
@@ -90,6 +91,7 @@ static void window_sum(struct window_data *wd, struct window_data *w,
         w->dirty += d->dirty;
         w->evicted += d->evicted;
         w->excess_free += d->excess_free;
+        w->relaxed += d->relaxed;
     }
 }
 
@@ -121,6 +123,15 @@ static void global_pool_check(slab_automove *a) {
     }
 }
 
+/* A percentage of memory is configured to be held "free" as buffers for the
+ * external storage system.
+ * % of global memory is desired in the global page pool
+ * each slab class has a % of free chunks desired based on how much memory is
+ * currently in the class. This allows time for extstore to flush data when
+ * spikes or waves of set data arrive.
+ * The global page pool reserve acts as a secondary buffer for any slab class,
+ * which helps absorb shifts in which class is active.
+ */
 static void memcheck(slab_automove *a) {
     unsigned int total_pages = 0;
     if (current_time < a->last_memcheck_run + MEMCHECK_PERIOD)
@@ -141,6 +152,11 @@ static void memcheck(slab_automove *a) {
     // remember to add what remains in global pool.
     total_pages += a->sam_after[0].total_pages;
     a->free_mem[0] = total_pages * a->free_ratio;
+}
+
+static struct window_data *get_window_data(slab_automove *a, int class) {
+    int w_offset = class * a->window_size;
+    return &a->window_data[w_offset + (a->window_cur % a->window_size)];
 }
 
 void slab_automove_extstore_run(void *arg, int *src, int *dst) {
@@ -170,15 +186,16 @@ void slab_automove_extstore_run(void *arg, int *src, int *dst) {
     for (n = POWER_SMALLEST; n < MAX_NUMBER_OF_SLAB_CLASSES; n++) {
         bool small_slab = a->sam_before[n].chunk_size < a->item_size
             ? true : false;
-        int w_offset = n * a->window_size;
-        struct window_data *wd = &a->window_data[w_offset + (a->window_cur % a->window_size)];
+        bool free_enough = false;
+        struct window_data *wd = get_window_data(a, n);
         // summarize the window-up-to-now.
         memset(&w_sum, 0, sizeof(struct window_data));
+        int w_offset = n * a->window_size;
         window_sum(&a->window_data[w_offset], &w_sum, a->window_size);
         memset(wd, 0, sizeof(struct window_data));
 
-        // if page delta, or evicted delta, mark window dirty
-        // (or outofmemory)
+        // if page delta, oom, or evicted delta, mark window dirty
+        // classes marked dirty cannot donate memory back to global pool.
         if (a->iam_after[n].evicted - a->iam_before[n].evicted > 0 ||
             a->iam_after[n].outofmemory - a->iam_before[n].outofmemory > 0) {
             wd->evicted = 1;
@@ -188,7 +205,14 @@ void slab_automove_extstore_run(void *arg, int *src, int *dst) {
             wd->dirty = 1;
         }
         // Mark excess free if we're over the free mem limit for too long.
-        if (a->sam_after[n].free_chunks > a->free_mem[n] && a->free_mem[n] > 0) {
+        // "free_enough" means it is either wobbling, recently received a new
+        // page of memory, or the crawler is freeing memory.
+        if (a->sam_after[n].free_chunks > a->free_mem[n]) {
+            free_enough = true;
+        }
+        // double the free requirements means we may have memory we can
+        // reclaim to global, if it stays this way for the whole window.
+        if (a->sam_after[n].free_chunks > (a->free_mem[n] * 2) && a->free_mem[n] > 0) {
             wd->excess_free = 1;
         }
 
@@ -198,7 +222,9 @@ void slab_automove_extstore_run(void *arg, int *src, int *dst) {
         // grab age as average of window total
         uint64_t age = w_sum.age / a->window_size;
 
-        // if > N free chunks and not dirty, make decision.
+        // if > N free chunks and not dirty, reclaim memory
+        // small slab classes aren't age balanced and rely more on global
+        // pool. reclaim them more aggressively.
         if (a->sam_after[n].free_chunks > a->sam_after[n].chunks_per_page * MIN_PAGES_FOR_RECLAIM
                 && w_sum.dirty == 0) {
             if (small_slab) {
@@ -214,19 +240,22 @@ void slab_automove_extstore_run(void *arg, int *src, int *dst) {
             }
         }
 
-        // if oldest and have enough pages, is oldest
-        if (!small_slab
-                && age > oldest_age
-                && a->sam_after[n].total_pages > MIN_PAGES_FOR_SOURCE) {
-            oldest = n;
-            oldest_age = age;
-        }
+        if (!small_slab) {
+            // if oldest and have enough pages, is oldest
+            if (age > oldest_age
+                    && a->sam_after[n].total_pages > MIN_PAGES_FOR_SOURCE) {
+                oldest = n;
+                oldest_age = age;
+            }
 
-        // don't count as youngest if it hasn't been using new chunks.
-        if (!small_slab && age < youngest_age && a->sam_after[n].total_pages != 0
-                && w_sum.excess_free < a->window_size) {
-            youngest = n;
-            youngest_age = age;
+            // don't count as youngest if it hasn't been using new chunks.
+            // (if it was relaxed recently, and is currently "free enough")
+            if (age < youngest_age && a->sam_after[n].total_pages != 0
+                    && w_sum.excess_free < a->window_size
+                    && !(w_sum.relaxed && free_enough)) {
+                youngest = n;
+                youngest_age = age;
+            }
         }
     }
 
@@ -239,28 +268,29 @@ void slab_automove_extstore_run(void *arg, int *src, int *dst) {
         return;
 
     if (wg_sum.pool_high >= a->window_size && !wg_sum.pool_low && youngest != -1) {
-        /**src = 0;
-        *dst = youngest;*/
-        /* TODO: No current way to directly assign page from 0 to elsewhere.
-         * Do a hack by setting the youngest's free mem limiter to
-         * zero and re-running memcheck in the next second.
-         * If set rates are very high and the pool is too low, this can bottom
-         * out...
-         */
-        // schedule a memcheck run for "soon" to keep the limit zeroed out
-        // while the pool stays too high. This will also allow multiple
-        // classes to zero out over time.
-        a->last_memcheck_run = current_time - (MEMCHECK_PERIOD - 2);
-        a->settings->ext_free_memchunks[youngest] = 0;
+        if (a->sam_after[youngest].free_chunks <= a->free_mem[youngest]) {
+            *src = 0;
+            *dst = youngest;
+        }
+        struct window_data *wd = get_window_data(a, youngest);
+        // "relaxing" here and below allows us to skip classes which will
+        // never grow or are growing slowly, more quickly finding other
+        // classes which violate the age ratio.
+        wd->relaxed = 1;
     } else if (!too_free && wg_sum.pool_low && oldest != -1) {
         *src = oldest;
         *dst = 0;
     } else if (!too_free && youngest != -1 && oldest != -1 && youngest != oldest) {
         // if we have a youngest and oldest, and oldest is outside the ratio.
-        if (a->sam_after[youngest].free_chunks <= a->free_mem[youngest]
-                && youngest_age < ((double)oldest_age * a->max_age_ratio)) {
-            *src = oldest;
-            *dst = youngest;
+        if (youngest_age < ((double)oldest_age * a->max_age_ratio)) {
+            struct window_data *wd = get_window_data(a, youngest);
+            wd->relaxed = 1;
+            // only actually assign more memory if it's absorbed what it has
+            if (a->sam_after[youngest].free_chunks <= a->free_mem[youngest]) {
+                *src = 0;
+                *dst = youngest;
+
+            }
         }
     }
     return;

--- a/slabs.c
+++ b/slabs.c
@@ -678,7 +678,7 @@ static int slab_rebalance_start(void) {
 
     pthread_mutex_lock(&slabs_lock);
 
-    if (slab_rebal.s_clsid < POWER_SMALLEST ||
+    if (slab_rebal.s_clsid < SLAB_GLOBAL_PAGE_POOL ||
         slab_rebal.s_clsid > power_largest  ||
         slab_rebal.d_clsid < SLAB_GLOBAL_PAGE_POOL ||
         slab_rebal.d_clsid > power_largest  ||
@@ -707,8 +707,11 @@ static int slab_rebalance_start(void) {
         (s_cls->size * s_cls->perslab);
     slab_rebal.slab_pos   = slab_rebal.slab_start;
     slab_rebal.done       = 0;
+    // Don't need to do chunk move work if page is in global pool.
+    if (slab_rebal.s_clsid == SLAB_GLOBAL_PAGE_POOL) {
+        slab_rebal.done = 1;
+    }
 
-    /* Also tells do_item_get to search for items in this slab */
     slab_rebalance_signal = 2;
 
     if (settings.verbose > 1) {
@@ -1189,7 +1192,7 @@ static enum reassign_result_type do_slabs_reassign(int src, int dst) {
         /* TODO: If we end up back at -1, return a new error type */
     }
 
-    if (src < POWER_SMALLEST        || src > power_largest ||
+    if (src < SLAB_GLOBAL_PAGE_POOL || src > power_largest ||
         dst < SLAB_GLOBAL_PAGE_POOL || dst > power_largest)
         return REASSIGN_BADCLASS;
 


### PR DESCRIPTION
allows reassigning memory from global page pool to a specific class.

this allows simplifying the algorithm to rely on moving memory to/from
global, removing hacks around relaxing free memory requirements.

adds more comments and cleans up some code.

Edit:
- bug in script: removed "evictions happened" gating check but didn't replace with the pool_filled_once check that the internal version uses. should probably switch back to 'evictions' check for the external script.