### PR TITLE
limit crawls for metadumper

### DIFF
--- a/crawler.c
+++ b/crawler.c
@@ -530,6 +530,9 @@ static int do_lru_crawler_start(uint32_t id, uint32_t remaining) {
         crawlers[sid].next = 0;
         crawlers[sid].prev = 0;
         crawlers[sid].time = 0;
+        if (remaining == LRU_CRAWLER_CAP_REMAINING) {
+            remaining = do_get_lru_size(sid);
+        }
         crawlers[sid].remaining = remaining;
         crawlers[sid].slabs_clsid = sid;
         crawlers[sid].reclaimed = 0;
@@ -622,7 +625,7 @@ int lru_crawler_start(uint8_t *ids, uint32_t remaining,
  * Also only clear the crawlerstats once per sid.
  */
 enum crawler_result_type lru_crawler_crawl(char *slabs, const enum crawler_run_type type,
-        void *c, const int sfd) {
+        void *c, const int sfd, unsigned int remaining) {
     char *b = NULL;
     uint32_t sid = 0;
     int starts = 0;
@@ -651,7 +654,7 @@ enum crawler_result_type lru_crawler_crawl(char *slabs, const enum crawler_run_t
         }
     }
 
-    starts = lru_crawler_start(tocrawl, settings.lru_crawler_tocrawl,
+    starts = lru_crawler_start(tocrawl, remaining,
             type, NULL, c, sfd);
     if (starts == -1) {
         return CRAWLER_RUNNING;

--- a/crawler.h
+++ b/crawler.h
@@ -1,6 +1,8 @@
 #ifndef CRAWLER_H
 #define CRAWLER_H
 
+#define LRU_CRAWLER_CAP_REMAINING -1
+
 typedef struct {
     uint64_t histo[61];
     uint64_t ttl_hourplus;
@@ -28,7 +30,8 @@ enum crawler_result_type {
 int start_item_crawler_thread(void);
 int stop_item_crawler_thread(void);
 int init_lru_crawler(void *arg);
-enum crawler_result_type lru_crawler_crawl(char *slabs, enum crawler_run_type, void *c, const int sfd);
+enum crawler_result_type lru_crawler_crawl(char *slabs, enum crawler_run_type,
+        void *c, const int sfd, unsigned int remaining);
 int lru_crawler_start(uint8_t *ids, uint32_t remaining,
                              const enum crawler_run_type type, void *data,
                              void *c, const int sfd);

--- a/items.c
+++ b/items.c
@@ -138,6 +138,11 @@ static unsigned int temp_lru_size(int slabs_clsid) {
     return ret;
 }
 
+/* must be locked before call */
+unsigned int do_get_lru_size(uint32_t id) {
+    return sizes[id];
+}
+
 /* Enable this for reference-count debugging. */
 #if 0
 # define DEBUG_REFCNT(it,op) \

--- a/items.h
+++ b/items.h
@@ -25,6 +25,7 @@ void do_item_update_nolock(item *it);
 int  do_item_replace(item *it, item *new_it, const uint32_t hv);
 
 int item_is_flushed(item *it);
+unsigned int do_get_lru_size(uint32_t id);
 
 void do_item_linktail_q(item *it);
 void do_item_unlinktail_q(item *it);

--- a/memcached.c
+++ b/memcached.c
@@ -4770,7 +4770,8 @@ static void process_command(conn *c, char *command) {
                 return;
             }
 
-            rv = lru_crawler_crawl(tokens[2].value, CRAWLER_EXPIRED, NULL, 0);
+            rv = lru_crawler_crawl(tokens[2].value, CRAWLER_EXPIRED, NULL, 0,
+                    settings.lru_crawler_tocrawl);
             switch(rv) {
             case CRAWLER_OK:
                 out_string(c, "OK");
@@ -4800,7 +4801,7 @@ static void process_command(conn *c, char *command) {
             }
 
             int rv = lru_crawler_crawl(tokens[2].value, CRAWLER_METADUMP,
-                    c, c->sfd);
+                    c, c->sfd, LRU_CRAWLER_CAP_REMAINING);
             switch(rv) {
                 case CRAWLER_OK:
                     out_string(c, "OK");


### PR DESCRIPTION
LRU crawler metadumper is used for getting snapshot-y looks at the LRU's.
Since there's no default limit, it'll get any new items added or bumped since
the roll started.

with this change it limits the number of items dumped to the number that
existed in that LRU when the roll was kicked off. You still end up with an
approximation, but not a terrible one:

- items bumped after the crawler passes them likely won't be revisited
- items bumped before the crawler passes them will likely be visited toward
  the end, or mixed with new items.
- deletes are somewhere in the middle.