### PR TITLE
remove redundant counter/lock from hash table

### DIFF
--- a/assoc.h
+++ b/assoc.h
@@ -6,5 +6,6 @@ void assoc_delete(const char *key, const size_t nkey, const uint32_t hv);
 void do_assoc_move_next_bucket(void);
 int start_assoc_maintenance_thread(void);
 void stop_assoc_maintenance_thread(void);
+void assoc_start_expand(uint64_t curr_items);
 extern unsigned int hashpower;
 extern unsigned int item_lock_hashpower;

--- a/memcached.c
+++ b/memcached.c
@@ -6127,6 +6127,10 @@ static void clock_handler(const int fd, const short which, void *arg) {
 #endif
     }
 
+    // While we're here, check for hash table expansion.
+    // This function should be quick to avoid delaying the timer.
+    assoc_start_expand(stats_state.curr_items);
+
     evtimer_set(&clockevent, clock_handler, 0);
     event_base_set(main_base, &clockevent);
     evtimer_add(&clockevent, &t);

--- a/trace.h
+++ b/trace.h
@@ -4,11 +4,11 @@
 #ifdef ENABLE_DTRACE
 #include "memcached_dtrace.h"
 #else
-#define MEMCACHED_ASSOC_DELETE(arg0, arg1, arg2)
+#define MEMCACHED_ASSOC_DELETE(arg0, arg1)
 #define MEMCACHED_ASSOC_DELETE_ENABLED() (0)
 #define MEMCACHED_ASSOC_FIND(arg0, arg1, arg2)
 #define MEMCACHED_ASSOC_FIND_ENABLED() (0)
-#define MEMCACHED_ASSOC_INSERT(arg0, arg1, arg2)
+#define MEMCACHED_ASSOC_INSERT(arg0, arg1)
 #define MEMCACHED_ASSOC_INSERT_ENABLED() (0)
 #define MEMCACHED_COMMAND_ADD(arg0, arg1, arg2, arg3, arg4)
 #define MEMCACHED_COMMAND_ADD_ENABLED() (0)


### PR DESCRIPTION
curr_items tracks how many items are linked in the hash table. internally to
the hash table, hash_items tracked how many items were in the hash table.

on every insert/delete, hash_items had to be locked and checked to see if th
table should be expanded. rip that all out, and call a check with the
once-per-second clock event to check for hash table expansion.

this actually ends up fixing an obscure bug: if you burst a bunch of sets
then stop, the hash table won't attempt to expand a second time until the
next insert. with this change, every second the hash table has a chance of
expanding again.

~2% perf improvement for sets against a single slab class. doesn't seem to help write scalability much. seems STATS_LOCK() needs more work :)