### PR TITLE
restartable cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,8 @@ memcached_SOURCES = memcached.c memcached.h \
                     crawler.c crawler.h \
                     itoa_ljust.c itoa_ljust.h \
                     slab_automove.c slab_automove.h \
-                    authfile.c authfile.h
+                    authfile.c authfile.h \
+                    restart.c restart.h
 
 if BUILD_CACHE
 memcached_SOURCES += cache.c

--- a/assoc.c
+++ b/assoc.c
@@ -255,11 +255,14 @@ static void *assoc_maintenance_thread(void *arg) {
              * allow dynamic hash table expansion without causing significant
              * wait times.
              */
-            pause_threads(PAUSE_ALL_THREADS);
-            assoc_expand();
-            pause_threads(RESUME_ALL_THREADS);
+            if (do_run_maintenance_thread) {
+                pause_threads(PAUSE_ALL_THREADS);
+                assoc_expand();
+                pause_threads(RESUME_ALL_THREADS);
+            }
         }
     }
+    mutex_unlock(&maintenance_lock);
     return NULL;
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -613,6 +613,7 @@ fi
 
 AC_CHECK_FUNCS(mlockall)
 AC_CHECK_FUNCS(getpagesizes)
+AC_CHECK_FUNCS(sysconf)
 AC_CHECK_FUNCS(memcntl)
 AC_CHECK_FUNCS(sigignore)
 AC_CHECK_FUNCS(clock_gettime)

--- a/crawler.h
+++ b/crawler.h
@@ -28,7 +28,7 @@ enum crawler_result_type {
     CRAWLER_OK=0, CRAWLER_RUNNING, CRAWLER_BADCLASS, CRAWLER_NOTSTARTED, CRAWLER_ERROR
 };
 int start_item_crawler_thread(void);
-int stop_item_crawler_thread(void);
+int stop_item_crawler_thread(bool wait);
 int init_lru_crawler(void *arg);
 enum crawler_result_type lru_crawler_crawl(char *slabs, enum crawler_run_type,
         void *c, const int sfd, unsigned int remaining);

--- a/crawler.h
+++ b/crawler.h
@@ -28,6 +28,8 @@ enum crawler_result_type {
     CRAWLER_OK=0, CRAWLER_RUNNING, CRAWLER_BADCLASS, CRAWLER_NOTSTARTED, CRAWLER_ERROR
 };
 int start_item_crawler_thread(void);
+#define CRAWLER_WAIT true
+#define CRAWLER_NOWAIT false
 int stop_item_crawler_thread(bool wait);
 int init_lru_crawler(void *arg);
 enum crawler_result_type lru_crawler_crawl(char *slabs, enum crawler_run_type,

--- a/items.c
+++ b/items.c
@@ -293,7 +293,7 @@ item *do_item_alloc(char *key, const size_t nkey, const unsigned int flags,
         return NULL;
     }
 
-    assert(it->it_flags == 0);
+    assert(it->it_flags == 0 || it->it_flags == ITEM_CHUNKED);
     //assert(it != heads[id]);
 
     /* Refcount is seeded to 1 by slabs_alloc() */

--- a/items.c
+++ b/items.c
@@ -60,6 +60,7 @@ static uint64_t sizes_bytes[LARGEST_ID];
 static unsigned int *stats_sizes_hist = NULL;
 static uint64_t stats_sizes_cas_min = 0;
 static int stats_sizes_buckets = 0;
+static uint64_t cas_id = 0;
 
 static volatile int do_run_lru_maintainer_thread = 0;
 static int lru_maintainer_initialized = 0;
@@ -109,11 +110,16 @@ static uint64_t lru_total_bumps_dropped(void);
 /* Get the next CAS id for a new item. */
 /* TODO: refactor some atomics for this. */
 uint64_t get_cas_id(void) {
-    static uint64_t cas_id = 0;
     pthread_mutex_lock(&cas_id_lock);
     uint64_t next_id = ++cas_id;
     pthread_mutex_unlock(&cas_id_lock);
     return next_id;
+}
+
+void set_cas_id(uint64_t new_cas) {
+    pthread_mutex_lock(&cas_id_lock);
+    cas_id = new_cas;
+    pthread_mutex_unlock(&cas_id_lock);
 }
 
 int item_is_flushed(item *it) {

--- a/items.h
+++ b/items.h
@@ -23,6 +23,7 @@ void do_item_remove(item *it);
 void do_item_update(item *it);   /** update LRU time to current and reposition */
 void do_item_update_nolock(item *it);
 int  do_item_replace(item *it, item *new_it, const uint32_t hv);
+void do_item_link_fixup(item *it);
 
 int item_is_flushed(item *it);
 unsigned int do_get_lru_size(uint32_t id);

--- a/items.h
+++ b/items.h
@@ -8,6 +8,7 @@
 
 /* See items.c */
 uint64_t get_cas_id(void);
+void set_cas_id(uint64_t new_cas);
 
 /*@null@*/
 item *do_item_alloc(char *key, const size_t nkey, const unsigned int flags, const rel_time_t exptime, const int nbytes);

--- a/logger.c
+++ b/logger.c
@@ -517,6 +517,8 @@ static void logger_thread_sum_stats(struct logger_stats *ls) {
 static void *logger_thread(void *arg) {
     useconds_t to_sleep = MIN_LOGGER_SLEEP;
     L_DEBUG("LOGGER: Starting logger thread\n");
+    // TODO: If we ever have item references in the logger code, will need to
+    // ensure everything is dequeued before stopping the thread.
     while (do_run_logger_thread) {
         int found_logs = 0;
         logger *l;

--- a/logger.c
+++ b/logger.c
@@ -591,13 +591,6 @@ void logger_init(void) {
         abort();
     }
 
-    /* This can be removed once the global stats initializer is improved */
-    STATS_LOCK();
-    stats.log_worker_dropped = 0;
-    stats.log_worker_written = 0;
-    stats.log_watcher_skipped = 0;
-    stats.log_watcher_sent = 0;
-    STATS_UNLOCK();
     /* This is what adding a STDERR watcher looks like. should replace old
      * "verbose" settings. */
     //logger_add_watcher(NULL, 0);

--- a/logger.c
+++ b/logger.c
@@ -553,12 +553,11 @@ static int start_logger_thread(void) {
     return 0;
 }
 
-// future.
-/*static int stop_logger_thread(void) {
+static int stop_logger_thread(void) {
     do_run_logger_thread = 0;
     pthread_join(logger_tid, NULL);
     return 0;
-}*/
+}
 
 /*************************
  * Public functions for submitting logs and starting loggers from workers.
@@ -589,6 +588,10 @@ void logger_init(void) {
      * "verbose" settings. */
     //logger_add_watcher(NULL, 0);
     return;
+}
+
+void logger_stop(void) {
+    stop_logger_thread();
 }
 
 /* called *from* the thread using a logger.

--- a/logger.h
+++ b/logger.h
@@ -190,4 +190,8 @@ enum logger_add_watcher_ret {
 
 enum logger_add_watcher_ret logger_add_watcher(void *c, const int sfd, uint16_t f);
 
+/* functions used by restart system */
+uint64_t logger_get_gid(void);
+void logger_set_gid(uint64_t gid);
+
 #endif

--- a/logger.h
+++ b/logger.h
@@ -111,7 +111,6 @@ typedef struct _logentry {
     struct timeval tv; /* not monotonic! */
     int size;
     union {
-        void *entry; /* unused, possibly an item */
         char end;
     } data[];
 } logentry;

--- a/logger.h
+++ b/logger.h
@@ -100,6 +100,9 @@ struct logentry_item_store {
 
 /* end intermediary structures */
 
+/* WARNING: cuddled items aren't compatible with warm restart. more code
+ * necessary to ensure log streams are all flushed/processed before stopping
+ */
 typedef struct _logentry {
     enum log_entry_subtype event;
     uint8_t pad;
@@ -108,7 +111,7 @@ typedef struct _logentry {
     struct timeval tv; /* not monotonic! */
     int size;
     union {
-        void *entry; /* probably an item */
+        void *entry; /* unused, possibly an item */
         char end;
     } data[];
 } logentry;
@@ -165,6 +168,7 @@ extern pthread_key_t logger_key;
 /* public functions */
 
 void logger_init(void);
+void logger_stop(void);
 logger *logger_create(void);
 
 #define LOGGER_LOG(l, flag, type, ...) \

--- a/memcached.c
+++ b/memcached.c
@@ -7112,7 +7112,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
         NULL
     };
 
-    while (restart_get_kv(ctx, &key, &val) == 0) {
+    while (restart_get_kv(ctx, &key, &val) == RESTART_OK) {
         int type = 0;
         int32_t val_int = 0;
         uint32_t val_uint = 0;

--- a/memcached.c
+++ b/memcached.c
@@ -8251,6 +8251,7 @@ int main (int argc, char **argv) {
     conn_init();
     bool reuse_mem = false;
     void *mem_base = NULL;
+    void *old_base = NULL;
     bool prefill = false;
     if (memory_file != NULL) {
         preallocate = true;
@@ -8258,7 +8259,8 @@ int main (int argc, char **argv) {
         prefill = true;
         reuse_mem = restart_mmap_open(settings.maxbytes,
                         memory_file,
-                        &mem_base);
+                        &mem_base,
+                        &old_base);
         restart_mmap_set();
     }
     slabs_init(settings.maxbytes, settings.factor, preallocate,
@@ -8299,7 +8301,7 @@ int main (int argc, char **argv) {
         slabs_prefill_global();
     /* In restartable mode and we've decided to issue a fixup on memory */
     if (memory_file != NULL && reuse_mem) {
-        restart_fixup();
+        restart_fixup(old_base);
     }
     /*
      * ignore SIGPIPE signals; we can use errno == EPIPE if we

--- a/memcached.c
+++ b/memcached.c
@@ -6991,6 +6991,7 @@ int main (int argc, char **argv) {
     int maxcore = 0;
     char *username = NULL;
     char *pid_file = NULL;
+    char *memory_file = NULL;
     struct passwd *pw;
     struct rlimit rlim;
     char *buf;
@@ -7219,6 +7220,7 @@ int main (int argc, char **argv) {
           "F"   /* Disable flush_all */
           "X"   /* Disable dump commands */
           "Y:"   /* Enable token auth */
+          "e:"  /* mmap path for external item memory */
           "o:"  /* Extended generic options */
           ;
 
@@ -7257,6 +7259,7 @@ int main (int argc, char **argv) {
         {"disable-flush-all", no_argument, 0, 'F'},
         {"disable-dumping", no_argument, 0, 'X'},
         {"auth-file", required_argument, 0, 'Y'},
+        {"memory-file", required_argument, 0, 'e'},
         {"extended", required_argument, 0, 'o'},
         {0, 0, 0, 0}
     };
@@ -7359,6 +7362,9 @@ int main (int argc, char **argv) {
             break;
         case 'P':
             pid_file = optarg;
+            break;
+        case 'e':
+            memory_file = optarg;
             break;
         case 'f':
             settings.factor = atof(optarg);
@@ -8242,9 +8248,11 @@ int main (int argc, char **argv) {
     stats_init();
     assoc_init(settings.hashpower_init);
     conn_init();
-    preallocate = true;
+    if (memory_file != NULL) {
+        preallocate = true;
+    }
     slabs_init(settings.maxbytes, settings.factor, preallocate,
-            use_slab_sizes ? slab_sizes : NULL);
+            use_slab_sizes ? slab_sizes : NULL, memory_file);
 #ifdef EXTSTORE
     if (storage_file) {
         enum extstore_res eres;

--- a/memcached.c
+++ b/memcached.c
@@ -6834,7 +6834,7 @@ static void sighup_handler(const int sig) {
 }
 
 static void sig_usrhandler(const int sig) {
-    printf("USR1 handled: %s.\n", strsignal(sig));
+    printf("Graceful shutdown signal handled: %s.\n", strsignal(sig));
     stop_main_loop = true;
 }
 
@@ -7113,7 +7113,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
             type++;
         }
         if (opts[type] == NULL) {
-            fprintf(stderr, "RESTART: unknown/unhandled key: %s\n", key);
+            fprintf(stderr, "[restart] unknown/unhandled key: %s\n", key);
             continue;
         }
 
@@ -7131,7 +7131,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
         switch (type) {
         case R_MMAP_OLDBASE:
             if (!safe_strtoull_hex(val, &meta->old_base)) {
-                fprintf(stderr, "failed to parse %s: %s\n", key, val);
+                fprintf(stderr, "[restart] failed to parse %s: %s\n", key, val);
                 reuse_mmap = -1;
             }
             break;
@@ -7242,11 +7242,11 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
             }
             break;
         default:
-            fprintf(stderr, "RESTART: unhandled key: %s\n", key);
+            fprintf(stderr, "[restart] unhandled key: %s\n", key);
         }
 
         if (reuse_mmap != 0) {
-            fprintf(stderr, "RESTART: restart incompatible due to setting for [%s] [old value: %s]\n", key, val);
+            fprintf(stderr, "[restart] restart incompatible due to setting for [%s] [old value: %s]\n", key, val);
             break;
         }
     }
@@ -8558,7 +8558,7 @@ int main (int argc, char **argv) {
     assoc_init(settings.hashpower_init);
 #ifdef EXTSTORE
     if (storage_file && reuse_mem) {
-        fprintf(stderr, "RESTART: memory restart with extstore not presently supported.\n");
+        fprintf(stderr, "[restart] memory restart with extstore not presently supported.\n");
         reuse_mem = false;
     }
 #endif

--- a/memcached.c
+++ b/memcached.c
@@ -5075,7 +5075,7 @@ static void process_command(conn *c, char *command) {
                     out_string(c, "ERROR failed to start lru crawler thread");
                 }
             } else if ((strcmp(tokens[COMMAND_TOKEN + 1].value, "disable") == 0)) {
-                if (stop_item_crawler_thread(false) == 0) {
+                if (stop_item_crawler_thread(CRAWLER_NOWAIT) == 0) {
                     out_string(c, "OK");
                 } else {
                     out_string(c, "ERROR failed to stop lru crawler thread");
@@ -6623,6 +6623,9 @@ static void usage(void) {
     printf("-X, --disable-dumping     disable stats cachedump and lru_crawler metadump\n");
     printf("-Y, --auth-file=<file>    (EXPERIMENTAL) enable ASCII protocol authentication. format:\n"
            "                          user:pass\\nuser2:pass2\\n\n");
+    printf("-e, --memory-file=<file>  (EXPERIMENTAL) mmap a file for item memory.\n"
+           "                          use only in ram disks or persistent memory mounts!\n"
+           "                          enables restartable cache (stop with SIGUSR1)\n");
 #ifdef TLS
     printf("-Z, --enable-ssl          enable TLS/SSL\n");
 #endif
@@ -6998,7 +7001,7 @@ static int _mc_meta_save_cb(const char *tag, void *ctx, void *data) {
     // comparisons for compat reasons are difficult.
     // it may be possible to punt on this for now; since we can test for the
     // absense of another key... such as the new numeric version.
-    restart_set_kv(ctx, "version", "%s", VERSION);
+    //restart_set_kv(ctx, "version", "%s", VERSION);
     // We hold the original factor or subopts _string_
     // it can be directly compared without roundtripping through floats or
     // serializing/deserializing the long options list.
@@ -7243,7 +7246,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
         }
 
         if (reuse_mmap != 0) {
-            fprintf(stderr, "RESTART: restart imcompatible due to setting for [%s] [old value: %s]\n", key, val);
+            fprintf(stderr, "RESTART: restart incompatible due to setting for [%s] [old value: %s]\n", key, val);
             break;
         }
     }

--- a/memcached.c
+++ b/memcached.c
@@ -7026,9 +7026,7 @@ static int _mc_meta_save_cb(const char *tag, void *ctx, void *data) {
     // coupling the internal variable into the restart system.
     restart_set_kv(ctx, "current_cas", "%llu", (unsigned long long) get_cas_id());
     restart_set_kv(ctx, "oldest_cas", "%llu", (unsigned long long) settings.oldest_cas);
-    // TODO: static -> unstatic from logger.c
-    // or... give the logger a restart callback.
-    //restart_set_kv(ctx, "logger_id", "%llu", );
+    restart_set_kv(ctx, "logger_id", "%llu", logger_get_gid());
     restart_set_kv(ctx, "hashpower", "%u", stats_state.hash_power_level);
     // NOTE: oldest_live is a rel_time_t, which aliases for unsigned int.
     // should future proof this with a 64bit upcast, or fetch value from a
@@ -7064,6 +7062,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
         R_CURRENT_CAS,
         R_OLDEST_CAS,
         R_OLDEST_LIVE,
+        R_LOGGER_GID,
     };
 
     const char *opts[] = {
@@ -7079,6 +7078,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
         [R_CURRENT_CAS] = "current_cas",
         [R_OLDEST_CAS] = "oldest_cas",
         [R_OLDEST_LIVE] = "oldest_live",
+        [R_LOGGER_GID] = "logger_gid",
         NULL
     };
 
@@ -7175,6 +7175,13 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
                 reuse_mmap = -1;
             } else {
                 settings.oldest_live = val_uint;
+            }
+            break;
+        case R_LOGGER_GID:
+            if (!safe_strtoull(val, &bigval_uint)) {
+                reuse_mmap = -1;
+            } else {
+                logger_set_gid(bigval_uint);
             }
             break;
         default:

--- a/memcached.c
+++ b/memcached.c
@@ -8644,7 +8644,7 @@ int main (int argc, char **argv) {
         struct timespec ts;
         if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
             monotonic = true;
-            monotonic_start = ts.tv_sec - ITEM_UPDATE_INTERVAL - 2;
+            monotonic_start = ts.tv_sec;
             // Monotonic clock needs special handling for restarts.
             // We get a start time at an arbitrary place, so we need to
             // restore the original time delta, which is always "now" - _start
@@ -8652,6 +8652,8 @@ int main (int argc, char **argv) {
                 // the running timespan at stop time + the time we think we
                 // were stopped.
                 monotonic_start -= meta->current_time + meta->time_delta;
+            } else {
+                monotonic_start -= ITEM_UPDATE_INTERVAL + 2;
             }
         }
     }

--- a/memcached.c
+++ b/memcached.c
@@ -151,7 +151,7 @@ volatile int slab_rebalance_signal;
 /* hoping this is temporary; I'd prefer to cut globals, but will complete this
  * battle another day.
  */
-void *ext_storage;
+void *ext_storage = NULL;
 #endif
 /** file scope variables **/
 static conn *listen_conn = NULL;
@@ -8556,6 +8556,12 @@ int main (int argc, char **argv) {
     // previously, to avoid filling a huge set of items into a tiny hash
     // table.
     assoc_init(settings.hashpower_init);
+#ifdef EXTSTORE
+    if (storage_file && reuse_mem) {
+        fprintf(stderr, "RESTART: memory restart with extstore not presently supported.\n");
+        reuse_mem = false;
+    }
+#endif
     slabs_init(settings.maxbytes, settings.factor, preallocate,
             use_slab_sizes ? slab_sizes : NULL, mem_base, reuse_mem);
 #ifdef EXTSTORE

--- a/memcached.c
+++ b/memcached.c
@@ -8749,7 +8749,7 @@ int main (int argc, char **argv) {
         }
     }
 
-    fprintf(stderr, "STOPPING\n");
+    fprintf(stderr, "Gracefully stopping\n");
     stop_threads();
     int i;
     // FIXME: make a function callable from threads.c
@@ -8759,7 +8759,6 @@ int main (int argc, char **argv) {
         }
     }
     if (memory_file != NULL) {
-        fprintf(stderr, "Closing mmap\n");
         restart_mmap_close();
     }
 

--- a/memcached.c
+++ b/memcached.c
@@ -8251,8 +8251,11 @@ int main (int argc, char **argv) {
     conn_init();
     bool reuse_mem = false;
     void *mem_base = NULL;
+    bool prefill = false;
     if (memory_file != NULL) {
         preallocate = true;
+        // Easier to manage memory if we prefill the global pool when reusing.
+        prefill = true;
         reuse_mem = restart_mmap_open(settings.maxbytes,
                         memory_file,
                         &mem_base);
@@ -8284,6 +8287,7 @@ int main (int argc, char **argv) {
         }
         ext_storage = storage;
         /* page mover algorithm for extstore needs memory prefilled */
+        prefill = true;
     }
 #endif
 
@@ -8291,7 +8295,8 @@ int main (int argc, char **argv) {
         setup_privilege_violations_handler();
     }
 
-    slabs_prefill_global();
+    if (prefill)
+        slabs_prefill_global();
     /* In restartable mode and we've decided to issue a fixup on memory */
     if (memory_file != NULL && reuse_mem) {
         restart_fixup();

--- a/memcached.h
+++ b/memcached.h
@@ -805,6 +805,7 @@ void item_trylock_unlock(void *arg);
 void item_unlock(uint32_t hv);
 void pause_threads(enum pause_thread_types type);
 void stop_threads(void);
+int stop_conn_timeout_thread(void);
 #define refcount_incr(it) ++(it->refcount)
 #define refcount_decr(it) --(it->refcount)
 void STATS_LOCK(void);

--- a/memcached.h
+++ b/memcached.h
@@ -804,6 +804,7 @@ void *item_trylock(uint32_t hv);
 void item_trylock_unlock(void *arg);
 void item_unlock(uint32_t hv);
 void pause_threads(enum pause_thread_types type);
+void stop_threads(void);
 #define refcount_incr(it) ++(it->refcount)
 #define refcount_decr(it) --(it->refcount)
 void STATS_LOCK(void);

--- a/restart.c
+++ b/restart.c
@@ -1,0 +1,170 @@
+#include "memcached.h"
+
+#include "restart.h"
+
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+
+// TODO: allocating from the _front_ (or using a different file?)
+// makes it easier to do dynamic memory limits again.
+// downside is having to track potential hugepage alignment for the slab
+// memory.
+// tracking data at the end of the memory base makes this easier.
+
+// TODO: also start/min size
+typedef struct {
+    void *base_addr;
+    double factor; /* factor from last slab init */
+    char version[255];
+    bool clean; /* set to true during a clean shutdown */
+} slab_mmap_meta;
+
+// TODO: struct to hand back to caller.
+static int mmap_fd = 0;
+static int pagesize = 0;
+static void *mmap_base = NULL;
+static size_t slabmem_limit = 0;
+
+// TODO: This should be a function external to the slabber.
+static unsigned int check_mmap(void *mem_base) {
+    slab_mmap_meta *m = (slab_mmap_meta *)((char *)mem_base + slabmem_limit);
+    if (!m->clean) {
+        fprintf(stderr, "mmap not clean\n");
+        return -1;
+    }
+    if (m->base_addr == 0) {
+        fprintf(stderr, "base address 0\n");
+        return -2;
+    }
+    if (memcmp(VERSION, m->version, strlen(VERSION)) != 0) {
+        fprintf(stderr, "version doesn't match\n");
+        return -3;
+    }
+    // TODO: check factor/etc important arguments
+    return 0;
+}
+
+// NOTE: must be called _after_ main code fixup?
+// else: m->base_addr is only set during close.
+// else: set m->clean = false here but set rest on close...
+void restart_mmap_set(void) {
+    slab_mmap_meta *m = (slab_mmap_meta *)((char *)mmap_base + slabmem_limit);
+    m->base_addr = mmap_base;
+    m->clean = false;
+    memcpy(m->version, VERSION, strlen(VERSION));
+}
+
+bool restart_mmap_open(const size_t limit, const char *file, void **mem_base) {
+    bool reuse_mmap = true;
+
+    pagesize = getpagesize();
+    mmap_fd = open(file, O_RDWR|O_CREAT, S_IRWXU);
+    fprintf(stderr, "mmap_fd: %d\n", mmap_fd);
+    if (ftruncate(mmap_fd, limit + pagesize) != 0) {
+        perror("ftruncate failed");
+        abort();
+    }
+    /* Allocate everything in a big chunk with malloc */
+    if (limit % pagesize) {
+        // FIXME: what was I smoking? is this an error?
+        fprintf(stderr, "WARNING: mem_limit not divible evenly by pagesize\n");
+    }
+    mmap_base = mmap(NULL, limit + pagesize, PROT_READ|PROT_WRITE, MAP_SHARED, mmap_fd, 0);
+    if (mmap_base == MAP_FAILED) {
+        perror("failed to mmap, aborting");
+        abort();
+    }
+    // Set the limit before calling check_mmap, so we can find the meta page..
+    slabmem_limit = limit;
+    if (check_mmap(mmap_base) != 0) {
+        fprintf(stderr, "failed to validate mmap, not reusing\n");
+        reuse_mmap = false;
+    }
+    *mem_base = mmap_base;
+
+    // save metadata snapshot.
+    // TODO: just have to mark it as not clean here.
+    //restart_set_mmap();
+    return reuse_mmap;
+}
+
+// TODO: meta at start vs end of memory.
+/* Gracefully stop/close the shared memory segment */
+void restart_mmap_close(void) {
+    slab_mmap_meta *m = (slab_mmap_meta *)((char *)mmap_base + slabmem_limit);
+    m->clean = true;
+    m->base_addr = mmap_base;
+    if (munmap(mmap_base, slabmem_limit + pagesize) != 0) {
+        perror("failed to munmap shared memory");
+    } else if (close(mmap_fd) != 0) {
+        perror("failed to close shared memory fd");
+    }
+}
+
+// given memory base, quickly walk memory and do pointer fixup.
+// do this once on startup to avoid having to do pointer fixup on every
+// reference from hash table or LRU.
+unsigned int restart_fixup(void) {
+    struct timeval tv;
+    uint64_t checked = 0;
+    slab_mmap_meta *m = (slab_mmap_meta *)((char *)mmap_base + slabmem_limit);
+    void *orig_addr = m->base_addr;
+    const unsigned int page_size = settings.slab_page_size;
+    unsigned int page_remain = page_size;
+
+    gettimeofday(&tv, NULL);
+    fprintf(stderr, "orig base: [%p] new base: [%p]\n", orig_addr, mmap_base);
+    fprintf(stderr, "recovery start [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
+ 
+    // since chunks don't align with pages, we have to also track page size.
+    while (checked < slabmem_limit) {
+        //fprintf(stderr, "checked: %lu\n", checked);
+        item *it = (item *)((char *)mmap_base + checked);
+
+        int size = slabs_fixup((char *)mmap_base + checked,
+                checked % settings.slab_page_size);
+        // slabber gobbled an entire page, skip and move on.
+        if (size == -1) {
+            assert(page_remain % page_size == 0);
+            assert(page_remain == page_size);
+            checked += page_remain;
+            page_remain = page_size;
+            continue;
+        }
+
+        // FIXME: only do this if linked.
+        // fixup next/prev links. same for freelist or LRU
+        if (it->next) {
+            it->next = (item *)((uint64_t)it->next - (uint64_t)orig_addr);
+            it->next = (item *)((uint64_t)it->next + (uint64_t)mmap_base);
+        }
+        if (it->prev) {
+            it->prev = (item *)((uint64_t)it->prev - (uint64_t)orig_addr);
+            it->prev = (item *)((uint64_t)it->prev + (uint64_t)mmap_base);
+        }
+
+        if (it->it_flags & ITEM_LINKED) {
+            //fprintf(stderr, "item was linked\n");
+            do_item_link_fixup(it);
+        }
+
+        // next chunk
+        checked += size;
+        page_remain -= size;
+        if (size > page_remain) {
+            //fprintf(stderr, "doot %d\n", page_remain);
+            checked += page_remain;
+            page_remain = settings.slab_page_size;
+        }
+        //assert(checked != 3145728);
+    }
+
+    gettimeofday(&tv, NULL);
+    fprintf(stderr, "recovery end [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
+
+    return 0;
+}

--- a/restart.c
+++ b/restart.c
@@ -136,18 +136,17 @@ unsigned int restart_fixup(void *orig_addr) {
             continue;
         }
 
-        // FIXME: only do this if linked.
-        // fixup next/prev links. same for freelist or LRU
-        if (it->next) {
-            it->next = (item *)((uint64_t)it->next - (uint64_t)orig_addr);
-            it->next = (item *)((uint64_t)it->next + (uint64_t)mmap_base);
-        }
-        if (it->prev) {
-            it->prev = (item *)((uint64_t)it->prev - (uint64_t)orig_addr);
-            it->prev = (item *)((uint64_t)it->prev + (uint64_t)mmap_base);
-        }
-
         if (it->it_flags & ITEM_LINKED) {
+            // fixup next/prev links while on LRU.
+            if (it->next) {
+                it->next = (item *)((uint64_t)it->next - (uint64_t)orig_addr);
+                it->next = (item *)((uint64_t)it->next + (uint64_t)mmap_base);
+            }
+            if (it->prev) {
+                it->prev = (item *)((uint64_t)it->prev - (uint64_t)orig_addr);
+                it->prev = (item *)((uint64_t)it->prev + (uint64_t)mmap_base);
+            }
+
             //fprintf(stderr, "item was linked\n");
             do_item_link_fixup(it);
         }

--- a/restart.c
+++ b/restart.c
@@ -119,7 +119,7 @@ unsigned int restart_fixup(void) {
     gettimeofday(&tv, NULL);
     fprintf(stderr, "orig base: [%p] new base: [%p]\n", orig_addr, mmap_base);
     fprintf(stderr, "recovery start [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
- 
+
     // since chunks don't align with pages, we have to also track page size.
     while (checked < slabmem_limit) {
         //fprintf(stderr, "checked: %lu\n", checked);

--- a/restart.c
+++ b/restart.c
@@ -62,18 +62,10 @@ typedef struct {
     bool done;
 } restart_cb_ctx;
 
-// NEW check code:
-// x check for metadata file
-// x open metadata file
+// TODO: error string from cb?
 // - look for final line with checksum
 // - checksum entire file (up until final line)
 // - seek to start
-// x read line-by-line:
-//   x find tag, switch context
-//   x call callback
-//   [callbacks themselves request next line]
-// x check return code. bail upstream if screwed.
-// TODO: error string from cb?
 
 static int restart_check(const char *file) {
     // metadata is kept in a separate file.
@@ -199,15 +191,9 @@ int restart_get_kv(void *ctx, char **key, char **val) {
     return -1;
 }
 
-// SAVE code:
-// x create metadata file
-// x loop callbacks:
-//   x write tag line [lol]
-//   x call callback
-//   [callbacks call _set() for key/values]
+// TODO:
 // - rolling checksum along with the writes.
 // - write final line + checksum + byte count or w/e.
-// x close file
 
 static int restart_save(const char *file) {
     // metadata is kept in a separate file.
@@ -286,7 +272,7 @@ bool restart_mmap_open(const size_t limit, const char *file, void **mem_base) {
     /* Allocate everything in a big chunk with malloc */
     if (limit % pagesize) {
         // FIXME: what was I smoking? is this an error?
-        fprintf(stderr, "WARNING: mem_limit not divible evenly by pagesize\n");
+        fprintf(stderr, "WARNING: mem_limit not divisible evenly by pagesize\n");
     }
     mmap_base = mmap(NULL, limit, PROT_READ|PROT_WRITE, MAP_SHARED, mmap_fd, 0);
     if (mmap_base == MAP_FAILED) {

--- a/restart.c
+++ b/restart.c
@@ -260,10 +260,19 @@ void restart_set_kv(void *ctx, const char *key, const char *fmt, ...) {
     // TODO: update crc32c
 }
 
+static long _find_pagesize(void) {
+#if defined(HAVE_SYSCONF) && defined(_SC_PAGESIZE)
+    return sysconf(_SC_PAGESIZE);
+#else
+    // A good guess.
+    return 4096;
+#endif
+}
+
 bool restart_mmap_open(const size_t limit, const char *file, void **mem_base) {
     bool reuse_mmap = true;
 
-    int pagesize = getpagesize();
+    long pagesize = _find_pagesize();
     memory_file = strdup(file);
     mmap_fd = open(file, O_RDWR|O_CREAT, S_IRWXU);
     if (ftruncate(mmap_fd, limit) != 0) {

--- a/restart.c
+++ b/restart.c
@@ -46,10 +46,7 @@ void restart_register(const char *tag, restart_check_cb ccb, restart_save_cb scb
         finder->next = cb;
     }
 
-    // TODO: Write a safe_strncpy into util.c and stop using it raw.
-    // or a local strlcpy.
-    strncpy(cb->tag, tag, RESTART_TAG_MAXLEN);
-    cb->tag[RESTART_TAG_MAXLEN-1] = '\0';
+    safe_strcpy(cb->tag, tag, RESTART_TAG_MAXLEN);
     cb->data = data;
     cb->ccb = *ccb;
     cb->scb = *scb;

--- a/restart.c
+++ b/restart.c
@@ -151,13 +151,11 @@ int restart_get_kv(void *ctx, char **key, char **val) {
             p++;
         }
         *p = '\0';
-        fprintf(stderr, "got line: [l:%lu] %s\n", len, line);
 
         if (line[0] == 'T') {
             cb = cb_stack;
             while (cb != NULL) {
                 // NOTE: len is allocated size, not line len. need to chomp \n
-                fprintf(stderr, "checking: [%lu] %s:\n", len, cb->tag);
                 if (strcmp(cb->tag, line+1) == 0) {
                     break;
                 }
@@ -282,7 +280,6 @@ bool restart_mmap_open(const size_t limit, const char *file, void **mem_base) {
     pagesize = getpagesize();
     memory_file = strdup(file);
     mmap_fd = open(file, O_RDWR|O_CREAT, S_IRWXU);
-    fprintf(stderr, "mmap_fd: %d\n", mmap_fd);
     if (ftruncate(mmap_fd, limit + pagesize) != 0) {
         perror("ftruncate failed");
         abort();
@@ -333,8 +330,10 @@ unsigned int restart_fixup(void *orig_addr) {
     unsigned int page_remain = page_size;
 
     gettimeofday(&tv, NULL);
-    fprintf(stderr, "orig base: [%p] new base: [%p]\n", orig_addr, mmap_base);
-    fprintf(stderr, "recovery start [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
+    if (settings.verbose > 0) {
+        fprintf(stderr, "orig base: [%p] new base: [%p]\n", orig_addr, mmap_base);
+        fprintf(stderr, "recovery start [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
+    }
 
     // since chunks don't align with pages, we have to also track page size.
     while (checked < slabmem_limit) {
@@ -407,8 +406,10 @@ unsigned int restart_fixup(void *orig_addr) {
         //assert(checked != 3145728);
     }
 
-    gettimeofday(&tv, NULL);
-    fprintf(stderr, "recovery end [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
+    if (settings.verbose > 0) {
+        gettimeofday(&tv, NULL);
+        fprintf(stderr, "recovery end [%d.%d]\n", (int)tv.tv_sec, (int)tv.tv_usec);
+    }
 
     return 0;
 }

--- a/restart.c
+++ b/restart.c
@@ -74,6 +74,7 @@ static int restart_check(const char *file) {
 
     FILE *f = fopen(metafile, "r");
     if (f == NULL) {
+        fprintf(stderr, "[restart] no metadata save file, starting with a clean cache\n");
         return -1;
     }
 
@@ -108,7 +109,12 @@ static int restart_check(const char *file) {
     unlink(metafile);
     free(metafile);
 
-    return failed ? -1 : 0;
+    if (failed) {
+        fprintf(stderr, "[restart] failed to valiate metadata, starting with a clean cache\n");
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 // This function advances the file read while being called directly from the
@@ -279,7 +285,6 @@ bool restart_mmap_open(const size_t limit, const char *file, void **mem_base) {
     // Set the limit before calling check_mmap, so we can find the meta page..
     slabmem_limit = limit;
     if (restart_check(file) != 0) {
-        fprintf(stderr, "[restart] failed to valiate metadata, not reusing item memory\n");
         reuse_mmap = false;
     }
     *mem_base = mmap_base;

--- a/restart.h
+++ b/restart.h
@@ -1,9 +1,9 @@
 #ifndef RESTART_H
 #define RESTART_H
 
-bool restart_mmap_open(const size_t limit, const char *file, void **mem_base);
+bool restart_mmap_open(const size_t limit, const char *file, void **mem_base, void **old_base);
 void restart_mmap_close(void);
 void restart_mmap_set(void);
-unsigned int restart_fixup(void);
+unsigned int restart_fixup(void *old_base);
 
 #endif

--- a/restart.h
+++ b/restart.h
@@ -1,0 +1,9 @@
+#ifndef RESTART_H
+#define RESTART_H
+
+bool restart_mmap_open(const size_t limit, const char *file, void **mem_base);
+void restart_mmap_close(void);
+void restart_mmap_set(void);
+unsigned int restart_fixup(void);
+
+#endif

--- a/restart.h
+++ b/restart.h
@@ -1,7 +1,16 @@
 #ifndef RESTART_H
 #define RESTART_H
 
-bool restart_mmap_open(const size_t limit, const char *file, void **mem_base, void **old_base);
+#define RESTART_TAG_MAXLEN 255
+
+typedef int (*restart_check_cb)(const char *tag, void *ctx, void *data);
+typedef int (*restart_save_cb)(const char *tag, void *ctx, void *data);
+void restart_register(const char *tag, restart_check_cb ccb, restart_save_cb scb, void *data);
+
+void restart_set_kv(void *ctx, const char *key, const char *fmt, ...);
+int restart_get_kv(void *ctx, char **key, char **val);
+
+bool restart_mmap_open(const size_t limit, const char *file, void **mem_base);
 void restart_mmap_close(void);
 void restart_mmap_set(void);
 unsigned int restart_fixup(void *old_base);

--- a/restart.h
+++ b/restart.h
@@ -3,12 +3,16 @@
 
 #define RESTART_TAG_MAXLEN 255
 
+enum restart_get_kv_ret {
+    RESTART_OK=0, RESTART_NOTAG, RESTART_BADLINE, RESTART_DONE
+};
+
 typedef int (*restart_check_cb)(const char *tag, void *ctx, void *data);
 typedef int (*restart_save_cb)(const char *tag, void *ctx, void *data);
 void restart_register(const char *tag, restart_check_cb ccb, restart_save_cb scb, void *data);
 
 void restart_set_kv(void *ctx, const char *key, const char *fmt, ...);
-int restart_get_kv(void *ctx, char **key, char **val);
+enum restart_get_kv_ret restart_get_kv(void *ctx, char **key, char **val);
 
 bool restart_mmap_open(const size_t limit, const char *file, void **mem_base);
 void restart_mmap_close(void);

--- a/slabs.c
+++ b/slabs.c
@@ -282,7 +282,7 @@ static void set_mmap(void) {
  * Determines the chunk sizes and initializes the slab class descriptors
  * accordingly.
  */
-void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes) {
+void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes, const char *memory_file) {
     int i = POWER_SMALLEST - 1;
     unsigned int size = sizeof(item) + settings.chunk_size;
     bool reuse_mmap = true;
@@ -312,7 +312,7 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc, co
 #endif
 
         pagesize = getpagesize();
-        mmap_fd = open("/dev/shm/memc_mmap", O_RDWR|O_CREAT, S_IRWXU);
+        mmap_fd = open(memory_file, O_RDWR|O_CREAT, S_IRWXU);
         fprintf(stderr, "mmap_fd: %d\n", mmap_fd);
         if (ftruncate(mmap_fd, mem_limit + pagesize) != 0) {
             perror("ftruncate failed");

--- a/slabs.c
+++ b/slabs.c
@@ -174,10 +174,13 @@ unsigned int slabs_fixup(char *chunk, const int border) {
 
     // increase free count if ITEM_SLABBED
     if (it->it_flags == ITEM_SLABBED) {
-        // if ITEM_SLABBED and prev stack on freelist
-        // FIXME: always stack on freelist, ignore/wipe prev/next links.
-        if (it->prev == 0)
-            p->slots = it;
+        // if ITEM_SLABBED re-stack on freelist.
+        // don't have to run pointer fixups.
+        it->prev = 0;
+        it->next = p->slots;
+        if (it->next) it->next->prev = it;
+        p->slots = it;
+
         p->sl_curr++;
         //fprintf(stderr, "replacing into freelist\n");
     }

--- a/slabs.c
+++ b/slabs.c
@@ -97,6 +97,10 @@ unsigned int slabs_clsid(const size_t size) {
     return res;
 }
 
+unsigned int slabs_size(const int clsid) {
+    return slabclass[clsid].size;
+}
+
 // TODO: could this work with the restartable memory?
 // Docs say hugepages only work with private shm allocs.
 #if defined(__linux__) && defined(MADV_HUGEPAGE)
@@ -158,7 +162,7 @@ unsigned int slabs_fixup(char *chunk, const int border) {
     // memory isn't used yet. shunt to global pool.
     // (which must be 0)
     if (id == 0) {
-        assert(border == 0);
+        //assert(border == 0);
         p = &slabclass[0];
         grow_slab_list(0);
         p->slab_list[p->slabs++] = (char*)chunk;

--- a/slabs.c
+++ b/slabs.c
@@ -284,7 +284,7 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc, co
 
     }
 
-    if (prealloc && do_slab_prealloc) {
+    if (do_slab_prealloc) {
         if (!reuse_mem) {
             slabs_preallocate(power_largest);
         }

--- a/slabs.c
+++ b/slabs.c
@@ -402,7 +402,7 @@ static void *do_slabs_alloc(const size_t size, unsigned int id,
         return NULL;
     }
     p = &slabclass[id];
-    //assert(p->sl_curr == 0 || ((item *)p->slots)->slabs_clsid == 0);
+    assert(p->sl_curr == 0 || (((item *)p->slots)->it_flags & ITEM_SLABBED));
 
     assert(size <= p->size);
     /* fail unless we have space at the end of a recently allocated page,

--- a/slabs.h
+++ b/slabs.h
@@ -8,7 +8,7 @@
     3rd argument specifies if the slab allocator should allocate all memory
     up front (if true), or allocate memory in chunks as it is needed (if false)
 */
-void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes);
+void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes, const char *memory_file);
 
 /** Call only during init. Pre-allocates all available memory */
 void slabs_prefill_global(void);

--- a/slabs.h
+++ b/slabs.h
@@ -19,6 +19,7 @@ void slabs_prefill_global(void);
  */
 
 unsigned int slabs_clsid(const size_t size);
+unsigned int slabs_size(const int clsid);
 
 /** Allocate object of given length. 0 on error */ /*@null@*/
 #define SLABS_ALLOC_NO_NEWPAGE 1

--- a/slabs.h
+++ b/slabs.h
@@ -64,5 +64,6 @@ void slabs_rebalancer_resume(void);
 #ifdef EXTSTORE
 void slabs_set_storage(void *arg);
 #endif
+void slabs_mmap_close(void);
 
 #endif

--- a/slabs.h
+++ b/slabs.h
@@ -8,7 +8,7 @@
     3rd argument specifies if the slab allocator should allocate all memory
     up front (if true), or allocate memory in chunks as it is needed (if false)
 */
-void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes, const char *memory_file);
+void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes, void *mem_base_external, bool reuse_mem);
 
 /** Call only during init. Pre-allocates all available memory */
 void slabs_prefill_global(void);
@@ -64,6 +64,8 @@ void slabs_rebalancer_resume(void);
 #ifdef EXTSTORE
 void slabs_set_storage(void *arg);
 #endif
-void slabs_mmap_close(void);
+
+/* Fixup for restartable code. */
+unsigned int slabs_fixup(char *chunk, const int border);
 
 #endif

--- a/t/binary.t
+++ b/t/binary.t
@@ -121,7 +121,7 @@ $empty->('x');
 $empty->('y');
 
 {
-    # diag "Some chunked item tests";
+    diag "Some chunked item tests";
     my $s2 = new_memcached('-o no_modern,slab_chunk_max=4096');
     ok($s2, "started the server");
     my $m2 = MC::Client->new($s2);

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -350,6 +350,11 @@ sub stop {
     kill 15, $self->{pid};
 }
 
+sub graceful_stop {
+    my $self = shift;
+    kill 'SIGUSR1', $self->{pid};
+}
+
 sub host { $_[0]{host} }
 sub port { $_[0]{port} }
 sub udpport { $_[0]{udpport} }

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -282,6 +282,7 @@ sub new_memcached {
     croak("memcached binary not executable\n") unless -x _;
 
     unless ($childpid) {
+        #print STDERR "RUN: $exe $args\n";
         exec "$builddir/timedrun 600 $exe $args";
         exit; # never gets here.
     }

--- a/t/restart.t
+++ b/t/restart.t
@@ -56,6 +56,20 @@ diag "load enough items to change hash power level";
     is($good, 1, "delete responses were all DELETED");
 }
 
+diag "Load a couple chunked items";
+{
+    my $cur = 768000;
+    my $cnt = 0;
+    my $end = $cur + 1024;
+    while ($cur <= $end) {
+        my $val = 'x' x $cur;
+        print $sock "set chunk${cnt} 0 0 $cur\r\n$val\r\n";
+        like(scalar <$sock>, qr/STORED/, "stored $cur size item");
+        $cur += 50;
+        $cnt++;
+    }
+}
+
 diag "Data that should expire while stopped.";
 {
     print $sock "set low1 0 8 2\r\nbo\r\n";
@@ -94,6 +108,7 @@ diag "low TTL item should be gone";
     mem_get_is($sock, 'low2', 'mo');
 }
 
+# initially inserted items.
 {
     my $cur = 2;
     my $cnt = 0;
@@ -102,6 +117,19 @@ diag "low TTL item should be gone";
         my $val = 'x' x $cur;
         mem_get_is($sock, 'foo' . $cnt, $val);
         $cur *= 2;
+        $cnt++;
+    }
+}
+
+# chunked items.
+{
+    my $cur = 768000;
+    my $cnt = 0;
+    my $end = $cur + 1024;
+    while ($cur <= $end) {
+        my $val = 'x' x $cur;
+        mem_get_is($sock, 'chunk' . $cnt, $val);
+        $cur += 50;
         $cnt++;
     }
 }

--- a/t/restart.t
+++ b/t/restart.t
@@ -65,6 +65,14 @@ diag "Data that should expire while stopped.";
     like(scalar <$sock>, qr/STORED/, "stored low ttl item");
 }
 
+# make sure it's okay to stop with a logger watcher enabled.
+{
+    my $wsock = $server->new_sock;
+    print $wsock "watch fetchers mutations\n";
+    my $res = <$wsock>;
+    is($res, "OK\r\n", "watcher enabled");
+}
+
 $server->graceful_stop();
 diag "killed, waiting";
 # TODO: add way to wait for server to fully exit..

--- a/t/restart.t
+++ b/t/restart.t
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $mem_path = "/dev/shm/mc_restart.$$";
+
+my $server = new_memcached("-m 128 -e $mem_path -I 2m");
+my $sock = $server->sock;
+
+{
+    # Set some values, various sizes.
+    my $cur = 2;
+    my $cnt = 0;
+    my $end = 2**20;
+    while ($cur <= $end) {
+        my $val = 'x' x $cur;
+        print $sock "set foo${cnt} 0 0 $cur\r\n$val\r\n";
+        like(scalar <$sock>, qr/STORED/, "stored $cur size item");
+        $cur *= 2;
+        $cnt++;
+    }
+}
+
+$server->graceful_stop();
+diag "killed, waiting";
+# TODO: should add way to wait for server to fully exit..
+sleep 5;
+
+{
+    $server = new_memcached("-m 128 -e $mem_path -I 2m");
+    $sock = $server->sock;
+    diag "reconnected";
+}
+
+{
+    my $cur = 2;
+    my $cnt = 0;
+    my $end = 1000000;
+    while ($cur < $end) {
+        my $val = 'x' x $cur;
+        mem_get_is($sock, 'foo' . $cnt, $val);
+        $cur *= 2;
+        $cnt++;
+    }
+}
+
+done_testing();
+
+END {
+    unlink $mem_path if $mem_path;
+}

--- a/thread.c
+++ b/thread.c
@@ -197,9 +197,11 @@ void stop_threads(void) {
 
     // assoc can call pause_threads(), so we have to stop it first.
     stop_assoc_maintenance_thread();
-    fprintf(stderr, "stopped assoc\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "stopped assoc\n");
 
-    fprintf(stderr, "asking workers to stop\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "asking workers to stop\n");
     buf[0] = 's';
     pthread_mutex_lock(&init_lock);
     init_count = 0;
@@ -212,23 +214,28 @@ void stop_threads(void) {
     wait_for_thread_registration(settings.num_threads);
     pthread_mutex_unlock(&init_lock);
 
-    fprintf(stderr, "asking background threads to stop\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "asking background threads to stop\n");
 
     // stop each side thread.
     // TODO: Verify these all work if the threads are already stopped
     stop_item_crawler_thread(true);
-    fprintf(stderr, "stopped lru crawler\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "stopped lru crawler\n");
     stop_lru_maintainer_thread();
-    fprintf(stderr, "stopped maintainer\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "stopped maintainer\n");
     stop_slab_maintenance_thread();
-    fprintf(stderr, "stopped slab mover\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "stopped slab mover\n");
     logger_stop();
-    fprintf(stderr, "stopped logger thread\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "stopped logger thread\n");
 
-    fprintf(stderr, "done\n");
+    if (settings.verbose > 0)
+        fprintf(stderr, "all background threads stopped\n");
 
-    // At this point, everything is stopped. If we're using shared memory,
-    // note that it's clean and close the file.
+    // At this point, every background thread must be stopped.
 }
 
 /*

--- a/thread.c
+++ b/thread.c
@@ -189,8 +189,10 @@ void pause_threads(enum pause_thread_types type) {
     pthread_mutex_unlock(&init_lock);
 }
 
-/* Must not be called with any deeper locks held */
-/* MUST be called only by parent thread */
+// MUST not be called with any deeper locks held
+// MUST be called only by parent thread
+// Note: listener thread is the "main" event base, which has exited its
+// loop in order to call this function.
 void stop_threads(void) {
     char buf[1];
     int i;
@@ -219,7 +221,7 @@ void stop_threads(void) {
 
     // stop each side thread.
     // TODO: Verify these all work if the threads are already stopped
-    stop_item_crawler_thread(true);
+    stop_item_crawler_thread(CRAWLER_WAIT);
     if (settings.verbose > 0)
         fprintf(stderr, "stopped lru crawler\n");
     stop_lru_maintainer_thread();

--- a/thread.c
+++ b/thread.c
@@ -233,6 +233,9 @@ void stop_threads(void) {
     logger_stop();
     if (settings.verbose > 0)
         fprintf(stderr, "stopped logger thread\n");
+    stop_conn_timeout_thread();
+    if (settings.verbose > 0)
+        fprintf(stderr, "stopped idle timeout thread\n");
 
     if (settings.verbose > 0)
         fprintf(stderr, "all background threads stopped\n");

--- a/timedrun.c
+++ b/timedrun.c
@@ -27,6 +27,7 @@ static int wait_for_process(pid_t pid)
     sigaction(SIGALRM, &sig_handler, NULL);
     sigaction(SIGHUP, &sig_handler, NULL);
     sigaction(SIGINT, &sig_handler, NULL);
+    sigaction(SIGUSR1, &sig_handler, NULL);
     sigaction(SIGTERM, &sig_handler, NULL);
     sigaction(SIGPIPE, &sig_handler, NULL);
 

--- a/util.c
+++ b/util.c
@@ -181,6 +181,27 @@ bool safe_strtod(const char *str, double *out) {
     return false;
 }
 
+// slow, safe function for copying null terminated buffers.
+// ensures null terminator set on destination buffer. copies at most dstmax-1
+// non-null bytes.
+// returns true if src was fully copied.
+// returns false if src was truncated into dst.
+bool safe_strcpy(char *dst, const char *src, const size_t dstmax) {
+   size_t x;
+
+   for (x = 0; x < dstmax - 1 && src[x] != '\0'; x++) {
+        dst[x] = src[x];
+   }
+
+   dst[x] = '\0';
+
+   if (src[x] == '\0') {
+       return true;
+   } else {
+       return false;
+   }
+}
+
 void vperror(const char *fmt, ...) {
     int old_errno = errno;
     char buf[1024];

--- a/util.c
+++ b/util.c
@@ -71,6 +71,36 @@ bool safe_strtoull(const char *str, uint64_t *out) {
     return false;
 }
 
+/* Could macro this. Decided to keep this unrolled for safety rather than add
+ * the base parameter to all callers. Very few places need to parse a number
+ * outside of base 10, currently exactly once, so splitting this up should
+ * help avoid typo bugs.
+ */
+bool safe_strtoull_hex(const char *str, uint64_t *out) {
+    assert(out != NULL);
+    errno = 0;
+    *out = 0;
+    char *endptr;
+    unsigned long long ull = strtoull(str, &endptr, 16);
+    if ((errno == ERANGE) || (str == endptr)) {
+        return false;
+    }
+
+    if (xisspace(*endptr) || (*endptr == '\0' && endptr != str)) {
+        if ((long long) ull < 0) {
+            /* only check for negative signs in the uncommon case when
+             * the unsigned number is so big that it's negative as a
+             * signed number. */
+            if (strchr(str, '-') != NULL) {
+                return false;
+            }
+        }
+        *out = ull;
+        return true;
+    }
+    return false;
+}
+
 bool safe_strtoll(const char *str, int64_t *out) {
     assert(out != NULL);
     errno = 0;

--- a/util.c
+++ b/util.c
@@ -184,6 +184,7 @@ bool safe_strtod(const char *str, double *out) {
 // slow, safe function for copying null terminated buffers.
 // ensures null terminator set on destination buffer. copies at most dstmax-1
 // non-null bytes.
+// Explicitly avoids over-reading src while looking for the null byte.
 // returns true if src was fully copied.
 // returns false if src was truncated into dst.
 bool safe_strcpy(char *dst, const char *src, const size_t dstmax) {

--- a/util.h
+++ b/util.h
@@ -12,6 +12,7 @@ bool uriencode(const char *src, char *dst, const size_t srclen, const size_t dst
  * returns true if conversion succeeded.
  */
 bool safe_strtoull(const char *str, uint64_t *out);
+bool safe_strtoull_hex(const char *str, uint64_t *out);
 bool safe_strtoll(const char *str, int64_t *out);
 bool safe_strtoul(const char *str, uint32_t *out);
 bool safe_strtol(const char *str, int32_t *out);

--- a/util.h
+++ b/util.h
@@ -17,6 +17,7 @@ bool safe_strtoll(const char *str, int64_t *out);
 bool safe_strtoul(const char *str, uint32_t *out);
 bool safe_strtol(const char *str, int32_t *out);
 bool safe_strtod(const char *str, double *out);
+bool safe_strcpy(char *dst, const char *src, const size_t dstmax);
 
 #ifndef HAVE_HTONLL
 extern uint64_t htonll(uint64_t);


### PR DESCRIPTION
SIGUSR1 for graceful stop, then restart and it recovers the cache.
uses mmap'ed file out of a tmpfs instead of anonymous/ipc segments.

WIP. Do not run this yet! Currently:
- Is able to stop most threads gracefully (might be some loggers/etc still)
- once traffic is drained off, closes and shuts down gracefully
- on restart, if a "reusable" segment is found, reloads via pointer fixup and inserting items back into the hash table.
- the main tradeoff is pointer fixup on restart vs offset pointers with fixup on use. Means the restart time can be long if the cache has many small items. A few million items seems to restart in seconds. 500 million can take two minutes. In the future it should be threadable, but keeping it simple for first release.
- since it's primarily operating on a file, you can also easily scp/netcat/etc a cache between machines. Everything needed for a restart should be contained in two files (main and .meta).

- this kills dynamic memory addition/removal. it might be possible to do a weird dance:
  - allow allocating a "absolute maximum" for the mmap.
  - only use -m worth of memory.
  - use slab page mover to move memory out of the end pages, then MADV_DONTNEED to ditch the memory? I have no idea if this works or is portable or if there're other options.
  - re-allocate at the end if memory limit is increased

EDIT:

restart process:
- if there's a .meta file, open it and walk through it for data nuggets to validate or restore. crc32 the whole thing
- delete the .meta file once it's been read/validated.
- on close, walk through each submodule and let them allocate and extend space as necessary and just write into the file.
- munmap and close both files.

TODO:

- [x] Make tests pass when `-e` not supplied.
- [x] Start dedicated test file(s) :)
- [x] restore previous hashpower on restart; else could mass-insert items into tiny hash table.
- [x] Major code cleanups/debug output removal (refactor code out of slabs.c?)
- [x] Chunk pointer fixup for chunked items
- [ ] extstore support (second pass, maybe?)
- [x] Option for shmem path
- [x] External .meta file saved next to memory file.
- [x] Store config values for validation
- [ ] Use a numeric value for VERSION to make restart detection easier [maybe]
- [ ] crc32 the metadata? at very least murmurhash it.
- [x] Validate start arguments are compatible on a restart, bail if not
- [x] Remember time 
- [x] remember CAS value.
- [x] Remember logging gid
- [x] Restart optimizations: if remembering state (obj count/etc), can avoid some stats updates.
- [ ] Start `-t` worth of threads and parallelize recovery [update: punting on this for now]
- [x] Ensure all features restart properly (maintainer, crawler, etc).
- [ ] probably doesn't work on 32bit systems :|
- [ ] support 'shutdown' command for graceful stop