### PR TITLE
Replace event_init() with event_base_new() for thread safety

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -7573,7 +7573,17 @@ int main (int argc, char **argv) {
     }
 
     /* initialize main thread libevent instance */
+#if defined(LIBEVENT_VERSION_NUMBER) && LIBEVENT_VERSION_NUMBER >= 0x02000101
+    /* If libevent version is larger/equal to 2.0.2-alpha, use newer version */
+    struct event_config *ev_config;
+    ev_config = event_config_new();
+    event_config_set_flag(ev_config, EVENT_BASE_FLAG_NOLOCK);
+    main_base = event_base_new_with_config(ev_config);
+    event_config_free(ev_config);
+#else
+    /* Otherwise, use older API */
     main_base = event_init();
+#endif
 
     /* initialize other stuff */
     logger_init();
@@ -7757,6 +7767,9 @@ int main (int argc, char **argv) {
       free(l_socket);
     if (u_socket)
       free(u_socket);
+
+    /* cleanup base */
+    event_base_free(main_base);
 
     return retval;
 }

--- a/thread.c
+++ b/thread.c
@@ -309,7 +309,16 @@ void accept_new_conns(const bool do_accept) {
  * Set up a thread's information.
  */
 static void setup_thread(LIBEVENT_THREAD *me) {
+#if defined(LIBEVENT_VERSION_NUMBER) && LIBEVENT_VERSION_NUMBER >= 0x02000101
+    struct event_config *ev_config;
+    ev_config = event_config_new();
+    event_config_set_flag(ev_config, EVENT_BASE_FLAG_NOLOCK);
+    me->base = event_base_new_with_config(ev_config);
+    event_config_free(ev_config);
+#else
     me->base = event_init();
+#endif
+
     if (! me->base) {
         fprintf(stderr, "Can't allocate event base\n");
         exit(1);
@@ -374,6 +383,8 @@ static void *worker_libevent(void *arg) {
     register_thread_initialized();
 
     event_base_loop(me->base, 0);
+
+    event_base_free(me->base);
     return NULL;
 }
 


### PR DESCRIPTION
Change to use event_base_new() instead of obsolete event_init() for creating
new event base. Also add evthread_use_pthreads() before using any libevent
function to enable thread-safe functions and structures in libevent.

By default, using this combination of APIs will add a lock to the event base.
This can prevent a potential race condition where one worker thread is polling on
its event base and handling requests while a new connection is dispatched and
added to that worker's event base. The performance is unlikely to be affected
by the lock.

This patch may relate to an [ancient issue from 2010](https://groups.google.com/forum/#!topic/memcached/pESfuEq7QAw), or [the one from 2012](https://code.google.com/archive/p/memcached/issues/141). According to [libevent documentation](http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/event__compat_8h.html#a1bf74386dd3725e1538fed2d70c1c113), `event_init()` is deprecated and is totally unsafe for multithreaded use. 