### PR TITLE
Fix lru_crawler skipping over last entry in slab in item_crawler_thread.

### DIFF
--- a/crawler.c
+++ b/crawler.c
@@ -533,6 +533,14 @@ static int do_lru_crawler_start(uint32_t id, uint32_t remaining) {
         if (remaining == LRU_CRAWLER_CAP_REMAINING) {
             remaining = do_get_lru_size(sid);
         }
+        /* Values for remaining:
+         * remaining = 0
+         * - scan all elements, until a NULL is reached
+         * - if empty, NULL is reached right away
+         * remaining = n + 1
+         * - first n elements are parsed (or until a NULL is reached)
+         */
+        if (remaining) remaining++;
         crawlers[sid].remaining = remaining;
         crawlers[sid].slabs_clsid = sid;
         crawlers[sid].reclaimed = 0;

--- a/t/lru-crawler.t
+++ b/t/lru-crawler.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 221;
+use Test::More tests => 222;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -58,6 +58,18 @@ while (1) {
     is($slabs->{"1:used_chunks"}, 60, "slab1 now has 60 used chunks");
     my $items = mem_stats($sock, "items");
     is($items->{"items:1:crawler_reclaimed"}, 30, "slab1 has 30 reclaims");
+}
+
+# Check that crawler metadump works correctly.
+{
+    print $sock "lru_crawler metadump all\r\n";
+    my $count = 0;
+    while (<$sock>) {
+        last if /^(\.|END)/;
+        /^(key=) (\S+).*([^\r\n]+)/;
+        $count++;
+    }
+    is ($count, 60);
 }
 
 for (1 .. 30) {


### PR DESCRIPTION
When using `lru_crawler metadump all` to dump cache contents, there is always one less key returned per slab.
Steps to reproduce and more details in issue #362 .

Problem seems to stem from a decrement before comparison in `item_crawler_thread`, on the following line:
https://github.com/memcached/memcached/blob/dbb7a8af90054bf4ef51f5814ef7ceb17d83d974/crawler.c#L389
When `crawlers[i].remaining` reaches 1, it gets decremented to 0, and `lru_crawler_class_done(i)` gets called, without calling `eval()` on the last item.

Please review and confirm.