### PR TITLE
Fix SASL_CB_GETCONF(PATH) detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,9 +122,33 @@ unsigned long val = SASL_CB_GETCONF;
                      [Set to nonzero if your SASL implementation supports SASL_CB_GETCONF])])
 ])
 
+dnl **********************************************************************
+dnl DETECT_SASL_CB_GETCONFPATH
+dnl
+dnl check if we can use SASL_CB_GETCONFPATH
+dnl **********************************************************************
+AC_DEFUN([AC_C_DETECT_SASL_CB_GETCONFPATH],
+[
+    AC_CACHE_CHECK([for SASL_CB_GETCONFPATH],
+        [ac_cv_c_sasl_cb_getconfpath],
+        [AC_TRY_COMPILE(
+            [
+#include <sasl/sasl.h>
+            ], [
+unsigned long val = SASL_CB_GETCONFPATH;
+            ],
+            [ ac_cv_c_sasl_cb_getconfpath=yes ],
+            [ ac_cv_c_sasl_cb_getconfpath=no ])
+        ])
+    AS_IF([test "$ac_cv_c_sasl_cb_getconfpath" = "yes"],
+          [AC_DEFINE([HAVE_SASL_CB_GETCONFPATH], 1,
+                     [Set to nonzero if your SASL implementation supports SASL_CB_GETCONFPATH])])
+])
+
 AC_CHECK_HEADERS([sasl/sasl.h])
 if test "x$enable_sasl" = "xyes"; then
   AC_C_DETECT_SASL_CB_GETCONF
+  AC_C_DETECT_SASL_CB_GETCONFPATH
   AC_DEFINE([ENABLE_SASL],1,[Set to nonzero if you want to include SASL])
   AC_SEARCH_LIBS([sasl_server_init], [sasl2 sasl], [],
     [

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -7,7 +7,7 @@
 
 char my_sasl_hostname[1025];
 
-#ifdef HAVE_SASL_CB_GETCONF
+#if defined(HAVE_SASL_CB_GETCONF) || defined(HAVE_SASL_CB_GETCONFPATH)
 /* The locations we may search for a SASL config file if the user didn't
  * specify one in the environment variable SASL_CONF_PATH
  */
@@ -82,7 +82,7 @@ static int sasl_server_userdb_checkpass(sasl_conn_t *conn,
 }
 #endif
 
-#ifdef HAVE_SASL_CB_GETCONF
+#if defined(HAVE_SASL_CB_GETCONF) || defined(HAVE_SASL_CB_GETCONFPATH)
 static int sasl_getconf(void *context, const char **path)
 {
     *path = getenv("SASL_CONF_PATH");
@@ -152,6 +152,10 @@ static sasl_callback_t sasl_callbacks[] = {
 
 #ifdef HAVE_SASL_CB_GETCONF
    { SASL_CB_GETCONF, sasl_getconf, NULL },
+#else
+#ifdef HAVE_SASL_CB_GETCONFPATH
+   { SASL_CB_GETCONFPATH, (sasl_callback_ft)sasl_getconf, NULL },
+#endif
 #endif
 
    { SASL_CB_LIST_END, NULL, NULL }


### PR DESCRIPTION
Fix for https://github.com/memcached/memcached/issues/365
On RHEL(5|6|7) the name of the defined constant in sasl.h is SASL_CB_GETCONFPATH and not SASL_CB_GETCONF, this adds support for HAVE_SASL_CB_GETCONFPATH in configure.ac and then uses it in sasl_defs.c