### PR TITLE
Drop supplementary groups in addition to setgid

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -7536,6 +7536,10 @@ int main (int argc, char **argv) {
             fprintf(stderr, "can't find the user %s to switch to\n", username);
             exit(EX_NOUSER);
         }
+        if (setgroups(0, NULL) < 0) {
+            fprintf(stderr, "failed to drop supplementary groups\n");
+            exit(EX_OSERR);
+        }
         if (setgid(pw->pw_gid) < 0 || setuid(pw->pw_uid) < 0) {
             fprintf(stderr, "failed to assume identity of user %s\n", username);
             exit(EX_OSERR);

--- a/memcached.h
+++ b/memcached.h
@@ -18,6 +18,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <assert.h>
+#include <grp.h>
 
 #include "itoa_ljust.h"
 #include "protocol_binary.h"


### PR DESCRIPTION
When launching as root, we drop permissions to run as a specific user, however the way this is done fails to drop supplementary groups from the process.

On many systems, the root user is a member of many groups used to guard important system files. If we neglect to drop these groups it's still possible for a compromised memcached instance to access critical system files as though it were running with root level permissions.

On any given system `grep root /etc/group` will reveal all the groups root is a member of, and memcached will have access to any file these groups are authorized for, in spite of our attempts
to drop this access.

It's possible to test if a given memcached instance is affected by this and running with elevated permissions by checking the respective line in procfs: `grep Groups /proc/$pid/status`

If any groups are listed, memcached would have access to everything the listed groups have access to. After this patch no groups will be listed and memcached will be locked down properly.