### PR TITLE
Fix seccomp for lru-crawl

### DIFF
--- a/linux_priv.c
+++ b/linux_priv.c
@@ -58,8 +58,13 @@ void drop_privileges(void) {
         goto fail;
     }
 
+    seccomp_release(ctx);
+    return;
+
 fail:
     seccomp_release(ctx);
+    fprintf(stderr, "Failed to set a seccomp profile on the main thread\n");
+    exit(EXIT_FAILURE);
 }
 
 void drop_worker_privileges(void) {
@@ -135,6 +140,11 @@ void drop_worker_privileges(void) {
         goto fail;
     }
 
+    seccomp_release(ctx);
+    return;
+
 fail:
     seccomp_release(ctx);
+    fprintf(stderr, "Failed to set a seccomp profile on a worker thread\n");
+    exit(EXIT_FAILURE);
 }

--- a/linux_priv.c
+++ b/linux_priv.c
@@ -80,6 +80,7 @@ void drop_worker_privileges(void) {
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(epoll_wait), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(epoll_pwait), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(epoll_ctl), 0);
+    rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(poll), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(readv), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mprotect), 0);


### PR DESCRIPTION
Add missing `poll` call for the worker. Also make sure that we fail loudly if the seccomp setup fails.
Fixes #372 