### PR TITLE
Fix segfault: Prevent calling sasl_server_step before sasl_server_start

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -555,6 +555,7 @@ typedef struct _io_wrap {
 struct conn {
     int    sfd;
     sasl_conn_t *sasl_conn;
+    bool sasl_started;
     bool authenticated;
     enum conn_states  state;
     enum bin_substates substate;

--- a/t/binary-sasl.t
+++ b/t/binary-sasl.t
@@ -192,7 +192,9 @@ for my $dir (split(/:/, $ENV{PATH}),
     }
 }
 
-system("echo testpass | $saslpasswd_path -a memcached -c -p testuser");
+my $sasl_realm = 'memcached.realm';
+
+system("echo testpass | $saslpasswd_path -a memcached -u $sasl_realm -c -p testuser");
 
 $mc = MC::Client->new;
 
@@ -309,7 +311,7 @@ sub new {
 sub authenticate {
     my ($self, $user, $pass, $mech)= @_;
     $mech ||= 'PLAIN';
-    my $buf = sprintf("%c%s%c%s", 0, $user, 0, $pass);
+    my $buf = sprintf("%c%s@%s%c%s", 0, $user, $sasl_realm, 0, $pass);
     my ($status, $rv, undef) = $self->_do_command(::CMD_SASL_AUTH, $mech, $buf, '');
     return $status;
 }
@@ -661,4 +663,3 @@ sub auth_error {
 unlink $sasldb;
 
 # vim: filetype=perl
-


### PR DESCRIPTION
Fixes: https://github.com/memcached/memcached/issues/379

If sasl_server_step is called on a sasl_conn which has not had sasl_server_start called on it, it will segfault from reading uninitialized memory.

Memcached currently calls sasl_server_start when the client sends the SASL_AUTH command and sasl_server_step when the client sends the SASL_STEP command. So if the client sends SASL_STEP before SASL_AUTH, the server segfaults.

For well-behaved clients, this case never happens; but for the java-memcached-client, when configured with an incorrect password, it happens very frequently. This is likely because the client handles auth on a background thread and the socket may be swapped out in the middle of authentication. You can see that code here: https://github.com/dustin/java-memcached-client/blob/master/src/main/java/net/spy/memcached/auth/AuthThread.java

The specific line that causes the segfault in libsasl is in sasl_server_step in server.c:
```c
    ret = s_conn->mech->m.plug->mech_step(conn->context,
					s_conn->sparams,
					clientin,
					clientinlen,
					serverout,
					serveroutlen,
					&conn->oparams);
```
it segfaults when doing the `s_conn->mech->m.plug` part with an error like `Cannot access memory at address 0x10`. This is because `s_conn->mech` is `NULL`.

---

I'm not sure that this is the best fix since it adds another field to the conn struct, but I could not find a way to cleanly determine if the sasl_conn had had sasl_server_start called on it using the existing data structures since `sasl_conn_t` is private so I can't just do `c->sasl_conn->mech == NULL`. Using the public libsasl API, I tried calling `sasl_getprop` like:
```c
const char *sasl_mech_name;
sasl_getprop(c->sasl_conn, SASL_MECHNAME, (const void **) &sasl_mech_name);
```
calling that from `process_bin_complete_sasl_auth`, `sasl_mech_name` ends up getting set to the value of `c->sfd`. Depending on where you call that from, you end up with a different piece of the conn struct, or a segfault. I'm almost wondering if libsasl should really have this guard since it seems fairly prone to exploitation.

I'm more than willing to modify this PR as necessary, but I wanted to post something to get the ball rolling.