### PR TITLE
Include keys with non-[\w.~-] bytes in memcached-tool dump

### DIFF
--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -98,10 +98,13 @@ if ($mode eq 'dump') {
         # return format looks like this
         # key=foo exp=2147483647 la=1521046038 cas=717111 fetch=no cls=13 size=1232
         if (/^key=(\S+) exp=(-?\d+) .*/) {
+            my $k = $1;
+            $k =~ s/%(.{2})/chr hex $1/eg;
+
             if ($2 == -1) {
-                $keyexp{$1} = 0;
+                $keyexp{$k} = 0;
             } else {
-                $keyexp{$1} = $2;
+                $keyexp{$k} = $2;
             }
         }
         $keycount++;


### PR DESCRIPTION
`lru_crawler metadump` uses `uriencode`.