### PR TITLE
Add .swp/.swo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,6 @@ doc/protocol-binary.txt
 /doc/doxy
 /memcached.spec
 .*.swp
+.swp
+.swo
 /compile_commands.json

--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -6,13 +6,12 @@ our @files;
 BEGIN {
     chdir "$Bin/.." or die;
 
-    my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md compile_commands.json);
+    my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md);
     push(@exempted, glob("doc/*.xml"));
     push(@exempted, glob("doc/*.full"));
     push(@exempted, glob("doc/xml2rfc/*.xsl"));
     push(@exempted, glob("m4/*backport*m4"));
     push(@exempted, glob("*.orig"));
-    push(@exempted, glob(".*.swp"));
     my %exempted_hash = map { $_ => 1 } @exempted;
 
     my @stuff = split /\0/, `git ls-files -z -c -m -o --exclude-standard`;


### PR DESCRIPTION
`t/whitespace.t` fails for me because I have `.swo` and `.swp` files created by `vim` in the project root. I believe vim is pretty common and it can be a good idea to add them to `.gitignore`.

Also, we probably don't need to explicitly exempt files in the test that are mentioned in `.gitignore`.