### PR TITLE
Mark seccomp experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ list to ask questions, github issues aren't seen by everyone!
 ## Dependencies
 
 * libevent, http://www.monkey.org/~provos/libevent/ (libevent-dev)
-* libseccomp, (optional, linux) - enables process restrictions for better
-  security.
+* libseccomp, (optional, experimental, linux) - enables process restrictions for
+  better security. Tested only on x86_64 architectures.
 
 ## Environment
 

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ AC_ARG_ENABLE(extstore,
   [AS_HELP_STRING([--enable-extstore], [Enable external storage EXPERIMENTAL ])])
 
 AC_ARG_ENABLE(seccomp,
-  [AS_HELP_STRING([--enable-seccomp],[Enable seccomp restrictions])])
+  [AS_HELP_STRING([--enable-seccomp],[Enable seccomp restrictions EXPERIMENTAL])])
 
 AC_ARG_ENABLE(sasl,
   [AS_HELP_STRING([--enable-sasl],[Enable SASL authentication])])


### PR DESCRIPTION
To make it less likely that distros enable seccomp by default, mark it
as EXPERIMENTAL in both readme and configure help.