### PR TITLE
Add a handler for seccomp crashes

### DIFF
--- a/devtools/Dockerfile.alpine
+++ b/devtools/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf
+RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf perl-test-harness-utils
 
 ADD . /src
 WORKDIR /src

--- a/devtools/Dockerfile.fedora
+++ b/devtools/Dockerfile.fedora
@@ -1,0 +1,12 @@
+FROM fedora:latest
+
+RUN dnf install -y perl automake autoconf libseccomp-devel libevent-devel gcc make git
+
+ADD . /src
+WORKDIR /src
+
+RUN aclocal && autoheader && automake --foreign --add-missing && autoconf
+RUN ./configure --enable-seccomp
+RUN make -j
+
+CMD make test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,7 @@ services:
         build:
             context: .
             dockerfile: devtools/Dockerfile.arch
+    fedora:
+        build:
+            context: .
+            dockerfile: devtools/Dockerfile.fedora

--- a/linux_priv.c
+++ b/linux_priv.c
@@ -3,10 +3,58 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
+#include <signal.h>
+#include <string.h>
 #include "memcached.h"
 
+static char *kill_msg;
+// Make sure to preserve the ??? position in the string, or correct the offsets
+// in the syssig handler.
+#define KILL_MSG_STR "Seccomp policy failure. Caught syscall ???. This is " \
+    "either an exploit attempt, or your system is not supported yet.\n"
+
+static void handle_syssig(int signum, siginfo_t *si, void *thread_context) {
+#if defined(si_syscall)
+    int syscall_no = si->si_syscall;
+#else
+    // If system has no support for si_syscal, the information may not be
+    // precise.
+    int syscall_no = si->si_value.sival_int;
+#endif
+
+    // Replace the characters in the kill message with the syscall number. We
+    // can't safely printf (even write is not really valid, but we're crashing
+    // anyway).
+
+    kill_msg[39] = (syscall_no / 100) % 10 + '0';
+    kill_msg[40] = (syscall_no / 10) % 10 + '0';
+    kill_msg[41] = syscall_no % 10 + '0';
+    if (write(2, kill_msg, strlen(kill_msg)) == -1) {
+        // An error occurred, but we can't do anything about it here. This check
+        // is mostly to avoid the "ignoring return value of 'write'" error on
+        // distributions with broken gcc (no "ignore via cast to void" support).
+    }
+
+    // We can't use the nice exit() version because it causes at_exit handlers
+    // to be looked up and run. We can't take any locks while handling the
+    // signal, so _exit() is the only thing to do safely.
+    _exit(EXIT_FAILURE);
+}
+
+static const struct sigaction act = {
+    .sa_sigaction = handle_syssig,
+    .sa_flags = SA_SIGINFO,
+};
+
+void setup_privilege_violations_handler(void) {
+    kill_msg = malloc(strlen(KILL_MSG_STR)+1);
+    strcpy(kill_msg, KILL_MSG_STR);
+
+    sigaction(SIGSYS, &act, NULL);
+}
+
 // If anything crosses the policy, kill the process.
-#define DENY_ACTION SCMP_ACT_KILL
+#define DENY_ACTION SCMP_ACT_TRAP
 
 void drop_privileges(void) {
     scmp_filter_ctx ctx = seccomp_init(DENY_ACTION);

--- a/memcached.c
+++ b/memcached.c
@@ -8175,6 +8175,10 @@ int main (int argc, char **argv) {
         slabs_prefill_global();
     }
 #endif
+
+    if (settings.drop_privileges) {
+        setup_privilege_violations_handler();
+    }
     /*
      * ignore SIGPIPE signals; we can use errno == EPIPE if we
      * need that information

--- a/memcached.h
+++ b/memcached.h
@@ -819,8 +819,10 @@ void append_stat(const char *name, ADD_STAT add_stats, conn *c,
 enum store_item_type store_item(item *item, int comm, conn *c);
 
 #if HAVE_DROP_PRIVILEGES
+extern void setup_privilege_violations_handler(void);
 extern void drop_privileges(void);
 #else
+#define setup_privilege_violations_handler()
 #define drop_privileges()
 #endif
 

--- a/openbsd_priv.c
+++ b/openbsd_priv.c
@@ -26,3 +26,6 @@ void drop_privileges() {
        }
      }
 }
+
+void drop_worker_privileges(void) {
+}

--- a/solaris_priv.c
+++ b/solaris_priv.c
@@ -42,3 +42,7 @@ void drop_privileges(void) {
 
    priv_freeset(privs);
 }
+
+void setup_privilege_violations_handler(void) {
+   // not needed
+}

--- a/t/misbehave.t
+++ b/t/misbehave.t
@@ -23,6 +23,7 @@ sleep(1);
 # check if the socket is dead now
 my $buff;
 my $ret = recv($sock, $buff, 1, MSG_PEEK | MSG_DONTWAIT);
-is($ret, undef, "did not allow misbehaving");
+# ret = 0 means read 0 bytes, which means a closed socket
+ok($ret == 0, "did not allow misbehaving");
 
 $server->DESTROY();


### PR DESCRIPTION
When seccomp causes a crash, use a SIGSYS action and handle it to print
out an error. Most functions are not allowed at that point (no buffered
output, no ?printf functions, no abort, ...), so the implementation is
as minimal as possible.
Print out a message with the syscall number and exit the process (all
threads).