### PR TITLE
Extstore performance boost and JBOD support

### DIFF
--- a/storage.h
+++ b/storage.h
@@ -7,6 +7,7 @@ void storage_write_resume(void);
 int start_storage_compact_thread(void *arg);
 void storage_compact_pause(void);
 void storage_compact_resume(void);
+struct extstore_conf_file *storage_conf_parse(char *arg, unsigned int page_size);
 
 // Ignore pointers and header bits from the CRC
 #define STORE_OFFSET offsetof(item, nbytes)

--- a/t/binary-extstore.t
+++ b/t/binary-extstore.t
@@ -17,7 +17,7 @@ if (!supports_extstore()) {
 
 $ext_path = "/tmp/extstore.$$";
 
-my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_page_count=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path,no_lru_crawler,slab_automove=0");
+my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,no_lru_crawler,slab_automove=0");
 ok($server, "started the server");
 
 # Based almost 100% off testClient.py which is:

--- a/t/chunked-extstore.t
+++ b/t/chunked-extstore.t
@@ -18,7 +18,7 @@ if (!supports_extstore()) {
 
 $ext_path = "/tmp/extstore.$$";
 
-my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_page_count=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path,slab_chunk_max=16384,slab_automove=0,ext_compact_under=1");
+my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,slab_chunk_max=16384,slab_automove=0,ext_compact_under=1");
 my $sock = $server->sock;
 
 # Wait until all items have flushed

--- a/t/error-extstore.t
+++ b/t/error-extstore.t
@@ -20,7 +20,7 @@ if (!supports_extstore()) {
 
 $ext_path = "/tmp/extstore.$$";
 
-my $server = new_memcached("-m 64 -I 4m -U 0 -o ext_page_size=8,ext_page_count=8,ext_wbuf_size=8,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path,slab_automove=0,ext_compact_under=1");
+my $server = new_memcached("-m 64 -I 4m -U 0 -o ext_page_size=8,ext_wbuf_size=8,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,slab_automove=0,ext_compact_under=1");
 my $sock = $server->sock;
 
 # Wait until all items have flushed

--- a/t/extstore.t
+++ b/t/extstore.t
@@ -17,7 +17,7 @@ if (!supports_extstore()) {
 
 $ext_path = "/tmp/extstore.$$";
 
-my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_page_count=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path,slab_automove=0,ext_compact_under=1");
+my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,slab_automove=0,ext_compact_under=1");
 my $sock = $server->sock;
 
 # Wait until all items have flushed


### PR DESCRIPTION
With JBOD support, specifying disk space is also finally sane, but this deprecates -o ext_page_buckets immediately.

example:
`-o ext_path=/m/f/e1:500g,ext_path=/m/h/e2:500g,ext_path=/m/g/e3:1t:compact`

gives 500G worth of pages available for any use (default) split across two devices. a third device has 1TB of pages available only for compacted data. This can be used to mix and match different types or costs of drives, such as optane+SSD, or SLC|MLC+TLC drives.

as of this PR, bucket routing is disabled as that requires further fixes to the compaction algorithm. multiple devices may be added to the default free bucket just fine.

Some things don't make a ton of sense right now but given the production bottlenecks it's likely fine:
 - just a big shared pool of IO threads.
 - each type of page bucket gets one write buffer.
which means the drives can sort of read/write independently.