### PR TITLE
expand NEED_ALIGN for chunked items

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -524,6 +524,23 @@ typedef struct _strchunk {
     uint8_t          slabs_clsid; /* Same as above. */
     char data[];
 } item_chunk;
+
+#ifdef NEED_ALIGN
+static inline char *ITEM_schunk(item *it) {
+    int offset = it->nkey + 1 + it->nsuffix
+        + ((it->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0);
+    int remain = offset % 8;
+    if (remain != 0) {
+        offset += 8 - remain;
+    }
+    return ((char *) &(it->data)) + offset;
+}
+#else
+#define ITEM_schunk(item) ((char*) &((item)->data) + (item)->nkey + 1 \
+         + (item)->nsuffix \
+         + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
+#endif
+
 #ifdef EXTSTORE
 typedef struct {
     unsigned int page_version; /* from IO header */

--- a/storage.c
+++ b/storage.c
@@ -62,7 +62,7 @@ static int storage_write(void *storage, const int clsid, const int item_age) {
                 // TODO: should be in items.c
                 if (it->it_flags & ITEM_CHUNKED) {
                     // Need to loop through the item and copy
-                    item_chunk *sch = (item_chunk *) ITEM_data(it);
+                    item_chunk *sch = (item_chunk *) ITEM_schunk(it);
                     int remain = orig_ntotal;
                     int copied = 0;
                     // copy original header


### PR DESCRIPTION
potential fix for #409 

not confident this is bug free.

some whackarse ARM platforms on specific glibc/gcc (new?) versions trip
SIGBUS while reading the header chunk for a split item.

the header chunk is unfortunate magic: It lives in ITEM_data() at a random
offset, is zero sized, and only exists to simplify code around finding the
orignial slab class, and linking/relinking subchunks to an item.

there's no fix to this which isn't a lot of code. I need to refactor chunked
items, and attempted to do so, but couldn't come up with something I liked
quickly enough.

This change pads the first chunk if alignment is necessary, which wastes
bytes and a little CPU, but I'm not going to worry a ton for these obscure
platforms.