### PR TITLE
Make lru-maintainer test less flaky

### DIFF
--- a/t/lru-maintainer.t
+++ b/t/lru-maintainer.t
@@ -76,6 +76,7 @@ for (my $key = 0; $key < 100; $key++) {
 {
     my $stats = mem_stats($sock);
     isnt($stats->{evictions}, 0, "some evictions happened");
+    sleep 1;
     my $istats = mem_stats($sock, "items");
     isnt($istats->{"items:31:number_warm"}, 0, "our canary moved to warm");
     use Data::Dumper qw/Dumper/;


### PR DESCRIPTION
Without this patch, building the memcached openSUSE package
in a 1-core-VM using `osc build --vm-type=kvm --noservice -j1`
would fail on a busy host with

```
#   Failed test 'our canary moved to warm'
#   at t/lru-maintainer.t line 81.
#          got: '0'
#     expected: anything else
# Looks like you failed 1 test of 226.
t/lru-maintainer.t ..........
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/226 subtests
```
The host was made busy with
`perl -e 'fork;fork;fork;fork;while(1){}'`