### PR TITLE
extstore: tiered storage

### DIFF
--- a/extstore.h
+++ b/extstore.h
@@ -9,6 +9,7 @@ struct extstore_page_data {
     uint64_t bytes_used;
     unsigned int bucket;
     unsigned int free_bucket;
+    bool active; // page is actively being written to; ignore it except for tallying.
 };
 
 /* Pages can have objects deleted from them at any time. This creates holes
@@ -105,6 +106,7 @@ void *extstore_init(struct extstore_conf_file *fh, struct extstore_conf *cf, enu
 int extstore_write_request(void *ptr, unsigned int bucket, unsigned int free_bucket, obj_io *io);
 void extstore_write(void *ptr, obj_io *io);
 int extstore_submit(void *ptr, obj_io *io);
+int extstore_submit_bg(void *ptr, obj_io *io);
 /* count are the number of objects being removed, bytes are the original
  * length of those objects. Bytes is optional but you can't track
  * fragmentation without it.
@@ -116,7 +118,7 @@ void extstore_get_stats(void *ptr, struct extstore_stats *st);
  * caller must allocate its stats.page_data memory first.
  */
 void extstore_get_page_data(void *ptr, struct extstore_stats *st);
-void extstore_run_maint(void *ptr);
 void extstore_close_page(void *ptr, unsigned int page_id, uint64_t page_version);
+void extstore_evict_page(void *ptr, unsigned int page_id, uint64_t page_version);
 
 #endif

--- a/memcached.c
+++ b/memcached.c
@@ -4193,10 +4193,10 @@ static void usage(void) {
            "   - ext_drop_unread:     don't re-write unread values during compaction (default: %s)\n"
            "   - ext_recache_rate:    recache an item every N accesses (default: %u)\n"
            "   - ext_compact_under:   compact when fewer than this many free pages\n"
-           "                          (default: 1/4th of the assigned storage)\n"
+           "                          (default: 1 percent of the assigned storage)\n"
            "   - ext_drop_under:      drop COLD items when fewer than this many free pages\n"
            "                          (default: 1/4th of the assigned storage)\n"
-           "   - ext_max_frag:        max page fragmentation to tolerate (default: %.2f)\n"
+           "   - ext_max_frag:        only defrag pages if they are less full than this pct-wise (default: %.2f)\n"
            "   - ext_max_sleep:       max sleep time of background threads in us (default: %u)\n"
            "   - slab_automove_freeratio: ratio of memory to hold free as buffer.\n"
            "                          (see doc/storage.txt for more info, default: %.3f)\n",

--- a/memcached.h
+++ b/memcached.h
@@ -414,6 +414,8 @@ struct stats {
     uint64_t      extstore_compact_lost; /* items lost because they were locked */
     uint64_t      extstore_compact_rescues; /* items re-written during compaction */
     uint64_t      extstore_compact_skipped; /* unhit items skipped during compaction */
+    uint64_t      extstore_compact_resc_cold; /* items re-written during compaction */
+    uint64_t      extstore_compact_resc_old; /* items re-written during compaction */
 #endif
 #ifdef TLS
     uint64_t      ssl_handshake_errors; /* TLS failures at accept/handshake time */

--- a/t/binary-extstore.t
+++ b/t/binary-extstore.t
@@ -184,7 +184,7 @@ $set->('x', 10, 19, "somevalue");
 
 # check evictions and misses
 {
-    my $keycount = 1000;
+    my $keycount = 1250;
     for (1 .. $keycount) {
         $set->("mfoo$_", 0, 19, $value);
     }

--- a/t/extstore-tiered.t
+++ b/t/extstore-tiered.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;
@@ -19,74 +19,69 @@ if (!supports_extstore()) {
 $ext_path = "/tmp/extstore1.$$";
 $ext_path2 = "/tmp/extstore2.$$";
 
-my $server = new_memcached("-m 256 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,ext_path=$ext_path2:96m,slab_automove=1,ext_max_sleep=100000");
+my $server = new_memcached("-m 256 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m:default,ext_path=$ext_path2:96m:compact,slab_automove=1,ext_max_sleep=100000");
 my $sock = $server->sock;
 
 my $value;
+my $lvalue;
 {
     my @chars = ("C".."Z");
     for (1 .. 20000) {
         $value .= $chars[rand @chars];
+    }
+    for (1 .. 15000) {
+        $lvalue .= $chars[rand @chars];
     }
 }
 
 # fill some larger objects
 {
     my $free_before = summarize_buckets(mem_stats($sock, ' extstore'));
-    # we gave 64m and 96m devices, so pages in DEFAULT should be > 8 or 12 to
-    # be sure they're both in the same pool.
-    cmp_ok($free_before->[0], '>', 18, "default has more pages");
-    my $keycount = 4000;
+    my $keycount = 1200;
     for (1 .. $keycount) {
         print $sock "set nfoo$_ 0 0 20000 noreply\r\n$value\r\n";
         print $sock "set lfoo$_ 0 0 20000 noreply\r\n$value\r\n";
     }
     # wait for a flush
     wait_ext_flush($sock);
-    # TODO: this is failing only on github actions and I have no idea why.
-    #mem_get_is($sock, "nfoo1", $value);
-    # fill to excess
-    for (1 .. $keycount) {
-        print $sock "set kfoo$_ 0 0 20000 noreply\r\n$value\r\n";
-        print $sock "set zfoo$_ 0 0 20000 noreply\r\n$value\r\n";
-    }
-    wait_ext_flush($sock);
-
-    my $free_after = summarize_buckets(mem_stats($sock, ' extstore'));
     # delete half
+    mem_get_is($sock, "nfoo1", $value);
     for (1 .. $keycount) {
         print $sock "delete lfoo$_ noreply\r\n";
     }
-    print $sock "lru_crawler crawl all\r\n";
-    <$sock>;
+    #    print $sock "lru_crawler crawl all\r\n";
+    #<$sock>;
+    # set a few more to kick off compaction?
+    $keycount = 2000;
+    for (1 .. $keycount) {
+        print $sock "set kfoo$_ 0 0 15000 noreply\r\n$lvalue\r\n";
+    }
+    # wait for a flush
+    wait_ext_flush($sock);
 
-    cmp_ok($free_after->[0], '<', 4, "default is mostly full");
-    # fetch
     # check extstore counters
+    my $free_after = summarize_buckets(mem_stats($sock, ' extstore'));
     my $stats = mem_stats($sock);
     is($stats->{evictions}, 0, 'no RAM evictions');
     cmp_ok($stats->{extstore_page_allocs}, '>', 0, 'at least one page allocated');
     cmp_ok($stats->{extstore_objects_written}, '>', $keycount / 2, 'some objects written');
     cmp_ok($stats->{extstore_bytes_written}, '>', length($value) * 2, 'some bytes written');
-    # commented out because we're not testing fetching data back in this test.
-    #cmp_ok($stats->{get_extstore}, '>', 0, 'one object was fetched');
-    #cmp_ok($stats->{extstore_objects_read}, '>', 0, 'one object read');
-    #cmp_ok($stats->{extstore_bytes_read}, '>', length($value), 'some bytes read');
-    cmp_ok($stats->{extstore_page_evictions}, '>', 0, 'at least one page evicted');
+    cmp_ok($stats->{get_extstore}, '>', 0, 'one object was fetched');
+    cmp_ok($stats->{extstore_objects_read}, '>', 0, 'one object read');
+    cmp_ok($stats->{extstore_bytes_read}, '>', length($value), 'some bytes read');
     cmp_ok($stats->{extstore_page_reclaims}, '>', 1, 'at least two pages reclaimed');
+    cmp_ok($stats->{extstore_compact_rescues}, '>', 1, 'at least two compact rescues');
+    cmp_ok($free_before->[1], '>', 0, 'compact bucket has dedicated free pages');
+    cmp_ok($free_before->[0], '>', $free_after->[0], 'fewer free default pages');
+    cmp_ok($free_before->[1], '>', $free_after->[1], 'fewer free compact pages');
 }
 
 sub summarize_buckets {
     my $s = shift;
     my @buks = ();
-    for (0 .. 6) {
-        push(@buks, 0);
-    }
     my $is_free = 0;
     my $x = 0;
     while (exists $s->{$x . ':version'}) {
-        #my $fb = $s->{$x . ':free_bucket'};
-        #print STDERR "BYTES: [$x:$fb] ", $s->{$x . ':bytes'}, "\n";
         my $is_used = $s->{$x . ':version'};
         if ($is_used == 0) {
             # version of 0 means the page is free.

--- a/t/extstore-tiered2.t
+++ b/t/extstore-tiered2.t
@@ -1,0 +1,133 @@
+#!/usr/bin/perl
+# Testing specifically how COLD and OLD work
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+use Data::Dumper qw/Dumper/;
+
+my $ext_path;
+my $ext_path2;
+my $ext_path3;
+
+if (!supports_extstore()) {
+    plan skip_all => 'extstore not enabled';
+    exit 0;
+}
+
+$ext_path = "/tmp/extstore1.$$";
+$ext_path2 = "/tmp/extstore2.$$";
+$ext_path3 = "/tmp/extstore3.$$";
+
+my $server = new_memcached("-m 256 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m:default,ext_path=$ext_path2:64m:coldcompact,ext_path=$ext_path3:64m:old,slab_automove=1,ext_max_sleep=100000");
+my $sock = $server->sock;
+
+my $value;
+my $lvalue;
+{
+    my @chars = ("C".."Z");
+    for (1 .. 20000) {
+        $value .= $chars[rand @chars];
+    }
+    for (1 .. 15000) {
+        $lvalue .= $chars[rand @chars];
+    }
+}
+
+my $COLDC = 4;
+my $OLD = 5;
+{
+    my $free_before = summarize_buckets(mem_stats($sock, ' extstore'));
+    my $keycount = 1200;
+    for (1 .. $keycount) {
+        print $sock "set nfoo$_ 0 0 20000 noreply\r\n$value\r\n";
+        print $sock "set lfoo$_ 0 0 20000 noreply\r\n$value\r\n";
+    }
+    # wait for a flush
+    wait_ext_flush($sock);
+
+    # ensure we didn't overflow into the new tiered buckets.
+    my $free_now = summarize_buckets(mem_stats($sock, ' extstore'));
+    is($free_now->[$COLDC], 8, "all COLDCOMPACT buckets are currently free");
+    is($free_now->[$OLD], 8, "all OLD buckets are currently free");
+
+    # ping all of the nfoo*'s so we get some LRU shuffle.
+    for (1 .. $keycount) {
+        print $sock "get nfoo$_\r\n";
+        my $rline = scalar <$sock>;
+        if ($rline eq "END\r\n") {
+            fail("get nfoo$_ resulted in a miss");
+        } elsif ($rline =~ m/^VALUE/) {
+            my $body = scalar <$sock>;
+            if ($body ne "$value\r\n") {
+                fail("get nfoo$_ resulted in bad data: $body");
+            } else {
+                # END follows body
+                my $end = scalar <$sock>;
+                if ($end ne "END\r\n") {
+                    fail("get nfoo$_ missing END: $end");
+                }
+            }
+        }
+    }
+
+    # fill some more junk then check where data got pushed to.
+    $keycount = 6000;
+    for (1 .. $keycount) {
+        print $sock "set kfoo$_ 0 0 20000 noreply\r\n$value\r\n";
+    }
+    wait_ext_flush($sock);
+    $keycount = 6000;
+    for (1 .. $keycount) {
+        print $sock "set zfoo$_ 0 0 20000 noreply\r\n$value\r\n";
+    }
+    wait_ext_flush($sock);
+
+    my $free_after = summarize_buckets(mem_stats($sock, ' extstore'));
+    my $stats = mem_stats($sock);
+    is($stats->{evictions}, 0, 'no RAM evictions');
+    cmp_ok($stats->{extstore_page_allocs}, '>', 0, 'at least one page allocated');
+    cmp_ok($stats->{extstore_page_evictions}, '>', 0, 'at least one page evicted');
+    cmp_ok($stats->{extstore_objects_written}, '>', $keycount / 2, 'some objects written');
+    cmp_ok($stats->{extstore_bytes_written}, '>', length($value) * 2, 'some bytes written');
+    cmp_ok($stats->{get_extstore}, '>', 0, 'one object was fetched');
+    cmp_ok($stats->{extstore_objects_read}, '>', 0, 'one object read');
+    cmp_ok($stats->{extstore_bytes_read}, '>', length($value), 'some bytes read');
+    cmp_ok($stats->{extstore_page_reclaims}, '>', 1, 'at least two pages reclaimed');
+    cmp_ok($stats->{extstore_compact_rescues}, '>', 1, 'at least two compact rescues');
+    cmp_ok($stats->{extstore_compact_resc_cold}, '>', 5, 'compact rescues to COLDCOMPACT');
+    cmp_ok($stats->{extstore_compact_resc_old}, '>', 5, 'compact rescues to OLD');
+
+    cmp_ok($free_before->[$COLDC], '>', $free_after->[$COLDC], 'fewer free coldcompact pages');
+    cmp_ok($free_before->[$OLD], '>', $free_after->[$OLD], 'fewer free old pages');
+
+}
+
+sub summarize_buckets {
+    my $s = shift;
+    my @buks = ();
+    my $is_free = 0;
+    my $x = 0;
+    while (exists $s->{$x . ':version'}) {
+        #my $fb = $s->{$x . ':free_bucket'};
+        #print STDERR "BYTES: [$x:$fb] ", $s->{$x . ':bytes'}, "\n";
+        my $is_used = $s->{$x . ':version'};
+        if ($is_used == 0) {
+            # version of 0 means the page is free.
+            $buks[$s->{$x . ':free_bucket'}]++;
+        }
+        $x++;
+    }
+    return \@buks;
+}
+
+done_testing();
+
+END {
+    unlink $ext_path if $ext_path;
+    unlink $ext_path2 if $ext_path2;
+    unlink $ext_path3 if $ext_path3;
+}


### PR DESCRIPTION
earlier commits added the concept of free_buckets and were able to run
simple tests of tiered device storage.

this commit rewrites the way compaction is handled in extstore to be more efficient (write less), and enables concepts of tiered storage: items can be moved to different files/devices depending on their status.

run with: `ext_path=/path/f1:64m,ext_path=/path2/f2:128m:compact`
creates a 64m file for "default" pages and a 128m file for compacted
pages. Also works with 'chunked' and 'lowttl'

This also adds buckets `old` and `coldcompact`. IE:
`ext_path=/path/f1:64m,ext_path=/path2/f2:128m:old`

If `old` exists and we run out of disk space in the main buckets, items are moved from their original location to the device holding the `old` file. This is useful if you have a load/reload pattern where you may need the previous days's data to stick around, but it could be on a cheaper/slower device (like networked block storage)

`coldcompact` is similar to `old` but only takes items which reside in the COLD LRU. Both `old` and `coldcompact` can be used at the same time.

Other changes:

- fixes off-by-one preventing first page in each file from being used.
- page evictions are now done on-demand instead of async
- use a dedicated IO thread for writes and compaction work
- kick in compaction much later (1% of pages free by default, instead of 25%)
- check if compaction should run after writing occurs, rather than simply sleeping, to improve responsiveness.
- compact _the most fragmented pages first_ instead of simply the oldest.
- reduce CPU usage in various scenarios related to eviction/compaction.

- removes the "fragmentation slew" calculation from when compaction
should kick in. Instead of writing early, should wait until we've hit
the compact_under page limit then start compacting the emptiest pages. This may reduce total write amplification significantly depending on the workload.
