### PR TITLE
FreeBSD superpages checking.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -6500,14 +6500,14 @@ static int enable_large_pages(void) {
     size_t spagesl = sizeof(spages);
 
     if (sysctlbyname("vm.pmap.pg_ps_enabled", &spages,
-	&spagesl, NULL, 0) != 0) {
+    &spagesl, NULL, 0) != 0) {
         fprintf(stderr, "Could not evaluate the presence of superpages features.");
         return -1;
     }
     if (spages != 1) {
-	    fprintf(stderr, "Superpages support not detected.\n");
-	    fprintf(stderr, "Will use default page size.\n");
-	    return -1;
+        fprintf(stderr, "Superpages support not detected.\n");
+        fprintf(stderr, "Will use default page size.\n");
+        return -1;
     }
     return 0;
 #else


### PR DESCRIPTION
This is a knob existing from 7.0 (2008), can be only changed
at boot time. It is enabled by default, on usual archs at least,
but in some cases it might not be desired so we check it
whatsoever.