### PR TITLE
memcached-tool dump: regex call unescaping key reassigns $2, losing exp value. store/reference it as $exp

### DIFF
--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -98,13 +98,13 @@ if ($mode eq 'dump') {
         # return format looks like this
         # key=foo exp=2147483647 la=1521046038 cas=717111 fetch=no cls=13 size=1232
         if (/^key=(\S+) exp=(-?\d+) .*/) {
-            my $k = $1;
+            my ($k, $exp) = ($1, $2);
             $k =~ s/%(.{2})/chr hex $1/eg;
 
-            if ($2 == -1) {
+            if ($exp == -1) {
                 $keyexp{$k} = 0;
             } else {
-                $keyexp{$k} = $2;
+                $keyexp{$k} = $exp;
             }
         }
         $keycount++;


### PR DESCRIPTION
See: #447 