### PR TITLE
Add optional feature support to RPM package building

### DIFF
--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -1,3 +1,14 @@
+%bcond_with arm_crc32
+%bcond_with extstore
+%bcond_with seccomp
+%bcond_with sasl
+%bcond_with sasl_pwdb
+%bcond_with dtrace
+%bcond_with 64bit
+%bcond_without option_checking
+%bcond_without coverage
+%bcond_without docs
+
 # Set with_systemd on distros that use it, so we can install the service
 # file, otherwise the sysvinit script will be installed
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1210
@@ -54,7 +65,17 @@ web applications by alleviating database load.
 
 
 %build
-%configure
+%configure \
+  %{?with_arm_crc32:--enable-arm-crc32} \
+  %{?with_extstore:--enable-extstore} \
+  %{?with_seccomp:--enable-seccomp} \
+  %{?with_sasl:--enable-sasl} \
+  %{?with_sasl_pwdb:--enable-pwdb} \
+  %{?with_dtrace:--enable-dtrace} \
+  %{?with_64bit:--enable-64bit} \
+  %{!?with_option_checking:--disable-option-checking}
+  %{!?with_coverage:--disable-coverage} \
+  %{!?with_docs:--disable-docs}
 
 make %{?_smp_mflags}
 


### PR DESCRIPTION
Some optional features can now be enabled for RPM building using the
rpmbuild conditional build parameters (--with and --without)

For example, sasl can be enabled and code coverage disabled in the RPM with:
rpmbuild --with sasl --without coverage -tb memcached-1.5.12.tar.gz

Note: rpmbuild doesn't allow dashes (`-`) in the parameter names. 
This is why `arm_crc32` `sasl_pwdb` and `option_checking` use underscores

Also, I was unable to get straightforward parameters working for optiions
with both enable and disable versions for configure. 
e.g. `--enable-dependency-tracking` and `--disable-dependency-tracking`