### PR TITLE
Travis CI - upgrade to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: cpp
 
 compiler:


### PR DESCRIPTION
### Description
Upgrade Travis CI config to use Ubuntu 16.04 instead of Ubuntu 14.04 

### Why
Ubuntu 14.04 is currently EOL