### PR TITLE
close delete + incr item survival bug

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -756,6 +756,7 @@ item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbyt
 #define DO_UPDATE true
 #define DONT_UPDATE false
 item *item_get(const char *key, const size_t nkey, conn *c, const bool do_update);
+item *item_get_locked(const char *key, const size_t nkey, conn *c, const bool do_update, uint32_t *hv);
 item *item_touch(const char *key, const size_t nkey, uint32_t exptime, conn *c);
 int   item_link(item *it);
 void  item_remove(item *it);

--- a/thread.c
+++ b/thread.c
@@ -566,6 +566,17 @@ item *item_get(const char *key, const size_t nkey, conn *c, const bool do_update
     return it;
 }
 
+// returns an item with the item lock held.
+// lock will still be held even if return is NULL, allowing caller to replace
+// an item atomically if desired.
+item *item_get_locked(const char *key, const size_t nkey, conn *c, const bool do_update, uint32_t *hv) {
+    item *it;
+    *hv = hash(key, nkey);
+    item_lock(*hv);
+    it = do_item_get(key, nkey, *hv, c, do_update);
+    return it;
+}
+
 item *item_touch(const char *key, size_t nkey, uint32_t exptime, conn *c) {
     item *it;
     uint32_t hv;


### PR DESCRIPTION
re #469 - delete actually locks/unlocks the item (and hashes the
key!) three times. Inbetween fetch and unlink, a fully locked
add_delta() can run, deleting the underlying item. DELETE then returns
success despite the original object hopscotching over it.

I really need to get to the frontend rewrite soon :(

This commit hasn't been fully audited for deadlocks on the stats
counters or extstore STORAGE_delete() function, but it passes tests.