### PR TITLE
new flexible ascii meta commands (mget, mset, mdelete)

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -117,6 +117,9 @@ For example, a metaget with flags of 'st' would return tokens for "size" and
 Syntax errors are handled the same as noted under 'Error strings' section
 below.
 
+For usage examples beyond basic syntax, please see the wiki:
+https://github.com/memcached/memcached/wiki/MetaCommands
+
 Expiration times
 ----------------
 
@@ -610,8 +613,6 @@ When combined with the X flag, or the client N or R flags, this extra response
 flag indicates to a client that a different client is responsible for
 recaching this item. If there is data supplied it may use it, or the client
 may decide to retry later or take some other action.
-
-[TODO: link to wiki for use case examples]
 
 Meta Set
 --------

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -59,7 +59,7 @@ key. The client sends a command line, and then a data block; after
 that the client expects one line of response, which will indicate
 success or failure.
 
-Retrieval commands (there are two: "get" and "gets") ask the server to
+Retrieval commands ("get", "gets", "gat", and "gats") ask the server to
 retrieve data corresponding to a set of keys (one or more keys in one
 request). The client sends a command line, which includes all the
 requested keys; after that for each item the server finds it sends to
@@ -75,6 +75,47 @@ ending with "END" on the last line.
 A command line always starts with the name of the command, followed by
 parameters (if any) delimited by whitespace. Command names are
 lower-case and are case-sensitive.
+
+Meta Commands [EXPERIMENTAL: MAY CHANGE]
+-------------
+
+Meta commands are a set of new ASCII-based commands. They follow the same
+structure of the basic commands but have a new flexible feature set.
+Meta commands incorporate most features available in the binary protocol, as
+well as a flag system to make the commands flexible rather than having a
+large number of high level commands. These commands completely replace the
+usage of basic Storage and Retrieval commands.
+
+Meta commands are EXPERIMENTAL and may change syntax as of this writing. They
+are documented below the basic commands.
+
+These work mixed with normal protocol commands on the same connection. All
+existing commands continue to work. The meta commands will not replace
+specialized commands that do not sit in the Storage or Retrieval categories
+noted in the 'Commands' section above.
+
+All meta commands follow a basic syntax:
+
+cm <key> <flags> <token1> <token2> <...>\r\n
+
+Where 'cm' is a 2 character command code. The number of tokens supplied is
+based off of the flags used.
+
+Responses look like:
+
+RC <flags> <token1> <token2> <...>\r\n
+
+Where 'rc' is a 2 character return code. The number of tokens returned are
+based off of the flags used.
+
+Flags are single character codes, ie 'q' or 'k' or 'I', which adjust the
+behavior of the command. The flags are reflected in the response. The order of
+which tokens are consumed or returned depend on the order of the flags given.
+For example, a metaget with flags of 'st' would return tokens for "size" and
+"TTL remaining" in that order. 'ts' would return "TTL remaining" then "size".
+
+Syntax errors are handled the same as noted under 'Error strings' section
+below.
 
 Expiration times
 ----------------
@@ -400,6 +441,186 @@ VALUE <key> <flags> <bytes> [<cas unique>]\r\n
 
 - <data block> is the data for this item.
 
+Meta Get
+--------
+
+The meta get command is the generic command for retrieving key data from
+memcached. Based on the flags supplied, it can replace all of the commands:
+"get", "gets", "gat", "gats", "touch", as well as adding new options.
+
+mg <key> <flags> <tokens>*\r\n
+
+- <key> means one key string. Unlike "get" metaget can only take a single key.
+
+- <flags> are a set of single character codes ended with a space or newline.
+
+- <tokens>* means zero or more tokens, based on the flags supplied. They are
+  consumed in order specified by the flags.
+
+After this command, the client expects an item to be returned, received as a
+text line followed by an optional data block. After the item is transferred,
+the server sends the string
+
+"EN\r\n"
+
+to indicate the end of the response.
+
+If a response line appearing in a retrieval request is not sent back
+by the server this means that the server does not
+have the item (because it was never stored, or stored
+but deleted to make space for more items, or expired, or explicitly
+deleted by a client).
+
+An item sent by the server looks like:
+
+VA <flags> <tokens>*\r\n
+<data block>\r\n
+
+- <flags> are a reflection of the flags sent to the server. Extra flags can be
+  added to the response based on the execution of the command.
+
+- <tokens>* are tokens returned by the server, based on the flags supplied.
+  They are added in order specified by the flags sent.
+
+- <data block> is the data for this item. Note that the data black is
+  optional, requiring the 'v' flag to be supplied.
+
+The flags used by the 'mg' command are:
+
+- c: return item cas token
+- f: return client flags token
+- h: return whether item has been hit before as a 0 or 1
+- k: return key as a token
+- l: return time since item was last accessed in seconds
+- O (token): consumes a token and copies back with response
+- q: use noreply semantics for return codes.
+- s: return item size token
+- t: return item TTL remaining in seconds (-1 for unlimited)
+- u: don't bump the item in the LRU
+- v: return item value in <data block>
+
+These flags can modify the item:
+- N (token): vivify on miss, takes TTL as a argument
+- R (token): if token is less than remaining TTL win for recache
+- T (token): update remaining TTL
+
+These extra flags can be added to the response:
+- W: client has "won" the recache flag
+- X: item is stale
+- Z: tem has already sent a winning flag
+
+The flags are now repeated with detailed information where useful:
+
+- h: return whether item has been hit before as a 0 or 1
+- l: return time since item was last accessed in seconds
+
+The above two flags return the value of "hit before?" and "last access time"
+before the command was processed. Otherwise this would always show a 1 for hit or
+always show an access time of "0" unless combined with the "u" flag.
+
+- O (token): consumes a token and copies back with response
+
+The O (opaque) token is used by this and other commands to allow easier
+pipelining of requests while saving bytes on the wire for responses. For
+example: if pipelining three get commands together, you may not know which
+response belongs to which without also retrieving the key. If the key is very
+long this can generate a lot of traffic, especially if the data block is very
+small. Instead, you can supply an "O" flag for each mg with tokens of "1" "2"
+and "3", to match up responses to the request.
+
+Opaque tokens may be up to 32 bytes in length, and are a string similar to
+keys.
+
+- q: use noreply semantics for return codes.
+
+Noreply is a method of reducing the amount of data sent back by memcached to
+the client for normal responses. In the case of metaget, if an item is not
+available the "VA" line is normally not sent, and the response is terminated by
+"EN\r\n".
+
+With noreply enabled, the "EN\r\n" marker is suppressed. This allows you to
+pipeline several mg's together and read all of the responses without the
+"EN\r\n" lines in the middle.
+
+Errors are always returned.
+
+- u: don't bump the item in the LRU
+
+It is possible to access an item without causing it to be "bumped" to the head
+of the LRU. This also avoids marking an item as being hit or updating its last
+access time.
+
+- v: return item value in <data block>
+
+The data block for a metaget response is optional, requiring this flag to be
+passed in.
+
+These flags can modify the item:
+- N (token): vivify on miss, takes TTL as a argument
+
+Used to help with so called "dog piling" problems with recaching of popular
+items. If supplied, and metaget does not find the item in cache, it will
+create a stub item with the key and TTL as supplied. If such an item is
+created a 'W' flag is added to the response to indicate to a client that they
+have "won" the right to recache an item.
+
+The automatically created item has 0 bytes of data.
+
+Further requests will see a 'Z' flag to indicate that another client has
+already received the win flag.
+
+Can be combined with CAS flags to gate the update further.
+
+- R (token): if token is less than remaining TTL win for recache
+
+Similar to and can be combined with 'N'. If the remaining TTL of an item is
+below the supplied token, return a 'W' flag to indicate the client has "won"
+the right to recache an item. This allows refreshing an item before it leads to
+a miss.
+
+- T (token): update remaining TTL
+
+Similar to "touch" and "gat" commands, updates the remaining TTL of an item if
+hit.
+
+These extra flags can be added to the response:
+- W: client has "won" the recache flag
+
+When combined with N or R flags, a client may be informed they have "won"
+ownership of a cache item. This allows a single client to be atomically
+notified that it should cache or update an item. Further clients requesting
+the item can use the existing data block (if valid or stale), retry, wait, or
+take some other action while the item is missing.
+
+This is used when the act of recaching an item can cause undue load on another
+system (CPU, database accesses, time, and so on).
+
+- X: item is stale
+
+Items can be marked as stale by the metadelete command. This indicates to the
+client that an object needs to be updated, and that it should make a decision
+o if potentially stale data is safe to use.
+
+This is used when you want to convince clients to recache an item, but it's
+safe to use pre-existing data while the recache happens.
+
+- Z: item has already sent a winning flag
+
+When combined with the X flag, or the client N or R flags, this extra response
+flag indicates to a client that a different client is responsible for
+recaching this item. If there is data supplied it may use it, or the client
+may decide to retry later or take some other action.
+
+[TODO: link to wiki for use case examples]
+
+Meta Set
+--------
+
+Meta Delete
+-----------
+
+Meta No-Op
+----------
 
 Slabs Reassign
 --------------

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -461,7 +461,7 @@ ME <key> <k>=<v>*\r\nEN\r\n
 Each of the keys and values are the internal data for the item.
 
 exp   = expiration time
-la    = last access time
+la    = time in seconds since last access
 cas   = CAS ID
 fetch = whether an item has been fetched before
 cls   = slab class id

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -444,6 +444,31 @@ VALUE <key> <flags> <bytes> [<cas unique>]\r\n
 
 - <data block> is the data for this item.
 
+Meta Debug
+----------
+
+The meta debug command is a human readable dump of all available internal
+metadata of an item, minus the value.
+
+me <key>\r\n
+
+- <key> means one key string.
+
+The response looks like:
+
+ME <key> <k>=<v>*\r\nEN\r\n
+
+Each of the keys and values are the internal data for the item.
+
+exp   = expiration time
+la    = last access time
+cas   = CAS ID
+fetch = whether an item has been fetched before
+cls   = slab class id
+size  = total size in bytes
+
+Others may be added.
+
 Meta Get
 --------
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -543,8 +543,8 @@ The flags are now repeated with detailed information where useful:
 - l: return time since item was last accessed in seconds
 
 The above two flags return the value of "hit before?" and "last access time"
-before the command was processed. Otherwise this would always show a 1 for hit or
-always show an access time of "0" unless combined with the "u" flag.
+before the command was processed. Otherwise this would always show a 1 for
+hit or always show an access time of "0" unless combined with the "u" flag.
 
 - O (token): opaque value, consumes a token and copies back with response
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -492,7 +492,7 @@ The flags used by the 'mg' command are:
 - h: return whether item has been hit before as a 0 or 1
 - k: return key as a token
 - l: return time since item was last accessed in seconds
-- O (token): consumes a token and copies back with response
+- O (token): opaque value, consumes a token and copies back with response
 - q: use noreply semantics for return codes.
 - s: return item size token
 - t: return item TTL remaining in seconds (-1 for unlimited)
@@ -518,7 +518,7 @@ The above two flags return the value of "hit before?" and "last access time"
 before the command was processed. Otherwise this would always show a 1 for hit or
 always show an access time of "0" unless combined with the "u" flag.
 
-- O (token): consumes a token and copies back with response
+- O (token): opaque value, consumes a token and copies back with response
 
 The O (opaque) token is used by this and other commands to allow easier
 pipelining of requests while saving bytes on the wire for responses. For
@@ -616,11 +616,168 @@ may decide to retry later or take some other action.
 Meta Set
 --------
 
+The meta set command a generic command for storing data to memcached. Based on
+the flags supplied, it can replace the commands: "set", "cas". as well as
+adding new options.
+
+ms <key> <flags> <tokens>*\r\n
+
+- <key> means one key string.
+
+- <flags> are a set of single character codes ended with a space or newline.
+
+- <tokens>* means zero or more tokens, based on the flags supplied. They are
+  consumed in order specified by the flags.
+
+After this line, the client sends the data block:
+
+<data block>\r\n
+
+- <data block> is a chunk of arbitrary 8-bit data of length supplied by an 'S'
+  flag and token from the previous line. If no 'S' flag is supplied the data
+  is assumed to be 0 length.
+
+After sending the command line and the data block the client awaits
+the reply, which is of the format:
+
+CD <flags> <tokens>*\r\n
+
+Where CD is one of:
+
+- "ST" (STORED), to indicate success.
+
+- "NS" (NOT_STORED), to indicate the data was not stored, but not
+because of an error.
+
+- "EX" (EXISTS), to indicate that the item you are trying to store with
+CAS semantics has been modified since you last fetched it.
+
+- "NF" (NOT_FOUND), to indicate that the item you are trying to store
+with CAS semantics did not exist.
+
+The flags used by the 'ms' command are:
+
+- C (token): compare CAS value when storing item
+- F (token): set client flags to token (32 bit unsigned numeric)
+- I: invalid. set-to-invalid if CAS is older than it should be.
+- k: return key as a token
+- O (token): opaque value, consumes a token and copies back with response
+- q: use noreply semantics for return codes
+- S (token): size of <data block> to store
+- T (token): Time-To-Live for item, see "Expiration" above.
+
+The flags are now repeated with detailed information where useful:
+
+- C (token): compare CAS value when storing item
+
+Similar to the basic "cas" command, only store item if the supplied token
+matches the current CAS value of the item. When combined with the 'I' flag, a
+CAS value that is _lower_ than the current value may be accepted, but the item
+will be marked as "stale", returning the X flag with mget requests.
+
+- F (token): set client flags to token (32 bit unsigned numeric)
+
+Sets flags to 0 if not supplied.
+
+- I: invalid. set-to-invalid if CAS is older than it should be.
+
+Functional when combined with 'C' flag above.
+
+- O (token): opaque value, consumes a token and copies back with response
+
+See description under 'Meta Get'
+
+- q: use noreply semantics for return codes
+
+Noreply is a method of reducing the amount of data sent back by memcached to
+the client for normal responses. In the case of metaset, a response that would
+start with "ST" (STORED) will not be sent. Any other code, such as "EX"
+(EXISTS) will still be returned.
+
+Errors are always returned.
+
 Meta Delete
 -----------
 
+The meta delete command allows for explicit deletion of items, as well as
+marking items as "stale" to allow serving items as stale during revalidation.
+
+md <key> <flags> <tokens>*\r\n
+
+- <key> means one key string.
+
+- <flags> are a set of single character codes ended with a space or newline.
+
+- <tokens>* means zero or more tokens, based on the flags supplied. They are
+  consumed in order specified by the flags.
+
+The response is in the format:
+
+CD <flags> <tokens>*\r\n
+
+Where CD is one of:
+
+- "DE" (DELETED), to indicate success
+
+- "NF" (NOT_FOUND), to indicate that the item with this key was not found.
+
+- "EX" (EXISTS), to indicate that the supplied CAS token does not match the
+  stored item.
+
+The flags used by the 'md' command are:
+
+- C (token): compare CAS value
+- I: invalidate. mark as stale, bumps CAS.
+- k: return key
+- O: opaque to copy back.
+- q: noreply
+- T (token): updates TTL
+
+The flags are now repeated with detailed information where useful:
+
+- C (token): compare CAS value
+
+Can be used to only delete or mark-stale if a supplied CAS value matches.
+
+- I: invalidate. mark as stale, bumps CAS.
+
+Instead of removing an item, this will give the item a new CAS value and mark
+it as stale. This means when it is later fetched by metaget, the client will
+be supplied an 'X' flag to show the data is stale and needs to be recached.
+
+- O (token): opaque to copy back.
+
+See description under 'Meta Get'
+
+- q: noreply
+
+See description under 'Meta Set'. In the case of meta delete, this will hide
+response lines with the code "DE". It will still return any other responses.
+
+- T (token): updates TTL
+
+When marking an item as stale with 'I', the 'T' flag can be used to update the
+TTL as well; limiting the amount of time an item will live while stale and
+waiting to be recached.
+
 Meta No-Op
 ----------
+
+The meta no-op command exists solely to return a static response code. It
+takes no flags, no arguments.
+
+This returns the static response:
+
+"EN\r\n"
+
+Similar to a meta get command.
+
+This command is useful when used with the 'q' flag and pipelining commands.
+For example, with 'mg' the response lines are blank on miss, and the 'q' flag
+will hide the "EN\r\n" response code. If pipelining several 'mg's together
+with noreply semantics, an "mn\r\n" command can be tagged to the end of the
+chain, which will return an "EN\r\n", signalling to a client that all previous
+commands have been processed.
 
 Slabs Reassign
 --------------

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -757,7 +757,7 @@ The flags used by the 'md' command are:
 - k: return key
 - O: opaque to copy back.
 - q: noreply
-- T (token): updates TTL
+- T (token): updates TTL, only when paired with the 'I' flag
 
 The flags are now repeated with detailed information where useful:
 
@@ -780,7 +780,7 @@ See description under 'Meta Get'
 See description under 'Meta Set'. In the case of meta delete, this will hide
 response lines with the code "DE". It will still return any other responses.
 
-- T (token): updates TTL
+- T (token): updates TTL, only when paired with the 'I' flag
 
 When marking an item as stale with 'I', the 'T' flag can be used to update the
 TTL as well; limiting the amount of time an item will live while stale and

--- a/items.h
+++ b/items.h
@@ -73,6 +73,7 @@ void fill_item_stats_automove(item_stats_automove *am);
 
 item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c, const bool do_update);
 item *do_item_touch(const char *key, const size_t nkey, uint32_t exptime, const uint32_t hv, conn *c);
+void do_item_bump(conn *c, item *it, const uint32_t hv);
 void item_stats_reset(void);
 extern pthread_mutex_t lru_locks[POWER_LARGEST];
 

--- a/memcached.c
+++ b/memcached.c
@@ -4237,7 +4237,7 @@ static void _mget_out_fullmeta(conn *c, char *key, size_t nkey) {
         conn_set_state(c, conn_write);
         c->write_and_go = conn_new_cmd;
     } else {
-        out_string(c, "END\r\n");
+        out_string(c, "END");
     }
     pthread_mutex_lock(&c->thread->stats.mutex);
     c->thread->stats.mget_cmds++;
@@ -4423,7 +4423,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
         // Now we abuse c->wbuf and our itoa's to fill requested fields.
         if (of.flags) {
             *p = ' ';
-            if (it->nsuffix == 0) {
+            if (FLAGS_SIZE(it) == 0) {
                 *(p+1) = '0';
                 p += 2;
             } else {

--- a/memcached.c
+++ b/memcached.c
@@ -4689,7 +4689,6 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
 #endif
         }
 
-        // FIXME: is extstore counting this? I don't believe it is.
         if (!c->noreply) {
             add_iov(c, "EN\r\n", 4);
         }
@@ -6516,7 +6515,7 @@ static enum transmit_result transmit(conn *c) {
         struct msghdr *m = &c->msglist[c->msgcurr];
 
         res = c->sendmsg(c, m, 0);
-        if (res > 0) {
+        if (res >= 0) {
             pthread_mutex_lock(&c->thread->stats.mutex);
             c->thread->stats.bytes_written += res;
             pthread_mutex_unlock(&c->thread->stats.mutex);
@@ -6546,7 +6545,7 @@ static enum transmit_result transmit(conn *c) {
             }
             return TRANSMIT_SOFT_ERROR;
         }
-        /* if res == 0 or res == -1 and error is not EAGAIN or EWOULDBLOCK,
+        /* if res == -1 and error is not EAGAIN or EWOULDBLOCK,
            we have a real error, on which we close the connection */
         if (settings.verbose > 0)
             perror("Failed to write, and not due to blocking");

--- a/memcached.c
+++ b/memcached.c
@@ -4500,9 +4500,16 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
         for (i = 0; i < olen; i++) {
             switch (opts[i]) {
                 case 'T':
-                    // FIXME: I broke this.
                     ttl_set = true;
-                case 'N': // fallthrough. handled the same way here.
+                    if (!safe_strtol(tokens[rtokens].value, &exptime_int)) {
+                        errstr = "bad tokens in command line format";
+                        goto error;
+                    }
+                    // FIXME: check for < 0, or stoul and cast here.
+                    it->exptime = realtime(exptime_int);
+                    rtokens++;
+                    break;
+                case 'N':
                     if (item_created) {
                         if (!safe_strtol(tokens[rtokens].value, &exptime_int)) {
                             errstr = "bad tokens in command line format";

--- a/memcached.c
+++ b/memcached.c
@@ -4441,9 +4441,9 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
 
     // NOTE: final token has length == 0.
     // KEY_TOKEN == 1. 0 is command.
-    rtokens = ntokens - 3; // cmd, key, final.
+    rtokens = 3; // cmd, key, final.
 
-    if (rtokens == 0) {
+    if (ntokens == 3) {
         // Default flag options. Might not be the best idea.
         opts = "sftv";
         olen = 4;
@@ -4451,7 +4451,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
         // need to parse out the options.
         opts = tokens[KEY_TOKEN + 1].value;
         olen = tokens[KEY_TOKEN + 1].length;
-        rtokens--;
+        rtokens++;
     }
 
     if (olen > MFLAG_MAX_OPT_LENGTH) {
@@ -4471,10 +4471,10 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
     fp--; // next token, or final space, goes here.
 
     // scrubs duplicated options and sets flags for how to load the item.
-    rtokens -= _meta_flag_preparse(opts, olen, &of);
+    int mfres = _meta_flag_preparse(opts, olen, &of);
 
-    if (rtokens < 0) {
-        out_errstring(c, "CLIENT_ERROR not enough tokens supplied");
+    if (mfres + rtokens != ntokens) {
+        out_errstring(c, "CLIENT_ERROR incorrect number of tokens supplied");
         return;
     }
     rtokens = KEY_TOKEN + 2;
@@ -4795,16 +4795,16 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
     key = tokens[KEY_TOKEN].value;
     nkey = tokens[KEY_TOKEN].length;
 
-    rtokens = ntokens - 3; // cmd, key, final.
+    rtokens = 3; // cmd, key, final.
 
-    if (rtokens == 0) {
+    if (ntokens == 3) {
         out_errstring(c, "CLIENT_ERROR bad command line format");
         return;
     }
 
     opts = tokens[KEY_TOKEN + 1].value;
     olen = tokens[KEY_TOKEN + 1].length;
-    rtokens--;
+    rtokens++;
 
     if (olen > MFLAG_MAX_OPT_LENGTH) {
         out_errstring(c, "CLIENT_ERROR options flags too long");
@@ -4819,10 +4819,10 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
 
     // scrubs duplicated options and sets flags for how to load the item.
     // TODO: I, E, APL?
-    rtokens -= _meta_flag_preparse(opts, olen, &of);
+    int mfres = _meta_flag_preparse(opts, olen, &of);
 
-    if (rtokens < 0) {
-        out_errstring(c, "CLIENT_ERROR not enough tokens supplied");
+    if (mfres + rtokens != ntokens) {
+        out_errstring(c, "CLIENT_ERROR incorrect number of tokens supplied");
         return;
     }
 
@@ -4978,16 +4978,16 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
     key = tokens[KEY_TOKEN].value;
     nkey = tokens[KEY_TOKEN].length;
 
-    rtokens = ntokens - 3; // cmd, key, final.
+    rtokens = 3; // cmd, key, final.
 
     // rtokens == 0 acts like a normal immediate delete
-    if (rtokens == 0) {
+    if (ntokens == 3) {
         opts = "";
         olen = 0;
     } else {
         opts = tokens[KEY_TOKEN + 1].value;
         olen = tokens[KEY_TOKEN + 1].length;
-        rtokens--;
+        rtokens++;
     }
 
     if (olen > MFLAG_MAX_OPT_LENGTH) {
@@ -5002,10 +5002,10 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
     p += olen;
 
     // scrubs duplicated options and sets flags for how to load the item.
-    rtokens -= _meta_flag_preparse(opts, olen, &of);
+    int mfres = _meta_flag_preparse(opts, olen, &of);
 
-    if (rtokens < 0) {
-        out_string(c, "CLIENT_ERROR not enough tokens supplied");
+    if (mfres + rtokens != ntokens) {
+        out_errstring(c, "CLIENT_ERROR incorrect number of tokens supplied");
         return;
     }
     rtokens = KEY_TOKEN + 2;

--- a/memcached.c
+++ b/memcached.c
@@ -4295,8 +4295,8 @@ static void _mget_out_fullmeta(conn *c, char *key, size_t nkey) {
         size_t total = 0;
         size_t ret;
         // similar to out_string().
-        memcpy(c->wbuf, "META ", 5);
-        total += 5;
+        memcpy(c->wbuf, "ME ", 3);
+        total += 3;
         memcpy(c->wbuf + total, ITEM_key(it), it->nkey);
         total += it->nkey;
         c->wbuf[total] = ' ';
@@ -4317,7 +4317,7 @@ static void _mget_out_fullmeta(conn *c, char *key, size_t nkey) {
         conn_set_state(c, conn_write);
         c->write_and_go = conn_new_cmd;
     } else {
-        out_string(c, "END");
+        out_string(c, "EN");
     }
     pthread_mutex_lock(&c->thread->stats.mutex);
     c->thread->stats.mget_cmds++;
@@ -4684,7 +4684,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
 
         // FIXME: is extstore counting this? I don't believe it is.
         if (!c->noreply) {
-            add_iov(c, "END\r\n", 5);
+            add_iov(c, "EN\r\n", 4);
         }
 
         // need to hold the ref at least because of the key above.
@@ -4749,10 +4749,8 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
         MEMCACHED_COMMAND_GET(c->sfd, key, nkey, -1, 0);
         pthread_mutex_unlock(&c->thread->stats.mutex);
 
-        // FIXME: what happens with noreply here?
-        // a miss will look like air here...
-        // so a nop command would be needed to append an END on purpose.
-        out_string(c, "END");
+        // This gets elided in noreply mode.
+        out_string(c, "EN");
     }
     return;
 error:
@@ -5799,8 +5797,8 @@ static void process_command(conn *c, char *command) {
         process_mset_command(c, tokens, ntokens);
     } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "md") == 0)) {
         process_mdelete_command(c, tokens, ntokens);
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mn") == 0)) {
-        out_string(c, "END");
+    } else if (ntokens >= 2 && (strcmp(tokens[COMMAND_TOKEN].value, "mn") == 0)) {
+        out_string(c, "EN");
         return;
     } else if ((ntokens == 4 || ntokens == 5) && (strcmp(tokens[COMMAND_TOKEN].value, "decr") == 0)) {
 

--- a/memcached.c
+++ b/memcached.c
@@ -3329,7 +3329,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
     APPEND_STAT("cmd_set", "%llu", (unsigned long long)slab_stats.set_cmds);
     APPEND_STAT("cmd_flush", "%llu", (unsigned long long)thread_stats.flush_cmds);
     APPEND_STAT("cmd_touch", "%llu", (unsigned long long)thread_stats.touch_cmds);
-    APPEND_STAT("cmd_mget", "%llu", (unsigned long long)thread_stats.mget_cmds);
+    APPEND_STAT("cmd_meta", "%llu", (unsigned long long)thread_stats.meta_cmds);
     APPEND_STAT("get_hits", "%llu", (unsigned long long)slab_stats.get_hits);
     APPEND_STAT("get_misses", "%llu", (unsigned long long)thread_stats.get_misses);
     APPEND_STAT("get_expired", "%llu", (unsigned long long)thread_stats.get_expired);
@@ -4329,7 +4329,7 @@ static void process_meta_command(conn *c, token_t *tokens, const size_t ntokens)
         out_string(c, "EN");
     }
     pthread_mutex_lock(&c->thread->stats.mutex);
-    c->thread->stats.mget_cmds++;
+    c->thread->stats.meta_cmds++;
     pthread_mutex_unlock(&c->thread->stats.mutex);
 }
 

--- a/memcached.c
+++ b/memcached.c
@@ -5793,12 +5793,15 @@ static void process_command(conn *c, char *command) {
 
         process_get_command(c, tokens, ntokens, true, false);
 
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mget") == 0)) {
+    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mg") == 0)) {
         process_mget_command(c, tokens, ntokens);
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mset") == 0)) {
+    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "ms") == 0)) {
         process_mset_command(c, tokens, ntokens);
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mdelete") == 0)) {
+    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "md") == 0)) {
         process_mdelete_command(c, tokens, ntokens);
+    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mn") == 0)) {
+        out_string(c, "END");
+        return;
     } else if ((ntokens == 4 || ntokens == 5) && (strcmp(tokens[COMMAND_TOKEN].value, "decr") == 0)) {
 
         process_arithmetic_command(c, tokens, ntokens, 0);

--- a/memcached.c
+++ b/memcached.c
@@ -4277,6 +4277,7 @@ struct _meta_flags {
     unsigned int hit :1;
     unsigned int value :1;
     unsigned int set_stale :1;
+    unsigned int no_reply :1;
 };
 
 static int _meta_flag_preparse(char *opts, size_t olen, struct _meta_flags *of) {
@@ -4312,6 +4313,9 @@ static int _meta_flag_preparse(char *opts, size_t olen, struct _meta_flags *of) 
                 break;
             case 'u':
                 of->no_update = 1;
+                break;
+            case 'q':
+                of->no_reply = 1;
                 break;
             // mset-related.
             case 'F':
@@ -4390,6 +4394,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
 
     // scrubs duplicated options and sets flags for how to load the item.
     rtokens -= _meta_flag_preparse(opts, olen, &of);
+    c->noreply = of.no_reply;
 
     // FIXME: make string more clear and add key to response
     if (rtokens < 0) {
@@ -4695,6 +4700,9 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
     // scrubs duplicated options and sets flags for how to load the item.
     // TODO: I, E, APL?
     rtokens -= _meta_flag_preparse(opts, olen, &of);
+    // FIXME: should this go after the token requirement? else people might
+    // become bewildered...
+    c->noreply = of.no_reply;
 
     // FIXME: make string more clear and add key to response
     if (rtokens < 0) {
@@ -4848,6 +4856,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
 
     // scrubs duplicated options and sets flags for how to load the item.
     rtokens -= _meta_flag_preparse(opts, olen, &of);
+    c->noreply = of.no_reply;
 
     // FIXME: make string more clear and add key to response
     if (rtokens < 0) {

--- a/memcached.c
+++ b/memcached.c
@@ -4336,7 +4336,6 @@ static void process_meta_command(conn *c, token_t *tokens, const size_t ntokens)
 #define MFLAG_MAX_OPT_LENGTH 20
 #define MFLAG_MAX_OPAQUE_LENGTH 32
 
-// TODO: I can't think of a reason for optimized mode to have class-id?
 struct _meta_flags {
     unsigned int no_update :1;
     unsigned int locked :1;
@@ -4831,11 +4830,6 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
     // Set noreply after tokens are understood.
     c->noreply = of.no_reply;
     rtokens = KEY_TOKEN + 2;
-
-    // TODO: Do we need to return the tokens?
-    // since NOT_STORED and so on are far away from this (past a read), if we
-    // need to store the tokens it would have to be stowed with the connection
-    // structure
 
     for (i = 0; i < olen; i++) {
         switch (opts[i]) {

--- a/memcached.h
+++ b/memcached.h
@@ -478,7 +478,12 @@ extern struct settings settings;
 #define ITEM_HDR 128
 /* additional 4 bytes for item client flags */
 #define ITEM_CFLAGS 256
-/* 7 bits free! */
+/* item has sent out a token already */
+#define ITEM_TOKEN_SENT 512
+/* reserved, in case tokens should be a 2-bit count in future */
+#define ITEM_TOKEN_RESERVED 1024
+/* if item has been marked as a stale value */
+#define ITEM_STALE 2048
 
 /**
  * Structure for storing items within memcached.

--- a/memcached.h
+++ b/memcached.h
@@ -282,6 +282,7 @@ struct slab_stats {
     X(incr_misses) \
     X(decr_misses) \
     X(cas_misses) \
+    X(mget_cmds) \
     X(bytes_read) \
     X(bytes_written) \
     X(flush_cmds) \

--- a/memcached.h
+++ b/memcached.h
@@ -613,15 +613,16 @@ typedef struct _io_wrap {
  * The structure representing a connection into memcached.
  */
 struct conn {
+    sasl_conn_t *sasl_conn;
     int    sfd;
+    bool sasl_started;
+    bool authenticated;
+    bool set_stale;
 #ifdef TLS
     SSL    *ssl;
     char   *ssl_wbuf;
     bool ssl_enabled;
 #endif
-    sasl_conn_t *sasl_conn;
-    bool sasl_started;
-    bool authenticated;
     enum conn_states  state;
     enum bin_substates substate;
     rel_time_t last_cmd_time;

--- a/memcached.h
+++ b/memcached.h
@@ -618,6 +618,7 @@ struct conn {
     bool sasl_started;
     bool authenticated;
     bool set_stale;
+    bool mset_res; /** uses mset format for return code */
 #ifdef TLS
     SSL    *ssl;
     char   *ssl_wbuf;

--- a/memcached.h
+++ b/memcached.h
@@ -282,7 +282,7 @@ struct slab_stats {
     X(incr_misses) \
     X(decr_misses) \
     X(cas_misses) \
-    X(mget_cmds) \
+    X(meta_cmds) \
     X(bytes_read) \
     X(bytes_written) \
     X(flush_cmds) \

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -25,6 +25,7 @@ my $sock = $server->sock;
 # - f: client flags
 # - l: last access time
 # - h: whether item has been hit before
+# - o: opaque to copy back.
 # - q: noreply semantics. TODO: tests.
 # - u: don't bump the item (TODO: test via 'h' flag)
 # updaters:
@@ -332,6 +333,16 @@ my $sock = $server->sock;
     diag "now purposefully cause an error\r\n";
     print $sock "mset quiet S\r\n";
     like(scalar <$sock>, qr/^CLIENT_ERROR/, "resp not STORED, DELETED, or END");
+}
+
+{
+    my $k = 'otest';
+    diag "testing mget opaque";
+    print $sock "mset $k ST 2 100\r\nra\r\n";
+    like(scalar <$sock>, qr/^STORED/, "set $k");
+
+    my $res = mget($sock, $k, 'stvo opaque');
+    is($res->{tokens}->[2], 'opaque', "o flag returned opaque");
 }
 
 ###

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -331,11 +331,14 @@ sub mget {
     my $s = shift;
     my $key = shift;
     my $flags = shift;
-    my @tokens = @_;
+    my $tokens = join(' ', @_);
 
-    print $s "mget $key $flags ", join(' ', @tokens), "\r\n";
+    print $s "mget $key $flags ", $tokens, "\r\n";
     my $header = scalar(<$s>);
-    my $val = scalar(<$s>);
+    my $val;
+    if ($flags =~ m/v/) {
+        $val = scalar(<$s>);
+    }
     my $end = scalar(<$s>);
 
     return mget_res($header . $val);

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -105,8 +105,8 @@ my $sock = $server->sock;
 # - test just modifying the TTL (touch)
 # - test fetching without value
 {
-    my $res = mget($sock, 'needwin', 'stcvN 30');
-    like($res->{flags}, qr/stcvN/, "got main flags back");
+    my $res = mget($sock, 'needwin', 'scvNt 30');
+    like($res->{flags}, qr/scvNt/, "got main flags back");
     like($res->{flags}, qr/W/, "got a win result");
     unlike($res->{flags}, qr/Z/, "no token already sent warning");
 
@@ -323,7 +323,7 @@ sub mget_res {
     my $resp = shift;
     my %r = ();
 
-    if ($resp =~ m/^VALUE (.*) (.*) (.*)\r\n(.*)\r\n/gm) {
+    if ($resp =~ m/^VALUE ([^\s]+) ([^\s]+) ([^\r]+)\r\n(.*)\r\n/gm) {
         $r{key} = $1;
         $r{flags} = $2;
         $r{val} = $4;

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -1,0 +1,191 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server = new_memcached();
+my $sock = $server->sock;
+
+# command syntax:
+# mget [key] [flags] [tokens]\r\n
+# response:
+# VALUE [key] [flags] [tokens]\r\n
+# data\r\n
+# END\r\n
+#
+# flags:
+# - s: item size
+# - v: return item value
+# - c: return item cas
+# - t: return item TTL remaining (-1 for unlimited)
+# - f: client flags
+# - q: noreply semantics.
+# updaters:
+# - N (token): vivify on miss, takes TTL as a argument
+# - R (token): if token is less than item TTL win for recache
+# - T (token): update remaining TTL
+# FIXME: do I need a "if stale and no token sent, flip" explicit flag?
+# extra response flags:
+# - W: client has "won" the token
+# - X: object is stale
+# - Z: object has sent a winning token
+#
+# mset [key] [flags] [tokens]\r\n
+# value\r\n
+# response:
+# STORED, NOT_STORED, etc
+# FIXME: STORED [key] [tokens] ?
+#
+# flags:
+# - q: noreply
+# - F (token): set client flags
+# - C (token): compare CAS value
+# - S (token): item size
+# - T (token): TTL
+#
+# mdelete [key] [flags] [tokens]\r\n
+# response:
+# FIXME
+# flags:
+# - q: noreply
+# - T (token): updates TTL
+# - I: invalidate. mark as stale, bumps CAS.
+
+# metaget tests
+
+# basic test
+# - raw mget
+# - raw mget miss
+# - raw mget bad key
+
+{
+    print $sock "set foo 0 0 2\r\nhi\r\n";
+    is(scalar <$sock>, "STORED\r\n", "stored test value");
+
+    print $sock "mget none\r\n";
+    is(scalar <$sock>, "END\r\n", "raw mget miss");
+
+    print $sock "mget foo\r\n";
+    like(scalar <$sock>, qr/^META foo /, "raw mget result");
+    # bleed the END off the socket.
+    my $dud = scalar <$sock>;
+}
+
+# mget with arguments
+# - set some specific TTL and get it back (within reason)
+# - get cas
+# - autovivify and bit-win
+
+{
+    print $sock "set foo2 0 90 2\r\nho\r\n";    
+    is(scalar <$sock>, "STORED\r\n", "stored test value");
+
+    mget_is({ sock => $sock, 
+              flags => 'sv', 
+              etokens => [2] },
+            'foo2', 'ho', "retrieved test value");
+
+    my $res = mget($sock, 'foo2', 'stv');
+}
+
+# lease-test, use two sockets? one socket should be fine, actually.
+# - get a win on autovivify
+# - get a loss on the same command
+# - have a set/cas fail
+# - have a cas succeed
+# - repeat for "triggered on TTL"
+
+# need mset past here
+
+# high level tests:
+# - mget + mset with serve-stale
+# - invalidate via mdelete and mget/revalidate with mset
+#   - remember failure scenarios!
+#   - also test re-setting as stale (extra double-bit dance)
+
+###
+
+# takes hash:
+# - sock
+# - args (metaget flags)
+# - array of tokens
+# - array of expected response tokens
+
+# returns hash:
+# - win (if won a condition)
+# - array of tokens
+# - value, etc?
+# useful to chain together for further requests.
+# works only with single line values. no newlines in value.
+# FIXME: some workaround for super long values :|
+# TODO: move this to lib/MemcachedTest.pm
+sub mget_is {
+    # single line values only
+    my ($o, $key, $val, $msg) = @_;
+
+    my $dval = defined $val ? "'$val'" : "<undef>";
+    $msg ||= "$key == $dval";
+
+    my $s = $o->{sock};
+    my $flags = $o->{flags};
+    # sometimes response flags can differ from request flags.
+    my $eflags = $o->{eflags} || $flags;
+    my $tokens = exists $o->{tokens} ? join(' ', @{$o->{tokens}}) : '';
+    my $etokens = exists $o->{etokens} ? join(' ', @{$o->{etokens}}) : '';
+
+    print $s "mget $key $flags $tokens\r\n";
+    if (! defined $val) {
+        my $line = scalar <$s>;
+        if ($line =~ /^VALUE/) {
+            $line .= scalar(<$s>) . scalar(<$s>);
+        }
+        Test::More::is($line, "END\r\n", $msg);
+    } else {
+        my $len = length($val);
+        my $body = scalar(<$s>);
+        my $expected = "VALUE $key $eflags $etokens\r\n$val\r\nEND\r\n";
+        if (!$body || $body =~ /^END/) {
+            Test::More::is($body, $expected, $msg);
+            return;
+        }
+        $body .= scalar(<$sock>) . scalar(<$sock>);
+        Test::More::is($body, $expected, $msg);
+        return mget_res($body);
+    }
+    return {};
+}
+
+sub mget {
+    my $s = shift;
+    my $key = shift;
+    my $flags = shift;
+    my @tokens = @_;
+
+    print $s "mget $key $flags ", join(' ', @tokens), "\r\n";
+    my $header = scalar(<$s>);
+    my $val = scalar(<$s>);
+    my $end = scalar(<$s>);
+
+    return mget_res($header . $val);
+}
+
+# parse out a response
+sub mget_res {
+    my $resp = shift;
+    my %r = ();
+
+    if ($resp =~ m/^VALUE (.*) (.*) (.*)\r\n(.*)\r\n/gm) {
+        $r{key} = $1;
+        $r{flags} = $2;
+        $r{val} = $4;
+        $r{tokens} = [split(/ /, $3)];
+    }
+
+    return \%r;
+}
+
+done_testing();

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -23,6 +23,8 @@ my $sock = $server->sock;
 # - c: return item cas
 # - t: return item TTL remaining (-1 for unlimited)
 # - f: client flags
+# - l: last access time TODO: test
+# - h: whether item has been hit before TODO: test
 # - q: noreply semantics.
 # updaters:
 # - N (token): vivify on miss, takes TTL as a argument

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -204,6 +204,20 @@ my $sock = $server->sock;
 }
 
 # test no-value mode
+{
+    # Set key with lower initial TTL.
+    print $sock "mset hidevalue ST 4 100\r\nhide\r\n";
+    like(scalar <$sock>, qr/^STORED/, "set hidevalue");
+
+    my $res = mget($sock, 'hidevalue', 'st');
+    ok(keys %$res, "not a miss");
+    is($res->{val}, '', "no value returned");
+
+    $res = mget($sock, 'hidevalue', 'stv');
+    ok(keys %$res, "not a miss");
+    is($res->{val}, 'hide', "real value returned");
+
+}
 
 # high level tests:
 # - mget + mset with serve-stale
@@ -352,7 +366,7 @@ sub mget {
 
     print $s "mget $key $flags ", $tokens, "\r\n";
     my $header = scalar(<$s>);
-    my $val;
+    my $val = "\r\n";
     if ($flags =~ m/v/) {
         $val = scalar(<$s>);
     }

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -261,6 +261,19 @@ my $sock = $server->sock;
     is($res->{val}, "g", "value was updated");
 }
 
+# Quiet flag suppresses most output. Badly invalid commands will still
+# generate something. Not weird to parse like 'noreply' token was...
+# mget's with hits should return real data.
+{
+    diag "testing quiet flag";
+    print $sock "mset quiet Sq 2\r\nmo\r\n";
+    print $sock "mdelete quiet q\r\n";
+    print $sock "mget quiet svq\r\n";
+    diag "now purposefully cause an error\r\n";
+    print $sock "mset quiet S\r\n";
+    like(scalar <$sock>, qr/^CLIENT_ERROR/, "resp not STORED, DELETED, or END");
+}
+
 ###
 
 # takes hash:

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -87,10 +87,10 @@ my $sock = $server->sock;
     print $sock "set foo 0 0 2\r\nhi\r\n";
     is(scalar <$sock>, "STORED\r\n", "stored test value");
 
-    print $sock "mg none\r\n";
+    print $sock "me none\r\n";
     is(scalar <$sock>, "EN\r\n", "raw mget miss");
 
-    print $sock "mg foo\r\n";
+    print $sock "me foo\r\n";
     like(scalar <$sock>, qr/^ME foo /, "raw mget result");
     # bleed the EN off the socket.
     my $dud = scalar <$sock>;

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -23,10 +23,10 @@ my $sock = $server->sock;
 # - c: return item cas
 # - t: return item TTL remaining (-1 for unlimited)
 # - f: client flags
-# - l: last access time TODO: test
+# - l: last access time
 # - h: whether item has been hit before
 # - q: noreply semantics. TODO: tests.
-# - u: don't bump the item (TODO: how to test? via last-access time?)
+# - u: don't bump the item (TODO: test via 'h' flag)
 # updaters:
 # - N (token): vivify on miss, takes TTL as a argument
 # - R (token): if token is less than item TTL win for recache

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -377,6 +377,16 @@ my $sock = $server->sock;
     is($res->{tokens}->[2], 'opaque', "O flag returned opaque");
 }
 
+{
+    diag "flag and token count errors";
+    print $sock "mg foo sv extratoken\r\n";
+    like(scalar <$sock>, qr/^CLIENT_ERROR incorrect number of tokens/, "too many tokens");
+    print $sock "mg foo svN\r\n";
+    like(scalar <$sock>, qr/^CLIENT_ERROR incorrect number of tokens/, "too few tokens");
+    print $sock "mg foo mooooo\r\n";
+    like(scalar <$sock>, qr/^CLIENT_ERROR invalid or duplicate flag/, "gone silly with flags");
+}
+
 # TODO: move wait_for_ext into Memcached.pm
 sub wait_for_ext {
     my $sock = shift;

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -11,7 +11,7 @@ my $server = new_memcached();
 my $sock = $server->sock;
 
 # command syntax:
-# mget [key] [flags] [tokens]\r\n
+# mg [key] [flags] [tokens]\r\n
 # response:
 # VA [flags] [tokens]\r\n
 # data\r\n
@@ -39,7 +39,7 @@ my $sock = $server->sock;
 # - X: object is stale
 # - Z: object has sent a winning token
 #
-# mset [key] [flags] [tokens]\r\n
+# ms [key] [flags] [tokens]\r\n
 # value\r\n
 # response:
 # ST [flags] [tokens]\r\n
@@ -61,7 +61,7 @@ my $sock = $server->sock;
 # - L: replace (exclusive)
 # - incr/decr? pushing it, I guess.
 #
-# mdelete [key] [flags] [tokens]\r\n
+# md [key] [flags] [tokens]\r\n
 # response:
 # DE [flags] [tokens]
 # flags:
@@ -71,6 +71,10 @@ my $sock = $server->sock;
 # - I: invalidate. mark as stale, bumps CAS.
 # - O: opaque to copy back.
 # - k: return key
+#
+# mn\r\n
+# response:
+# EN
 
 # metaget tests
 

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -219,6 +219,21 @@ my $sock = $server->sock;
 
 }
 
+# test hit-before? flag
+# NOTE: maybe sucks. can't tell if it was hit before without 'u' flag.
+{
+    print $sock "mset hitflag ST 3 100\r\nhit\r\n";
+    like(scalar <$sock>, qr/^STORED/, "set hitflag");
+
+    my $res = mget($sock, 'hitflag', 'usth');
+    ok(keys %$res, "not a miss");
+    is($res->{tokens}->[2], 0, "not been hit before");
+
+    $res = mget($sock, 'hitflag', 'sth');
+    ok(keys %$res, "not a miss");
+    is($res->{tokens}->[2], 1, "been hit before");
+}
+
 # high level tests:
 # - mget + mset with serve-stale
 # - set a value

--- a/t/stats.t
+++ b/t/stats.t
@@ -26,9 +26,9 @@ my $stats = mem_stats($sock);
 # Test number of keys
 if (MemcachedTest::enabled_tls_testing()) {
     # when TLS is enabled, stats contains time_since_server_cert_refresh
-    is(scalar(keys(%$stats)), 71, "expected count of stats values");
+    is(scalar(keys(%$stats)), 72, "expected count of stats values");
 } else {
-    is(scalar(keys(%$stats)), 70, "expected count of stats values");
+    is(scalar(keys(%$stats)), 71, "expected count of stats values");
 }
 
 # Test initial state


### PR DESCRIPTION
Edit: overhauled top comment to reflect development work.

- we get asked a lot to provide a "metaget" command, for various uses, as well as random one-off commands.
- I really hate this and have been wanting to experiment with tuning of how get commands work for a long time.

Assuming that if I offer a metaget command which gives people the information they're curious about in an inefficient format, plus data they don't need, we'll just end up with a slow command with compatibility issues. No matter how you wrap warnings in documentation, people will put it into production under high load. Then I'm stuck with it forever.

Behold, mget! The metaget (+ mset, mdelete) commands are designed to give the ascii protocol parity with the binary protocol. Further, it extends the protocol to give atomic stampeding herd protection on MISS, stale-while-revalidate, and other features.

**NOTE: The rest of this comment is out of date. The mechanics are the same but examples will not match. See t/metaget.t and doc/protocol.txt for use examples and current syntax**

```
set foo 0 0 2
hi
STORED
mget foo
META foo exp=-1 la=2 cas=1 fetch=no cls=1 size=64
END
mget foo stfu
VALUE foo stfu 0 2 -1
END
mget foo st
VALUE foo st 2 -1
END
```
first VALUE returns client flags, size, TTL remaining, and doesn't bump the LRU
second VALUE returns size, and TTL remaining.

Without arguments it outputs the full
metadata in a format similar to LRU crawler... but without needing to
escape the key first. split by space, then by = for indexes 2+ for
parsing.

If you supply an argument to mget, it is interpreted as a set of option
flags. This is an optimized command, using fast itoa's to write numbers into the client write buffer.
For a single get it should rival or beat the existing (ancient) get code path.

Options enable what gets returned (numerically) on the VALUE line. The
options return int a strict order: if you say 's' (size) last, the
first value after the key is still the size. I might still make this
flexible, but it makes the parsing more difficult. As new options are
added in the future, they'll get independent flags and will be inserted
at the end of the current list. [NOTE: _probably_ doing flexible ordering]

Next, 'v' will conditionally enable returning the value of the object.
'u' will disable bumping the LRU. Allows fetch the value
of an object without bumping it to the top of the LRU.

Further, this command will supplant GETS/TOUCH/GAT/GATS (get-and-touch + cas variants):

`mget foo T 30`

... will update the TTL to 30 seconds from now, the same as a touch
command.

`mget foo Tsfv 30`

... is equivalent to the GAT command

`mget foo Tsfvc 30`

... is equivalent to the GATS command.

arguments that take tokens will consume them in a similar strict order
as returning them in the VALUE line. [NOTE: as above, probably a flexible order]

Now, we extend this into an anti-stampede system by overriding the
usage of CAS values:

`mget foo Ncfsv ttl`

... if this command results in a MISS, an item with an empty value will
be vivified, with a ttl. The CAS is also returned. For response:

```
mget foo Nfsvc ttl\r\n
VALUE foo NcfsvW [flags: 0] [size: 0] [cas: N]
\r\n\r\n (0b value)
```
The W flag is added to the return set, indicating this client has "Won" the right to recache this item. The CAS value is now used to overwrite the temporary item with the real value. A second client would see:

```
VALUE foo NcfsvZ [flags: 0] [size: 0] [cas: N]
\r\n\r\n
```

Z indicating that a token has been handed out to a client, so this value shouldn't be used. A lack of 'W' means it didn't win the "race" either. Clients can make informed decisions on sleep/waiting, fetching from a secondary data source, or giving up. They can also include the 't' flag to see how much TTL is remaining on a locked token.

In some cases "stale" indicated values can be useful:

client A: miss -> win, 15s TTL. CAS 1.
client B: (30s later) miss -> win (object expired), CAS 2.
client A: (5s later) mset CAS 1 (attempting to store but CAS is now old)

server notes that CAS value is less than the current CAS value. it can
allow a "stale" store: ignore the supplied TTL (keep remaining from
original object), and keep CAS as what it was before (the higher value). Now, with a
value rather than nothing at all. An 'X' flag is returned to indicate a value is "stale". Clients can decide on whether it's safe to use a stale value.

client B: (5s later) mset CAS 2.

... CAS now matches, "latest" value wins, stale and token markers are removed, TTL is acquired, value updated, etc.

---

Next: "invalidating to stale"

`mdelete foo T <ttl>`

sets TTL to new TTL (ideally low: 30s or so), flipping the stale bit if
not already set. Also bumps the CAS value. The next client:

```
client A:
mget foo svfc
VALUE foo svfcXW [size] [flags] [cas]
...data...

client B:
mget foo svfc
VALUE foo svfcXZ [size] [flags] [cas]
...data...
```

client A fetches a value that was set to stale, sees flag X (item is stale), and flag W (won for recache). It also gets a value back. It can return the value to the caller, and kick off an asynchronous recache.

if another client comes in and "shadow deletes" this item after client
A has already won, the CAS would reset, internal token flag would be undone.
Starting the dance again.

---

Internally: This is implemented via the pre-existing CAS value (8 bytes per item), and two internal flag bits (one for STALE, one for TOKEN_SENT). I had described another implementation which uses client flags, but this should be much simpler to integrate. The command may be extended later to allow atomic test-and-sets for client flag bits.

---

Finally: multiple valid clients. EDIT: This no longer works innately.

---

Clients are expected to create an abstraction around this, though with
some examples it shouldn't be as complicated as this writeup makes it
sound.

See the next comment for a more complete spec.