### PR TITLE
-Y [filename] for ascii authentication mode

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,8 @@ memcached_SOURCES = memcached.c memcached.h \
                     logger.c logger.h \
                     crawler.c crawler.h \
                     itoa_ljust.c itoa_ljust.h \
-                    slab_automove.c slab_automove.h
+                    slab_automove.c slab_automove.h \
+                    authfile.c authfile.h
 
 if BUILD_CACHE
 memcached_SOURCES += cache.c

--- a/authfile.c
+++ b/authfile.c
@@ -1,0 +1,124 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "authfile.h"
+
+// TODO: frontend needs a refactor so this can avoid global objects.
+
+#define MAX_ENTRY_LEN 256
+// Not supposed to be a huge database!
+#define MAX_ENTRIES 8
+
+typedef struct auth_entry {
+    char *user;
+    size_t ulen;
+    char *pass;
+    size_t plen;
+} auth_t;
+
+auth_t main_auth_entries[MAX_ENTRIES];
+int entry_cnt = 0;
+char *main_auth_data = NULL;
+
+enum authfile_ret authfile_load(const char *file) {
+    struct stat sb;
+    char *auth_data = NULL;
+    auth_t auth_entries[MAX_ENTRIES];
+
+    if (stat(file, &sb) == -1) {
+        return AUTHFILE_MISSING;
+    }
+
+    auth_data = calloc(1, sb.st_size);
+
+    if (auth_data == NULL) {
+        return AUTHFILE_OOM;
+    }
+
+    FILE *pwfile = fopen(file, "r");
+    if (pwfile == NULL) {
+        // not strictly necessary but to be safe.
+        free(auth_data);
+        return AUTHFILE_OPENFAIL;
+    }
+
+    char *auth_cur = auth_data;
+    auth_t *entry_cur = auth_entries;
+    int used = 0;
+
+    while ((fgets(auth_cur, MAX_ENTRY_LEN, pwfile)) != NULL) {
+        int x;
+        int found = 0;
+
+        for (x = 0; x < MAX_ENTRY_LEN; x++) {
+            if (!found && auth_cur[x] == ':') {
+                entry_cur->user = auth_cur;
+                entry_cur->ulen = x;
+                entry_cur->pass = &auth_cur[x+1];
+                found = 1;
+            } else if (found) {
+                // Find end of password.
+                if (auth_cur[x] == '\n' ||
+                    auth_cur[x] == '\r' ||
+                    auth_cur[x] == '\0') {
+                    entry_cur->plen = x - (entry_cur->ulen + 1);
+                    break;
+                }
+            }
+        }
+
+        // malformed line.
+        if (!found) {
+            (void)fclose(pwfile);
+            free(auth_data);
+            return AUTHFILE_MALFORMED;
+        }
+
+        // FIXME: no silent truncation.
+        if (++used == MAX_ENTRIES) {
+            break;
+        }
+        // EOF
+        if (auth_cur[x] == '\0')
+            break;
+
+        auth_cur += x;
+        entry_cur++;
+    }
+
+    // swap the main pointer out now, so if there's an error reloading we
+    // don't break the existing authentication.
+    if (main_auth_data != NULL) {
+        free(main_auth_data);
+    }
+
+    entry_cnt = used;
+    main_auth_data = auth_data;
+    memcpy(main_auth_entries, auth_entries, sizeof(auth_entries));
+
+    (void)fclose(pwfile);
+
+    return AUTHFILE_OK;
+}
+
+// if only loading the file could be this short...
+int authfile_check(const char *user, const char *pass) {
+    size_t ulen = strlen(user);
+    size_t plen = strlen(pass);
+
+    for (int x = 0; x < entry_cnt; x++) {
+        auth_t *e = &main_auth_entries[x];
+        if (ulen == e->ulen && plen == e->plen &&
+            memcmp(user, e->user, e->ulen) == 0 &&
+            memcmp(pass, e->pass, e->plen) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/authfile.h
+++ b/authfile.h
@@ -1,0 +1,16 @@
+#ifndef AUTHFILE_H
+#define AUTHFILE_H
+
+enum authfile_ret {
+    AUTHFILE_OK = 0,
+    AUTHFILE_MISSING,
+    AUTHFILE_OOM,
+    AUTHFILE_OPENFAIL,
+    AUTHFILE_MALFORMED,
+};
+
+// FIXME: mc_authfile or something?
+enum authfile_ret authfile_load(const char *file);
+int authfile_check(const char *user, const char *pass);
+
+#endif /* AUTHFILE_H */

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -123,6 +123,23 @@ In the descriptions of individual commands below, these error lines
 are not again specifically mentioned, but clients must allow for their
 possibility.
 
+Authentication
+--------------
+
+Optional username/password token authentication (see -Y option). Used by
+sending a fake "set" command with any key:
+
+set <key> <flags> <exptime> <bytes>\r\n
+username password\r\n
+
+key, flags, and exptime are ignored for authentication. Bytes is the length
+of the username/password payload.
+
+- "STORED\r\n" indicates success. After this point any command should work
+  normally.
+
+- "CLIENT_ERROR [message]\r\n" will be returned if authentication fails for
+  any reason.
 
 Storage commands
 ----------------

--- a/memcached.h
+++ b/memcached.h
@@ -377,6 +377,7 @@ struct settings {
     uint64_t oldest_cas; /* ignore existing items with CAS values lower than this */
     int evict_to_free;
     char *socketpath;   /* path to unix socket if using local socket */
+    char *auth_file;    /* path to user authentication file */
     int access;  /* access mask (a la chmod) for unix domain socket */
     double factor;          /* chunk size growth factor */
     int chunk_size;
@@ -392,6 +393,7 @@ struct settings {
     int item_size_max;        /* Maximum item size */
     int slab_chunk_size_max;  /* Upper end for chunks within slab pages. */
     int slab_page_size;     /* Slab's page units. */
+    bool sig_hup;           /* a HUP signal was received but not yet handled */
     bool sasl;              /* SASL on/off */
     bool maxconns_fast;     /* Whether or not to early close connections */
     bool lru_crawler;        /* Whether or not to enable the autocrawler thread */
@@ -700,6 +702,7 @@ struct conn {
     int keylen;
     conn   *next;     /* Used for generating a list of conn structures */
     LIBEVENT_THREAD *thread; /* Pointer to the thread object serving this connection */
+    int (*try_read_command)(conn *c); /* pointer for top level input parser */
     ssize_t (*read)(conn  *c, void *buf, size_t count);
     ssize_t (*sendmsg)(conn *c, struct msghdr *msg, int flags);
     ssize_t (*write)(conn *c, void *buf, size_t count);

--- a/t/ascii-auth.t
+++ b/t/ascii-auth.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More tests => 9;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+# FIXME: Some tests are forcing UDP to be enabled via MemcachedTest.pm - need
+# to audit and fix.
+my $server = new_memcached("-Y $Bin/authfile -U 0");
+my $sock = $server->sock;
+
+# Test unauthenticated modes
+print $sock "set foo 0 0 2\r\nhi\r\n";
+like(scalar <$sock>, qr/CLIENT_ERROR/, "failed to do a write");
+print $sock "get foo\r\n";
+like(scalar <$sock>, qr/CLIENT_ERROR/, "failed to do a read");
+
+# Fail to authenticate.
+print $sock "set foo 0 0 7\r\nfoo bab\r\n";
+like(scalar <$sock>, qr/CLIENT_ERROR/, "failed to authenticate");
+
+# Try for real.
+print $sock "set foo 0 0 7\r\nfoo bar\r\n";
+like(scalar <$sock>, qr/STORED/, "authenticated?");
+
+print $sock "set toast 0 0 2\r\nhi\r\n";
+like(scalar <$sock>, qr/STORED/, "stored an item that didn't look like user/pass");
+
+mem_get_is($sock, "toast", "hi");
+
+# Create a second socket, try to authenticate against the second token.
+
+my $sock2 = $server->new_sock;
+
+print $sock2 "set foo 0 0 10\r\nbaaaz quux\r\n";
+like(scalar <$sock2>, qr/STORED/, "authenticated a second socket?");
+
+print $sock2 "set toast2 0 0 2\r\nho\r\n";
+like(scalar <$sock2>, qr/STORED/, "stored an item that didn't look like user/pass");
+
+mem_get_is($sock2, "toast2", "ho");
+
+# TODO: tests for reloads.

--- a/t/authfile
+++ b/t/authfile
@@ -1,0 +1,2 @@
+foo:bar
+baaaz:quux

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -262,7 +262,7 @@ sub new_memcached {
         }
         $udpport = free_port("udp");
         $args .= " -p $port";
-        if (supports_udp()) {
+        if (supports_udp() && $args !~ /-U (\S+)/) {
             $args .= " -U $udpport";
         }
         if ($ssl_enabled) {


### PR DESCRIPTION
Loads "username:password\n" tokens (up to 8) out of a supplied authfile.

If enabled, disables binary protocol (though may be able to enable both
if sasl is also used?).

authentication is done via the "set" command. A separate handler is
used to avoid some hot path conditionals and narrow the code
executed in an unauthenticated state.

ie:
```
set foo 0 0 7\r\n
foo bar\r\n
```
returns "STORED" on success. Else returns CLIENT_ERROR with some
information.

Any key is accepted: if using a client that doesn't try to authenticate
when connecting to a pool of servers, the authentication set can be
tried with the same key as one that failed to coerce the client to
routing to the correct server. Else an "auth" or similar key would
always go to the same server.

kill -HUP'ing memcached causes it to reload the authentication file. Haven't decided on a command or not yet.