### PR TITLE
Fix segfault when an item's flags are 0

### DIFF
--- a/items.c
+++ b/items.c
@@ -330,7 +330,9 @@ item *do_item_alloc(char *key, const size_t nkey, const unsigned int flags,
     it->nbytes = nbytes;
     memcpy(ITEM_key(it), key, nkey);
     it->exptime = exptime;
-    memcpy(ITEM_suffix(it), &flags, sizeof(flags));
+    if (nsuffix > 0) {
+        memcpy(ITEM_suffix(it), &flags, sizeof(flags));
+    }
 
     /* Initialize internal chunk. */
     if (it->it_flags & ITEM_CHUNKED) {


### PR DESCRIPTION
If flags are 0 ```item_make_header``` sets nsuffix to 0 (to save space), otherwise it sets it to ```sizeof(flags)```. In the case where nsuffix was 0 flags were still being memcpy'd which in our case was leading to segfaults.

I've changed it so the memcpy of flags should only happen when the space for them has been accounted for. This should be like the behavior in 1.5.14.