### PR TITLE
Fix off-by-one in logger to allow CAS commands to be logged.

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -181,7 +181,7 @@ static int _logger_thread_parse_ise(logentry *e, char *scratch) {
     const char * const cmd_map[] = {
         "null", "add", "set", "replace", "append", "prepend", "cas" };
 
-    if (le->cmd <= 5)
+    if (le->cmd <= 6)
         cmd = cmd_map[le->cmd];
 
     uriencode(le->key, keybuf, le->nkey, KEY_MAX_URI_ENCODED_LENGTH);

--- a/t/watcher.t
+++ b/t/watcher.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Socket qw/SO_RCVBUF/;
 
-use Test::More tests => 10;
+use Test::More tests => 12;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -102,4 +102,16 @@ if ($res eq "STORED\r\n") {
     }
     is($found_log, 1, "found rawcmd log entry");
     is($found_ev, 1, "found eviction log entry");
+}
+
+# test cas command logs
+{
+    $watcher = $server->new_sock;
+    print $watcher "watch mutations\n";
+    $res = <$watcher>;
+    is($res, "OK\r\n", "mutations watcher enabled");
+
+    print $client "cas cas_watch_key 0 0 5 0\r\nvalue\r\n";
+    my $log = <$watcher>;
+    like($log, qr/cmd=cas/, "correctly logged cas command");
 }


### PR DESCRIPTION
Due to an off-by-one in the bounds check in ` _logger_thread_parse_ise`, mutation watchers watchers receive `cmd=na` instead of `cmd=cas` for CAS commands. The bug was introduced in 87a70654c176dfe984449b4b5c6c85cbddec469a: `"null"` was prepended to `cmd_map`, but the following bounds check wasn't updated. As a result, the max value, `NREAD_CAS` (`6`), gets improperly mapped to `"na"`.

I've included a test to verify the (tiny) fix. Without my change to `logger.c`, the test fails with the following error (note the `cmd=na` in the log message):

```
$ prove t/watcher.t 
t/watcher.t .. 3/12 
#   Failed test 'correctly logged cas command'
#   at t/watcher.t line 116.
#                   'ts=1559259272.846954 gid=47403 type=item_store key=cas_watch_key status=not_found cmd=na ttl=0 clsid=1
# '
#     doesn't match '(?^:cmd=cas)'
# Looks like you failed 1 test of 12.
t/watcher.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/12 subtests 

Test Summary Report
-------------------
t/watcher.t (Wstat: 256 Tests: 12 Failed: 1)
  Failed test:  12
  Non-zero exit status: 1
Files=1, Tests=12,  3 wallclock secs ( 0.01 usr  0.00 sys +  0.15 cusr  0.33 csys =  0.49 CPU)
Result: FAIL
```

With my change, the new test (as well as all of `make test`) passes.