### PR TITLE
for configured slab sizes, need strdup

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -7566,7 +7566,7 @@ int main (int argc, char **argv) {
                 }
                 settings.logger_buf_size *= 1024; /* kilobytes */
             case SLAB_SIZES:
-                slab_sizes_unparsed = subopts_value;
+                slab_sizes_unparsed = strdup(subopts_value);
                 break;
             case SLAB_CHUNK_MAX:
                 if (subopts_value == NULL) {


### PR DESCRIPTION
Am new here 

👋 

The `-o slab_sizes` options allows for configurable `slab-sizes`. When we are parsing the subopt value, we need to make a copy of the string.

We do this already for 

```
memcached.c:7613:                settings.ssl_chain_cert = strdup(subopts_value);
memcached.c:7620:                settings.ssl_key = strdup(subopts_value);
memcached.c:7670:                settings.ssl_ciphers = strdup(subopts_value);
memcached.c:7677:                settings.ssl_ca_cert = strdup(subopts_value);
```

This change just does the same for `slab_sizes_unparsed` also.

@dormando 