### PR TITLE
add error handling when calling dup function

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -420,6 +420,10 @@ static int start_conn_timeout_thread() {
 static void conn_init(void) {
     /* We're unlikely to see an FD much higher than maxconns. */
     int next_fd = dup(1);
+    if (next_fd < 0) {
+        perror("Failed to duplicate file descriptor\n");
+        exit(1);
+    }
     int headroom = 10;      /* account for extra unexpected open FDs */
     struct rlimit rl;
 
@@ -5969,7 +5973,16 @@ static int server_socket(const char *interface,
                  * among threads, so this is guaranteed to assign one
                  * FD to each thread.
                  */
-                int per_thread_fd = c ? dup(sfd) : sfd;
+                int per_thread_fd;
+                if (c == 0) {
+                    per_thread_fd = sfd;
+                } else {
+                    per_thread_fd = dup(sfd);
+                    if (per_thread_fd < 0) {
+                        fprintf(stderr, "Failed to duplicate file descriptor\n");
+                        exit(EXIT_FAILURE);
+                    }
+                }
                 dispatch_conn_new(per_thread_fd, conn_read,
                                   EV_READ | EV_PERSIST,
                                   UDP_READ_BUFFER_SIZE, transport);

--- a/testapp.c
+++ b/testapp.c
@@ -478,6 +478,7 @@ static int connect_server(const char *hostname, in_port_t port, bool nonblock)
 static enum test_return test_vperror(void) {
     int rv = 0;
     int oldstderr = dup(STDERR_FILENO);
+    assert(oldstderr >= 0);
     char tmpl[sizeof(TMP_TEMPLATE)+1];
     strncpy(tmpl, TMP_TEMPLATE, sizeof(TMP_TEMPLATE)+1);
 


### PR DESCRIPTION
The dup function can return errors.
So I added error handling code.