### PR TITLE
Remove a wrong function comment

### DIFF
--- a/items.c
+++ b/items.c
@@ -148,7 +148,6 @@ unsigned int do_get_lru_size(uint32_t id) {
 /**
  * Generates the variable-sized part of the header for an object.
  *
- * key     - The key
  * nkey    - The length of the key
  * flags   - key flags
  * nbytes  - Number of bytes to hold value and addition CRLF terminator


### PR DESCRIPTION
The function doesn't use 'key' parameter anymore.