### PR TITLE
Make memcached setgroups failure non-fatal

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -8475,7 +8475,6 @@ int main (int argc, char **argv) {
         }
         if (setgroups(0, NULL) < 0) {
             fprintf(stderr, "failed to drop supplementary groups\n");
-            exit(EX_OSERR);
         }
         if (setgid(pw->pw_gid) < 0 || setuid(pw->pw_uid) < 0) {
             fprintf(stderr, "failed to assume identity of user %s\n", username);

--- a/memcached.c
+++ b/memcached.c
@@ -8474,7 +8474,18 @@ int main (int argc, char **argv) {
             exit(EX_NOUSER);
         }
         if (setgroups(0, NULL) < 0) {
-            fprintf(stderr, "failed to drop supplementary groups\n");
+            /* setgroups may fail with EPERM, indicating we are already in a
+             * minimally-privileged state. In that case we continue. For all
+             * other failure codes we exit.
+             *
+             * Note that errno is stored here because fprintf may change it.
+             */
+            bool should_exit = errno != EPERM;
+            fprintf(stderr, "failed to drop supplementary groups: %s\n",
+                    strerror(errno));
+            if (should_exit) {
+                exit(EX_OSERR);
+            }
         }
         if (setgid(pw->pw_gid) < 0 || setuid(pw->pw_uid) < 0) {
             fprintf(stderr, "failed to assume identity of user %s\n", username);


### PR DESCRIPTION
A call to setgroups can fail on Linux if the user lacks cap_setgid or if setgroups has been disallowed in a user namespace. The latter happens when the namespace has no GID map or if /proc/pid/setgroups has been changed to "deny". Treating this failure as fatal means that memcached cannot start in a bazel fakeroot. Ignoring failure seems harmless.