### PR TITLE
restart: add missing msync at close time

### DIFF
--- a/restart.c
+++ b/restart.c
@@ -303,6 +303,8 @@ bool restart_mmap_open(const size_t limit, const char *file, void **mem_base) {
 
 /* Gracefully stop/close the shared memory segment */
 void restart_mmap_close(void) {
+    msync(mmap_base, slabmem_limit, MS_SYNC);
+
     if (restart_save(memory_file) != 0) {
         fprintf(stderr, "[restart] failed to save metadata");
     }


### PR DESCRIPTION
To make sure that the backing pages actually make it to the backing
device prior to shutdown, munmap must be preceded by an msync call.
Additionally, since the metadata file is used as a flag to check if
the shutdown was graceful, the data needs to be sync'd prior to that
file being written.