### PR TITLE
TLS leak

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -5805,6 +5805,7 @@ static void drive_machine(conn *c) {
                             if (settings.verbose) {
                                 fprintf(stderr, "SSL connection failed with error code : %d : %s\n", err, strerror(errno));
                             }
+                            SSL_free(ssl);
                             close(sfd);
                             break;
                         }

--- a/thread.c
+++ b/thread.c
@@ -500,6 +500,12 @@ static void thread_libevent_process(int fd, short which, void *arg) {
                             fprintf(stderr, "Can't listen for events on fd %d\n",
                                 item->sfd);
                         }
+#ifdef TLS
+                        if (item->ssl) {
+                            SSL_shutdown(item->ssl);
+                            SSL_free(item->ssl);
+                        }
+#endif
                         close(item->sfd);
                     }
                 } else {


### PR DESCRIPTION
frees said context. Don't believe SSL_shutdown is required? Should
double check.