### PR TITLE
TLS: Reload CA cert in certificate refresh routine

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3342,9 +3342,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
 #endif
 #ifdef TLS
     if (settings.ssl_enabled) {
-        SSL_LOCK();
         APPEND_STAT("time_since_server_cert_refresh", "%u", now - settings.ssl_last_cert_refresh_time);
-        SSL_UNLOCK();
     }
 #endif
 }

--- a/t/ssl_cert_refresh.t
+++ b/t/ssl_cert_refresh.t
@@ -13,14 +13,16 @@ if (!enabled_tls_testing()) {
     exit 0;
 }
 
+my $ca_cert = "t/" . MemcachedTest::CA_CRT;
 my $cert = "t/". MemcachedTest::SRV_CRT;
 my $key = "t/". MemcachedTest::SRV_KEY;
+my $ca_cert_back = "t/ca_cert_back";
 my $cert_back = "t/cert_back";
 my $key_back = "t/pkey_back";
 my $new_cert_key = "t/server.pem";
 my $default_crt_ou = "OU=Subunit of Test Organization";
 
-my $server = new_memcached();
+my $server = new_memcached("-o ssl_ca_cert=$ca_cert");
 my $stats = mem_stats($server->sock);
 my $pid = $stats->{pid};
 my $sock = $server->sock;
@@ -32,8 +34,10 @@ $cert_details =~ m/(OU=([^\/\n]*))/;
 is($1, $default_crt_ou, 'Got the default cert');
 
 # Swap a new certificate with a key
+copy($ca_cert, $ca_cert_back) or die "CA cert backup failed: $!";
 copy($cert, $cert_back) or die "Cert backup failed: $!";
 copy($key, $key_back) or die "Key backup failed: $!";
+copy($new_cert_key, $ca_cert) or die "New CA cert copy failed: $!";
 copy($new_cert_key, $cert) or die "New Cert copy failed: $!";
 copy($new_cert_key, $key) or die "New key copy failed: $!";
 
@@ -46,7 +50,7 @@ $cert_details = $server->new_sock->dump_peer_certificate();
 $cert_details =~ m/(OU=([^\/]*))/;
 is($1, 'OU=FOR TESTING PURPOSES ONLY','Got the new cert');
 # Old connection should use the previous certificate
-$cert_details =$sock->dump_peer_certificate();
+$cert_details = $sock->dump_peer_certificate();
 $cert_details =~ m/(OU=([^\/\n]*))/;
 is($1, $default_crt_ou, 'Old connection still has the old cert');
 
@@ -56,6 +60,7 @@ sleep 2;
 $stats = mem_stats($sock);
 
 # Restore and ensure previous certificate is back for new connections.
+move($ca_cert_back, $ca_cert) or die "CA cert restore failed: $!";
 move($cert_back, $cert) or die "Cert restore failed: $!";
 move($key_back, $key) or die "Key restore failed: $!";
 print $sock "refresh_certs\r\n";


### PR DESCRIPTION
With TLS enabled, the current implementation only reloads the certificate and key on a `refresh_certs` line from a client. This patch additionally attempts to reload the CA certificate, if supplied.

Also swap `SSL_LOCK` for `STATS_LOCK` in what I believe was a typo in the original TLS implementation PR.

cc @tharanga