### PR TITLE
Add include stdio.h to restart.c

### DIFF
--- a/restart.c
+++ b/restart.c
@@ -2,6 +2,7 @@
 
 #include "restart.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/types.h>


### PR DESCRIPTION
Compile error occur..
```
restart.c: In function ‘restart_check’:
restart.c:75:5: error: implicit declaration of function ‘fopen’ [-Werror=implicit-function-declaration]
     FILE *f = fopen(metafile, "r");
     ^
restart.c:75:15: error: initialization makes pointer from integer without a cast [-Werror]
     FILE *f = fopen(metafile, "r");
               ^
restart.c:77:9: error: implicit declaration of function ‘fprintf’ [-Werror=implicit-function-declaration]
         fprintf(stderr, "[restart] no metadata save file, starting with a clean cache\n");
         ^
restart.c:77:9: error: incompatible implicit declaration of built-in function ‘fprintf’ [-Werror]
restart.c:77:17: error: ‘stderr’ undeclared (first use in this function)
         fprintf(stderr, "[restart] no metadata save file, starting with a clean cache\n");
                 ^
restart.c:77:17: note: each undeclared identifier is reported only once for each function it appears in
restart.c:89:9: error: incompatible implicit declaration of built-in function ‘fprintf’ [-Werror]
         fprintf(stderr, "[restart] corrupt metadata file\n");
...
```

restart.c source code need to include stdio.h .