### PR TITLE
DTrace build fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,12 +172,11 @@ if test "x$enable_dtrace" = "xyes"; then
   if test "x$DTRACE" != "xno"; then
     AC_DEFINE([ENABLE_DTRACE],1,[Set to nonzero if you want to include DTRACE])
     build_dtrace=yes
-    # DTrace on MacOSX does not use -G option
-    $DTRACE -G -o conftest.$$ -s memcached_dtrace.d 2>/dev/zero
+    $DTRACE -h -o conftest.h -s memcached_dtrace.d 2>/dev/zero
     if test $? -eq 0
     then
         dtrace_instrument_obj=yes
-        rm conftest.$$
+        rm conftest.h
     fi
 
     if test "`which tr`" = "/usr/ucb/tr"; then

--- a/memcached_dtrace.d
+++ b/memcached_dtrace.d
@@ -57,7 +57,7 @@ provider memcached {
     * @param connid the connection id
     * @param threadid the thread id
     */
-   probe conn__dispatch(int connid, int threadid);
+   probe conn__dispatch(int connid, int64_t threadid);
 
    /**
     * Allocate memory from the slab allocator.

--- a/thread.c
+++ b/thread.c
@@ -580,7 +580,7 @@ void dispatch_conn_new(int sfd, enum conn_states init_state, int event_flags,
 
     cq_push(thread->new_conn_queue, item);
 
-    MEMCACHED_CONN_DISPATCH(sfd, thread->thread_id);
+    MEMCACHED_CONN_DISPATCH(sfd, (int64_t)thread->thread_id);
     buf[0] = 'c';
     if (write(thread->notify_send_fd, buf, 1) != 1) {
         perror("Writing to thread notify pipe");


### PR DESCRIPTION
During config step just being "contented" by generating the header,
there is no symbols to attach for, no chance to work as is.
Changing a probe signature, on some platforms, pthread_t is an
opaque type thus casting to a type large enough to hold it
for all oses.