### PR TITLE
Fix cross compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,23 +264,42 @@ return sizeof(void*) == 8 ? 0 : 1;
     ],[
       CFLAGS="-m64 $org_cflags"
     ],[
-    AC_MSG_ERROR([Don't know how to build a 64-bit object.])
+      AC_MSG_ERROR([Don't know how to build a 64-bit object.])
+    ],[
+       dnl cross compile
+       AC_MSG_WARN([Assuming no extra CFLAGS are required for cross-compiling 64bit version.])
     ])
 fi
 
 dnl If data pointer is 64bit or not.
-AC_RUN_IFELSE(
-  [AC_LANG_PROGRAM([], [dnl
-return sizeof(void*) == 8 ? 0 : 1;
-  ])
-],[
-  have_64bit_ptr=yes
-],[
+AC_CHECK_HEADERS([stdint.h])
+AS_IF([test -z "$have_64bit_ptr"],
+  [AC_RUN_IFELSE(
+     [AC_LANG_PROGRAM([], [return sizeof(void*) == 8 ? 0 : 1;])],
+     [have_64bit_ptr=yes ],
+     [have_64bit_ptr=no],
+     [dnl cross compile (this test requires C99)
+      AS_IF([test "x$ac_cv_header_stdint_h" = xyes],
+        [AC_COMPILE_IFELSE(
+           [AC_LANG_PROGRAM([
+              #include <stdint.h>
+              #if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFUL
+              /* 64 bit pointer */
+              #else
+              #error 32 bit pointer
+              #endif
+            ], [])],
+            [have_64bit_ptr=yes],
+            [have_64bit_ptr=no])],
+        [have_64bit_ptr=unknown])
+     ])
 ])
-
-if test $have_64bit_ptr = yes; then
+AS_IF([test "$have_64bit_ptr" = "unknown" ],[
+  AC_MSG_ERROR([Cannot detect pointer size. Must pass have_64bit_ptr={yes,no} to configure.])
+])
+AS_IF([test "$have_64bit_ptr" = yes],[
   AC_DEFINE(HAVE_64BIT_PTR, 1, [data pointer is 64bit])
-fi
+])
 
 # Issue 213: Search for clock_gettime to help people linking
 #            with a static version of libevent
@@ -570,30 +589,10 @@ fi
 AC_C_SOCKLEN_T
 
 dnl Check if we're a little-endian or a big-endian system, needed by hash code
-AC_DEFUN([AC_C_ENDIAN],
-[AC_CACHE_CHECK(for endianness, ac_cv_c_endian,
-[
-  AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM([], [dnl
-        long val = 1;
-        char *c = (char *) &val;
-        exit(*c == 1);
-    ])
-  ],[
-    ac_cv_c_endian=big
-  ],[
-    ac_cv_c_endian=little
-  ])
-])
-if test $ac_cv_c_endian = big; then
-  AC_DEFINE(ENDIAN_BIG, 1, [machine is bigendian])
-fi
-if test $ac_cv_c_endian = little; then
-  AC_DEFINE(ENDIAN_LITTLE, 1, [machine is littleendian])
-fi
-])
-
-AC_C_ENDIAN
+AC_C_BIGENDIAN(
+  [AC_DEFINE(ENDIAN_BIG, 1, [machine is bigendian])],
+  [AC_DEFINE(ENDIAN_LITTLE, 1, [machine is littleendian])],
+  [AC_MSG_ERROR([Cannot detect endianness. Must pass ac_cv_c_bigendian={yes,no} to configure.])])
 
 AC_DEFUN([AC_C_HTONLL],
 [
@@ -670,12 +669,15 @@ AC_DEFUN([AC_C_ALIGNMENT],
   ],[
     ac_cv_c_alignment=need
   ],[
-    ac_cv_c_alignment=need
+    dnl cross compile
+    ac_cv_c_alignment=maybe
   ])
 ])
-if test $ac_cv_c_alignment = need; then
-  AC_DEFINE(NEED_ALIGN, 1, [Machine need alignment])
-fi
+AS_IF([test $ac_cv_c_alignment = need],
+  [AC_DEFINE(NEED_ALIGN, 1, [Machine need alignment])])
+AS_IF([test $ac_cv_c_alignment = maybe],
+  [AC_MSG_WARN([Assuming aligned access is required when cross-compiling])
+   AC_DEFINE(NEED_ALIGN, 1, [Machine need alignment])])
 ])
 
 AC_C_ALIGNMENT

--- a/configure.ac
+++ b/configure.ac
@@ -271,35 +271,8 @@ return sizeof(void*) == 8 ? 0 : 1;
     ])
 fi
 
-dnl If data pointer is 64bit or not.
-AC_CHECK_HEADERS([stdint.h])
-AS_IF([test -z "$have_64bit_ptr"],
-  [AC_RUN_IFELSE(
-     [AC_LANG_PROGRAM([], [return sizeof(void*) == 8 ? 0 : 1;])],
-     [have_64bit_ptr=yes ],
-     [have_64bit_ptr=no],
-     [dnl cross compile (this test requires C99)
-      AS_IF([test "x$ac_cv_header_stdint_h" = xyes],
-        [AC_COMPILE_IFELSE(
-           [AC_LANG_PROGRAM([
-              #include <stdint.h>
-              #if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFUL
-              /* 64 bit pointer */
-              #else
-              #error 32 bit pointer
-              #endif
-            ], [])],
-            [have_64bit_ptr=yes],
-            [have_64bit_ptr=no])],
-        [have_64bit_ptr=unknown])
-     ])
-])
-AS_IF([test "$have_64bit_ptr" = "unknown" ],[
-  AC_MSG_ERROR([Cannot detect pointer size. Must pass have_64bit_ptr={yes,no} to configure.])
-])
-AS_IF([test "$have_64bit_ptr" = yes],[
-  AC_DEFINE(HAVE_64BIT_PTR, 1, [data pointer is 64bit])
-])
+dnl Check if data pointer is 64bit or not
+AC_CHECK_SIZEOF([void *])
 
 # Issue 213: Search for clock_gettime to help people linking
 #            with a static version of libevent

--- a/restart.h
+++ b/restart.h
@@ -4,7 +4,7 @@
 #define RESTART_TAG_MAXLEN 255
 
 // Track the pointer size for restart fiddling.
-#ifdef HAVE_64BIT_PTR
+#if SIZEOF_VOID_P == 8
     typedef uint64_t mc_ptr_t;
 #else
     typedef uint32_t mc_ptr_t;


### PR DESCRIPTION
AC_RUN_IFELSE does not work when cross-compiling so we need to provide
fallback methods for those cases.

I tried to use constructs that work with Autoconf 2.52.
Alas, I wasn't able to generate a working build system with that version.

Autoconf 2.58 / Automake 1.7.9 is the earliest combo that I could get
to work (with and without this patch).
Perhaps it's time for a slight bump for the required version numbers?

Cross-compiles successfully against:
riscv64-unknown-linux-gnu