### PR TITLE
restart: add error handling when a tag is not found in a metadata file.

### DIFF
--- a/restart.c
+++ b/restart.c
@@ -82,6 +82,7 @@ static int restart_check(const char *file) {
     restart_cb_ctx ctx;
 
     ctx.f = f;
+    ctx.cb = NULL;
     ctx.line = NULL;
     ctx.done = false;
     if (restart_get_kv(&ctx, NULL, NULL) != RESTART_DONE) {
@@ -89,6 +90,10 @@ static int restart_check(const char *file) {
         // callback here.
         fprintf(stderr, "[restart] corrupt metadata file\n");
         // TODO: this should probably just return -1 and skip the reuse.
+        abort();
+    }
+    if (ctx.cb == NULL) {
+        fprintf(stderr, "[restart] Failed to read a tag from metadata file\n");
         abort();
     }
 

--- a/t/restart.t
+++ b/t/restart.t
@@ -12,6 +12,15 @@ use MemcachedTest;
 # /dev/shm.
 my $mem_path = "/tmp/mc_restart.$$";
 
+# read a invalid metadata file
+{
+    my $meta_path = "$mem_path.meta";
+    open(my $f, "> $meta_path") || die("Can't open a metadata file.");
+    eval {  new_memcached("-e $mem_path"); };
+    unlink($meta_path);
+    ok($@, "Died with an empty metadata file");
+}
+
 my $server = new_memcached("-m 128 -e $mem_path -I 2m");
 my $sock = $server->sock;
 


### PR DESCRIPTION
It seems that there is a problem that a process is executed normally even if it fails when reading the tag from the metadata file.