### PR TITLE
restart: remove unused restart_mmap_set function

### DIFF
--- a/restart.h
+++ b/restart.h
@@ -23,7 +23,6 @@ enum restart_get_kv_ret restart_get_kv(void *ctx, char **key, char **val);
 
 bool restart_mmap_open(const size_t limit, const char *file, void **mem_base);
 void restart_mmap_close(void);
-void restart_mmap_set(void);
 unsigned int restart_fixup(void *old_base);
 
 #endif


### PR DESCRIPTION
restart_mmap_set function in restart.h is not used but has not been removed.