### PR TITLE
Double-Initialization of Multiple Mutexes and Condition Variables

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -277,7 +277,7 @@ int start_assoc_maintenance_thread() {
             hash_bulk_move = DEFAULT_HASH_BULK_MOVE;
         }
     }
-    pthread_mutex_init(&maintenance_lock, NULL);
+
     if ((ret = pthread_create(&maintenance_tid, NULL,
                               assoc_maintenance_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create thread: %s\n", strerror(ret));

--- a/crawler.c
+++ b/crawler.c
@@ -696,11 +696,6 @@ int init_lru_crawler(void *arg) {
 #ifdef EXTSTORE
         storage = arg;
 #endif
-        if (pthread_cond_init(&lru_crawler_cond, NULL) != 0) {
-            fprintf(stderr, "Can't initialize lru crawler condition\n");
-            return -1;
-        }
-        pthread_mutex_init(&lru_crawler_lock, NULL);
         active_crawler_mod.c.c = NULL;
         active_crawler_mod.mod = NULL;
         active_crawler_mod.data = NULL;

--- a/items.c
+++ b/items.c
@@ -1722,10 +1722,7 @@ void lru_maintainer_resume(void) {
 }
 
 int init_lru_maintainer(void) {
-    if (lru_maintainer_initialized == 0) {
-        pthread_mutex_init(&lru_maintainer_lock, NULL);
-        lru_maintainer_initialized = 1;
-    }
+    lru_maintainer_initialized = 1;
     return 0;
 }
 

--- a/slabs.c
+++ b/slabs.c
@@ -1290,12 +1290,6 @@ int start_slab_maintenance_thread(void) {
         }
     }
 
-    if (pthread_cond_init(&slab_rebalance_cond, NULL) != 0) {
-        fprintf(stderr, "Can't initialize rebalance condition\n");
-        return -1;
-    }
-    pthread_mutex_init(&slabs_rebalance_lock, NULL);
-
     if ((ret = pthread_create(&rebalance_tid, NULL,
                               slab_rebalance_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create rebal thread: %s\n", strerror(ret));


### PR DESCRIPTION
This PR resolves multiple mutexes and condition variables that are initialized twice, which is undefined behavior according to the POSIX standard (see excerpts at the end of this post). Beyond resolving this UB, this PR also simplifies initialization somewhat.

The following mutexes and condition variables are touched by this PR:
1. `slabs_rebalance_lock` (originally initialized in slabs.c:59 and slabs.c:1297)
2. `slab_rebalance_cond` (originally initialized in slabs.c:713 and slabs.c:1293)
3. `maintenance_lock` (originally initialized in assoc.c:29 and assoc.c:280)
4. `lru_crawler_lock` (originally initialized in crawler.c:97 and crawler.c:703)
5. `lru_crawler_cond` (originally initialized in crawler.c:98 and crawler.c:699)
6. `lru_maintainer_lock` (originally initialized in items.c:67 and items.c:1726)

This behavior was detected using Symbolic Execution techniques developed in collaboration by the SYMBIOSYS research project at COMSYS, RWTH Aachen University and Cesar Rodriguez (Diffblue, Ltd.). This research is supported by the European Research Council (ERC) under the EU's Horizon 2020 Research and Innovation Programme grant agreement n. 647295 (SYMBIOSYS).

IEEE 1003.1-2008 (POSIX) on double-initialization of mutexes:
> 50875: Attempting to initialize an already initialized condition variable results in undefined behavior.  
> 50876: In cases where default condition variable attributes are appropriate, the macro  
> 50877: PTHREAD_COND_INITIALIZER can be used to initialize condition variables that are statically  
> 50878: allocated. The effect shall be equivalent to dynamic initialization by a call to pthread_cond_init()  
> 50879: with parameter attr specified as NULL, except that no error checks are performed.  

IEEE 1003.1-2008 (POSIX) on double-initialization of condition variables:
> 50875: Attempting to initialize an already initialized condition variable results in undefined behavior.  
> 50876: In cases where default condition variable attributes are appropriate, the macro  
> 50877: PTHREAD_COND_INITIALIZER can be used to initialize condition variables that are statically  
> 50878: allocated. The effect shall be equivalent to dynamic initialization by a call to pthread_cond_init()  
> 50879: with parameter attr specified as NULL, except that no error checks are performed.  