### PR TITLE
Ensure t/whitespace.t dies with a good error outside valid git checkouts

### DIFF
--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -5,6 +5,11 @@ our @files;
 
 BEGIN {
     chdir "$Bin/.." or die;
+    unless (-d "$Bin/../.git") {
+        use Test::More;
+        plan skip_all => "Skipping test because this does not appear to be a memcached git working directory";
+        exit 0;
+    }
 
     my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md compile_commands.json);
     push(@exempted, glob("doc/*.xml"));


### PR DESCRIPTION
Greetings!  I'm trying to familiarize myself with the memcached codebase so I thought I'd try to bang out a few easy "help wanted" issues.  Please let me know if there is anything I can change to get this PR accepted.  Thanks!

The test as written uses git to find a list of files to check, so it doesn't
work correctly outside a git checkout.

Reported in #485