### PR TITLE
configuration option to disable watch commands

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -428,6 +428,7 @@ struct settings {
     unsigned int logger_watcher_buf_size; /* size of logger's per-watcher buffer */
     unsigned int logger_buf_size; /* size of per-thread logger buffer */
     bool drop_privileges;   /* Whether or not to drop unnecessary process privileges */
+    bool no_watch; /* allows watch commands to be dropped */
     bool relaxed_privileges;   /* Relax process restrictions when running testapp */
 #ifdef EXTSTORE
     unsigned int ext_item_size; /* minimum size of items to store externally */

--- a/t/watcher.t
+++ b/t/watcher.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Socket qw/SO_RCVBUF/;
 
-use Test::More tests => 12;
+use Test::More tests => 13;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -120,4 +120,15 @@ if ($res eq "STORED\r\n") {
         sleep 1;
     }
     is($found_cas, 1, "correctly logged cas command");
+}
+# test no_watch extended option
+{
+    my $nowatch_server = new_memcached('-o no_watch');
+    my $watchsock = $nowatch_server->new_sock;
+
+    print $watchsock "watch mutations\n";
+
+    my $watchresult = <$watchsock>;
+
+    is($watchresult, "CLIENT_ERROR watch commands not allowed\r\n", "attempted watch gave client error with no_watch option set");
 }


### PR DESCRIPTION
Suggested in #544.  This is my first stab at this feature.  Looking for
feedback about what to do when commands are disabled (print ERROR,
other?).  Examples of other feature flags I should look at?

TODO:
* test locally
* write tests
* get feedback on help option name / descriptions
* other?