### PR TITLE
Fix a second data race on stats

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -9528,8 +9528,8 @@ int main (int argc, char **argv) {
     }
 
     /* initialize other stuff */
-    logger_init();
     stats_init();
+    logger_init();
     conn_init();
     bool reuse_mem = false;
     void *mem_base = NULL;


### PR DESCRIPTION
This data race (different from #573) is due to the logging thread being started before the stats are initialized. As `stats_init` only initializes memory, I simply moved the `stats_init` call up one line. The logging thread correctly locks the stats structure when updating it in [`logger_thread_sum_stats`](https://github.com/memcached/memcached/blob/e7c7a1089c066d105bf0a6c1a812668644a4a6f0/logger.c#L553), but that does not help, as the initialization of the stats data structures has not happened yet (and is performed without holding the stats lock).

This behavior was detected using Symbolic Execution techniques developed in collaboration by the SYMBIOSYS research project at COMSYS, RWTH Aachen University and Cesar Rodriguez (Diffblue, Ltd.). This research is supported by the European Research Council (ERC) under the EU's Horizon 2020 Research and Innovation Programme grant agreement n. 647295 (SYMBIOSYS).