### PR TITLE
Update documentation for --max-item-size

### DIFF
--- a/doc/memcached.1
+++ b/doc/memcached.1
@@ -140,7 +140,7 @@ specify the protocol clients must speak.  Possible options are "auto"
 .TP
 .B \-I, --max-item-size=<size>
 Override the default size of each slab page. The default size is 1mb. Default
-value for this parameter is 1m, minimum is 1k, max is 128m.
+value for this parameter is 1m, minimum is 1k, max is 1G (1024 * 1024 * 1024).
 Adjusting this value changes the item size limit.
 .TP
 .B \-S, --enable-sasl


### PR DESCRIPTION
This limit was added in this patch [1], while this patch [2] fixed it in -h output. 

[1] https://github.com/memcached/memcached/commit/b5ad069ed887b8086756def7fb2efa65f5c1e462#diff-3970a0b3806605c2c138450fdae4e80e
[2] https://github.com/memcached/memcached/commit/50bdc9f3e134122e280031683f2b502f84e96624#diff-3970a0b3806605c2c138450fdae4e80e