### PR TITLE
Fix the bug sasl will load config from the wrong path when HAVE_SASL_CB_GETCONFPATH enabled

### DIFF
--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -26,7 +26,7 @@ const char *const locations_dir_path[] = {
 };
 
 /* If the element of locations is directory, locations_file_path stores
- * the actual configue file which used by sasl, when GETCONFPATH is
+ * the actual configure file which used by sasl, when GETCONFPATH is
  * enabled */
 const char *const locations_file_path[] = {
     "/etc/sasl/memcached.conf/memcached.conf",

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -82,11 +82,12 @@ static int sasl_server_userdb_checkpass(sasl_conn_t *conn,
 }
 #endif
 
-#if defined(HAVE_SASL_CB_GETCONF)
+#if defined(HAVE_SASL_CB_GETCONF) || defined(HAVE_SASL_CB_GETCONFPATH)
 static int sasl_getconf(void *context, const char **path)
 {
     *path = getenv("SASL_CONF_PATH");
 
+#if defined(HAVE_SASL_CB_GETCONF)
     if (*path == NULL) {
         for (int i = 0; locations[i] != NULL; ++i) {
             if (access(locations[i], F_OK) == 0) {
@@ -95,23 +96,7 @@ static int sasl_getconf(void *context, const char **path)
             }
         }
     }
-
-    if (settings.verbose) {
-        if (*path != NULL) {
-            fprintf(stderr, "Reading configuration from: <%s>\n", *path);
-        } else {
-            fprintf(stderr, "Failed to locate a config path\n");
-        }
-
-    }
-
-    return (*path != NULL) ? SASL_OK : SASL_FAIL;
-}
 #elif defined(HAVE_SASL_CB_GETCONFPATH)
-static int sasl_getconf(void *context, const char **path)
-{
-    *path = getenv("SASL_CONF_PATH");
-
     char buf[50];
     if (*path == NULL) {
         for (int i = 0; locations[i] != NULL; ++i) {
@@ -131,6 +116,7 @@ static int sasl_getconf(void *context, const char **path)
             }
         }
     }
+#endif
 
     if (settings.verbose) {
         if (*path != NULL) {

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -27,7 +27,7 @@ const char *const locations_dir_path[] = {
 
 /* If the element of locations is directory, locations_file_path stores
  * the actual configue file which used by sasl, when GETCONFPATH is
- * enabld */
+ * enabled */
 const char *const locations_file_path[] = {
     "/etc/sasl/memcached.conf/memcached.conf",
     "/etc/sasl2/memcached.conf/memcached.conf",

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -12,8 +12,8 @@ char my_sasl_hostname[1025];
  * specify one in the environment variable SASL_CONF_PATH
  */
 const char * const locations[] = {
-    "/etc/sasl/memcached.conf",
-    "/etc/sasl2/memcached.conf",
+    "/etc/sasl",
+    "/etc/sasl2",
     NULL
 };
 #endif
@@ -89,7 +89,10 @@ static int sasl_getconf(void *context, const char **path)
 
     if (*path == NULL) {
         for (int i = 0; locations[i] != NULL; ++i) {
-            if (access(locations[i], F_OK) == 0) {
+            char buff[30];
+            strcpy(buff, locations[i]);
+            strcat(buff, "/memcached.conf");
+            if (access(buff, F_OK) == 0) {
                 *path = locations[i];
                 break;
             }


### PR DESCRIPTION
From the function load_config of https://github.com/cyrusimap/cyrus-sasl/blob/master/lib/server.c, when we return the path "/etc/sasl2/memcached.conf" in function sasl_getconf of memcached, it will concat the path to "/etc/sasl2/memcached.conf/memcached.conf", by the following code:
```
        snprintf(config_filename, len, "%.*s%c%s.conf", (int)path_len, path_to_config,
	        HIER_DELIMITER, global_callbacks.appname);
```
so the correct configure file /etc/sasl2/memcached.conf will not be read.