### PR TITLE
Update the build documentation in BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,37 +1,24 @@
-Ideally, you want to make a static binary, otherwise the dynamic
-linker pollutes your address space with shared libs right in the
-middle.  (NOTE: actually, this shouldn't matter so much anymore, now
-that we only allocate huge, fixed-size slabs)
+To build memcached in your machine from local repo you will have to install
+autotools, automake and libevent. In a debian based system that will look
+like this
 
-Make sure your libevent has epoll (Linux) or kqueue (BSD) support.
-Using poll or select only is slow, and works for testing, but
-shouldn't be used for high-traffic memcache installations.
+sudo apt-get install autotools-dev
+sudo apt-get install automake
+sudo apt-get install libevent-dev
 
-To build libevent with epoll on Linux, you need two things. First,
-you need /usr/include/sys/epoll.h . To get it, you can install the
-userspace epoll library, epoll-lib. The link to the latest version
-is buried inside
-http://www.xmailserver.org/linux-patches/nio-improve.html ; currently
-it's http://www.xmailserver.org/linux-patches/epoll-lib-0.9.tar.gz .
-If you're having any trouble building/installing it, you can just copy
-epoll.h from that tarball to /usr/include/sys as that's the only thing
-from there that libevent really needs.
+After that you can build memcached binary using automake
 
-Secondly, you need to declare syscall numbers of epoll syscalls, so
-libevent can use them. Put these declarations somewhere
-inside <sys/epoll.h>:
+cd memcached
+./autogen.sh
+./configure
+make test
+make
 
-#define __NR_epoll_create               254
-#define __NR_epoll_ctl          255
-#define __NR_epoll_wait         256
+It should create the binary in the same folder, which you can run
 
-After this you should be able to build libevent with epoll support.
-Once you build/install libevent, you don't need <sys/epoll.h> to
-compile memcache or link it against libevent. Don't forget that for epoll
-support to actually work at runtime you need to use a kernel with epoll
-support patch applied, as explained in the README file.
+./memcached -p 11233
 
-BSD users are luckier, and will get kqueue support by default.
+You can telnet into that memcached to ensure it's up and running
 
-
-
+telnet 127.0.0.1 11233
+stats


### PR DESCRIPTION
The current instruction is 17 years old. memcached in the meantime moved to automake and has an easier way to locally build and locally test a new binary.