### PR TITLE
linux_priv.c: add termios.h include to fix powerpc(64) builds

### DIFF
--- a/linux_priv.c
+++ b/linux_priv.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <seccomp.h>
+#include <termios.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
On PowerPC (and variants), Linux has its own ioctls.h which defines `TCGETS` as `_IOR('t', 19, struct termios)`.

That means without having included `termios.h`, build will fail with usage of incomplete type `struct termios` as soon as `TCGETS` is used.

```
linux_priv.c:82:90: error: invalid application of 'sizeof' to incomplete type 'struct termios'
   82 |     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ioctl), 1, SCMP_A1(SCMP_CMP_EQ, TCGETS));
```

This allows memcached to build out of box.