### PR TITLE
Fix tabular output for the memcached-tool 'stats' command

### DIFF
--- a/scripts/memcached-tool
+++ b/scripts/memcached-tool
@@ -150,9 +150,9 @@ if ($mode eq 'stats') {
             $items{$1} = $2;
         }
     }
-    printf ("#%-17s %5s %11s\n", $addr, "Field", "Value");
+    printf ("#%-22s %5s %13s\n", $addr, "Field", "Value");
     foreach my $name (sort(keys(%items))) {
-        printf ("%24s %12s\n", $name, $items{$name});
+        printf ("%29s %14s\n", $name, $items{$name});
 
     }
     exit;


### PR DESCRIPTION
Fix up tabular output for `memcached-tool ... stats`. Here's a snipped example of the current output:
```
$ ./scripts/memcached-tool localhost stats
#localhost:11211   Field       Value
         accepting_conns           1
               auth_cmds           0
...
        hash_power_level          16
               incr_hits           0
             incr_misses           0
                libevent 2.1.11-stable
          limit_maxbytes    67108864
...
             rusage_user    0.062149
   slab_global_page_pool           0
slab_reassign_busy_deletes           0
slab_reassign_busy_items           0
slab_reassign_chunk_rescues           0
slab_reassign_evictions_nomem           0
slab_reassign_inline_reclaim           0
   slab_reassign_rescues           0
   slab_reassign_running           0
             slabs_moved           0
...
                  uptime         642
                 version      1.5.20
```

And with the fix, the output should look like this, with all those wide fields and values aligned:
```
$ ./scripts/memcached-tool localhost stats
#localhost:11211        Field         Value
              accepting_conns             1
                    auth_cmds             0
                  auth_errors             0
                        bytes             0
                   bytes_read            35
                bytes_written          7615
                   cas_badval             0
                     cas_hits             0
                   cas_misses             0
                    cmd_flush             0
                      cmd_get             0
                     cmd_meta             0
                      cmd_set             0
                    cmd_touch             0
                  conn_yields             0
        connection_structures             3
        crawler_items_checked             0
            crawler_reclaimed             0
             curr_connections             2
                   curr_items             0
                    decr_hits             0
                  decr_misses             0
                  delete_hits             0
                delete_misses             0
              direct_reclaims             0
               evicted_active             0
            evicted_unfetched             0
                    evictions             0
            expired_unfetched             0
                  get_expired             0
                  get_flushed             0
                     get_hits             0
                   get_misses             0
                   hash_bytes        524288
            hash_is_expanding             0
             hash_power_level            16
                    incr_hits             0
                  incr_misses             0
                     libevent 2.1.11-stable
               limit_maxbytes      67108864
          listen_disabled_num             0
             log_watcher_sent             0
          log_watcher_skipped             0
           log_worker_dropped             0
           log_worker_written             0
            lru_bumps_dropped             0
          lru_crawler_running             0
           lru_crawler_starts          1275
       lru_maintainer_juggles           802
            lrutail_reflocked             0
                 malloc_fails             0
              max_connections          1024
                moves_to_cold             0
                moves_to_warm             0
             moves_within_lru             0
                          pid         19013
                 pointer_size            64
                    reclaimed             0
         rejected_connections             0
                 reserved_fds            20
                rusage_system      0.036835
                  rusage_user      0.071995
        slab_global_page_pool             0
   slab_reassign_busy_deletes             0
     slab_reassign_busy_items             0
  slab_reassign_chunk_rescues             0
slab_reassign_evictions_nomem             0
 slab_reassign_inline_reclaim             0
        slab_reassign_rescues             0
        slab_reassign_running             0
                  slabs_moved             0
                      threads             4
                         time    1575486561
   time_in_listen_disabled_us             0
            total_connections             7
                  total_items             0
                   touch_hits             0
                 touch_misses             0
                       uptime           754
                      version        1.5.20
```