### PR TITLE
DTrace build fix on Mac proposal.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,7 @@ endif
 
 memcached_debug_CFLAGS += -DMEMCACHED_DEBUG
 
+# build fails on Darwin with const signature replacements.
 if DARWIN
 memcached_dtrace.h: memcached_dtrace.d
 	${DTRACE} -h -s memcached_dtrace.d

--- a/Makefile.am
+++ b/Makefile.am
@@ -112,11 +112,16 @@ endif
 
 memcached_debug_CFLAGS += -DMEMCACHED_DEBUG
 
+if DARWIN
 memcached_dtrace.h: memcached_dtrace.d
 	${DTRACE} -h -s memcached_dtrace.d
-	sed -e 's,void \*,const void \*,g' memcached_dtrace.h | \
-            sed -e 's,char \*,const char \*,g' | tr '\t' ' ' > mmc_dtrace.tmp
+else
+memcached_dtrace.h: memcached_dtrace.d
+	${DTRACE} -h -s memcached_dtrace.d
+	sed -e 's,void \*,const void \*,' memcached_dtrace.h | \
+	sed -e 's,char \*,const char \*,g' | tr '\t' ' ' > mmc_dtrace.tmp
 	mv mmc_dtrace.tmp memcached_dtrace.h
+endif
 
 memcached_dtrace.o: $(memcached_OBJECTS)
 	$(DTRACE) $(DTRACEFLAGS) -G -o memcached_dtrace.o -s ${srcdir}/memcached_dtrace.d $(memcached_OBJECTS)

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,16 @@ AM_CONFIG_HEADER([config.h])
 
 AC_PROG_CC
 
+is_darwin=no
+
+case "${host_os}" in
+	darwin*)
+		is_darwin=yes
+		;;
+esac
+
+AM_CONDITIONAL([DARWIN], [test "$is_darwin" = "yes"])
+
 dnl **********************************************************************
 dnl DETECT_ICC ([ACTION-IF-YES], [ACTION-IF-NO])
 dnl
@@ -193,6 +203,8 @@ if test "x$enable_dtrace" = "xyes"; then
     then
         dtrace_instrument_obj=yes
         rm conftest.h
+        # on Mac probe id are generated with $
+        CFLAGS="$CFLAGS -Wno-dollar-in-identifier-extension"
     fi
 
     if test "`which tr`" = "/usr/ucb/tr"; then

--- a/configure.ac
+++ b/configure.ac
@@ -12,9 +12,9 @@ AC_PROG_CC
 is_darwin=no
 
 case "${host_os}" in
-	darwin*)
-		is_darwin=yes
-		;;
+   darwin*)
+   is_darwin=yes
+   ;;
 esac
 
 AM_CONDITIONAL([DARWIN], [test "$is_darwin" = "yes"])
@@ -204,7 +204,9 @@ if test "x$enable_dtrace" = "xyes"; then
         dtrace_instrument_obj=yes
         rm conftest.h
         # on Mac probe id are generated with $
-        CFLAGS="$CFLAGS -Wno-dollar-in-identifier-extension"
+        if test "$is_darwin" = "yes"; then
+          CFLAGS="$CFLAGS -Wno-dollar-in-identifier-extension"
+        fi
     fi
 
     if test "`which tr`" = "/usr/ucb/tr"; then


### PR DESCRIPTION
The header generated comes with $ IDs thus breaking the build.
The probes are set with const address arguments already
which just add the qualifier again.