### PR TITLE
Build and test on amd64 and arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
 dist: xenial
 language: cpp
+arch:
+    - amd64
+    - arm64
 
 compiler:
     - gcc


### PR DESCRIPTION
Hello,

With this Pull Request I'd like to request to add arm64 architecture to the build matrix at TravisCI.

ARM64 is used more and more for servers too and it would be good if Memcached is tested regularly.
I've ran the build and tests both on one of our arm64 machines and at [TravisCI](https://travis-ci.org/martin-g/memcached) and at the moment both are fine!

`amd64` is the default arch at TravisCI so it is preserved!