### PR TITLE
hash: fix build failure against gcc-10

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4,6 +4,8 @@
 #include "jenkins_hash.h"
 #include "murmur3_hash.h"
 
+hash_func hash;
+
 int hash_init(enum hashfunc_type type) {
     switch(type) {
         case JENKINS_HASH:

--- a/hash.h
+++ b/hash.h
@@ -2,7 +2,7 @@
 #define    HASH_H
 
 typedef uint32_t (*hash_func)(const void *key, size_t length);
-hash_func hash;
+extern hash_func hash;
 
 enum hashfunc_type {
     JENKINS_HASH=0, MURMUR3_HASH


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
gcc  -g -O2 -pthread -pthread -Wall -Werror -pedantic -Wmissing-prototypes \
  -Wmissing-declarations -Wredundant-decls   -o memcached ... -levent
ld: memcached-hash.o:memcached/hash.h:5:
  multiple definition of `hash'; memcached-memcached.o:memcached/hash.h:5: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Brian Evans
Bug: https://bugs.gentoo.org/706196