### PR TITLE
NAPI_ID based thread selection as optional feature

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -465,6 +465,8 @@ struct settings {
     rel_time_t ssl_last_cert_refresh_time; /* time of the last server certificate refresh */
     unsigned int ssl_wbuf_size; /* size of the write buffer used by ssl_sendmsg method */
 #endif
+    int num_napi_ids; /* Max number of NAPI_IDs */
+    bool napi_id_based_thread_selection;
 };
 
 extern struct stats stats;
@@ -604,6 +606,7 @@ typedef struct {
     char   *ssl_wbuf;
 #endif
 
+    int napi_id;                /* align NAPI_ID to thread */
 } LIBEVENT_THREAD;
 typedef struct conn conn;
 #ifdef EXTSTORE


### PR DESCRIPTION
This patch provides another thread selection option in the
"dispatch_conn_new" code path. The default mechanism for thread selection
is round-robin. This patch uses NAPI_ID based thread selection that
creates an association between socket(s) traffic that arrives on a given
NIC (hardware) queue and the memcached thread that consumes this traffic.
This mapping between a memcached thread and a HW NIC queue streamlines
the flow of data from the NIC to the application. In addition, an optimal
path with reduced context switches is possible, if epoll based busy
polling (sysctl -w net.core.busy_poll = <non-zero value>) is also enabled

This feature is enabled by specifying the command line parameter
"--napi_ids=<num>", where <num> is the number of available/assigned
hardware queues.  The patch also checks that the value of the <num>
parameter matches the <num> parameter specified for the "--threads=<num>"
option to ensure this mapping. If the option is unspecified, or the
conditions unmet, the code defaults to round robin thread selection.

v2: rebase on tip of tree (1.5.22).

Signed-off-by: Kiran Patil <kiran.patil@intel.com>