### PR TITLE
Optional SSL server session cache

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1634,6 +1634,9 @@ following additional statistics are available via the "stats" command.
 | ssl_handshake_errors           | 64u      | Number of times the server has |
 |                                |          | encountered an OpenSSL error   |
 |                                |          | during handshake (SSL_accept). |
+| ssl_new_sessions               | 64u      | When SSL session caching is    |
+|                                |          | enabled, the number of newly   |
+|                                |          | created server-side sessions.  |
 | time_since_server_cert_refresh | 32u      | Number of seconds that have    |
 |                                |          | elapsed since the last time    |
 |                                |          | certs were reloaded from disk. |

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1637,6 +1637,8 @@ following additional statistics are available via the "stats" command.
 | ssl_new_sessions               | 64u      | When SSL session caching is    |
 |                                |          | enabled, the number of newly   |
 |                                |          | created server-side sessions.  |
+|                                |          | Available only when compiled   |
+|                                |          | with OpenSSL 1.1.1 or newer.   |
 | time_since_server_cert_refresh | 32u      | Number of seconds that have    |
 |                                |          | elapsed since the last time    |
 |                                |          | certs were reloaded from disk. |

--- a/doc/tls.txt
+++ b/doc/tls.txt
@@ -18,7 +18,7 @@ will use new certificates without a need of re-starting the server process.
 # Multiple ports with and without TLS : by default all TCP ports are secured. Optionally we can setup
 the server to secure a specific TCP port.
 
-Note that initial implementation does not support session resumption or renegotiation.
+Note that initial implementation does not support session renegotiation.
 
 Design
 ------

--- a/memcached.c
+++ b/memcached.c
@@ -260,6 +260,7 @@ static void settings_init(void) {
     settings.udpport = 0;
 #ifdef TLS
     settings.ssl_enabled = false;
+    settings.ssl_session_cache = false;
     settings.ssl_ctx = NULL;
     settings.ssl_chain_cert = NULL;
     settings.ssl_key = NULL;
@@ -269,7 +270,6 @@ static void settings_init(void) {
     settings.ssl_ca_cert = NULL;
     settings.ssl_last_cert_refresh_time = current_time;
     settings.ssl_wbuf_size = 16 * 1024; // default is 16KB (SSL max frame size is 17KB)
-    settings.ssl_session_cache = false;
 #endif
     /* By default this string should be NULL for getaddrinfo() */
     settings.inter = NULL;

--- a/memcached.c
+++ b/memcached.c
@@ -3233,6 +3233,9 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
 #endif
 #ifdef TLS
     if (settings.ssl_enabled) {
+        if (settings.ssl_session_cache) {
+            APPEND_STAT("ssl_new_sessions", "%llu", (unsigned long long)stats.ssl_new_sessions);
+        }
         APPEND_STAT("ssl_handshake_errors", "%llu", (unsigned long long)stats.ssl_handshake_errors);
         APPEND_STAT("time_since_server_cert_refresh", "%u", now - settings.ssl_last_cert_refresh_time);
     }

--- a/memcached.c
+++ b/memcached.c
@@ -9873,7 +9873,7 @@ int main (int argc, char **argv) {
      * SSL parameter validation
      */
     if (settings.ssl_session_cache && !settings.ssl_enabled) {
-        fprintf(stderr, "-z (ssl_session_cache) requires -Z (ssl_enabled)\n");
+        fprintf(stderr, "ERROR: -z (ssl_session_cache) requires -Z (ssl_enabled).\n");
         exit(EX_USAGE);
     }
 

--- a/memcached.c
+++ b/memcached.c
@@ -260,7 +260,6 @@ static void settings_init(void) {
     settings.udpport = 0;
 #ifdef TLS
     settings.ssl_enabled = false;
-    settings.ssl_session_cache = false;
     settings.ssl_ctx = NULL;
     settings.ssl_chain_cert = NULL;
     settings.ssl_key = NULL;
@@ -270,6 +269,7 @@ static void settings_init(void) {
     settings.ssl_ca_cert = NULL;
     settings.ssl_last_cert_refresh_time = current_time;
     settings.ssl_wbuf_size = 16 * 1024; // default is 16KB (SSL max frame size is 17KB)
+    settings.ssl_session_cache = false;
 #endif
     /* By default this string should be NULL for getaddrinfo() */
     settings.inter = NULL;
@@ -3313,7 +3313,6 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
 #endif
 #ifdef TLS
     APPEND_STAT("ssl_enabled", "%s", settings.ssl_enabled ? "yes" : "no");
-    APPEND_STAT("ssl_session_cache", "%s", settings.ssl_session_cache ? "yes" : "no");
     APPEND_STAT("ssl_chain_cert", "%s", settings.ssl_chain_cert);
     APPEND_STAT("ssl_key", "%s", settings.ssl_key);
     APPEND_STAT("ssl_verify_mode", "%d", settings.ssl_verify_mode);
@@ -3321,6 +3320,7 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("ssl_ciphers", "%s", settings.ssl_ciphers ? settings.ssl_ciphers : "NULL");
     APPEND_STAT("ssl_ca_cert", "%s", settings.ssl_ca_cert ? settings.ssl_ca_cert : "NULL");
     APPEND_STAT("ssl_wbuf_size", "%u", settings.ssl_wbuf_size);
+    APPEND_STAT("ssl_session_cache", "%s", settings.ssl_session_cache ? "yes" : "no");
 #endif
 }
 
@@ -8022,8 +8022,6 @@ static void usage(void) {
            "                          enables restartable cache (stop with SIGUSR1)\n");
 #ifdef TLS
     printf("-Z, --enable-ssl          enable TLS/SSL\n");
-    printf("-z, --enable-ssl-session-cache enable SSL server session cache to support session\n"
-           "                          resumption; requires SSL to be enabled\n");
 #endif
     printf("-o, --extended            comma separated list of extended options\n"
            "                          most options have a 'no_' prefix to disable\n"
@@ -8126,6 +8124,8 @@ static void usage(void) {
            "   - ssl_ca_cert:         PEM format file of acceptable client CA's\n"
            "   - ssl_wbuf_size:       size in kilobytes of per-connection SSL output buffer\n"
            "                          (default: %u)\n", settings.ssl_wbuf_size / (1 << 10));
+    printf("   - ssl_session_cache:   enable server-side SSL session cache, to support session\n"
+           "                          resumption\n");
     verify_default("ssl_keyformat", settings.ssl_keyformat == SSL_FILETYPE_PEM);
     verify_default("ssl_verify_mode", settings.ssl_verify_mode == SSL_VERIFY_NONE);
 #endif
@@ -8781,6 +8781,7 @@ int main (int argc, char **argv) {
         SSL_CIPHERS,
         SSL_CA_CERT,
         SSL_WBUF_SIZE,
+        SSL_SESSION_CACHE,
 #endif
 #ifdef MEMCACHED_DEBUG
         RELAXED_PRIVILEGES,
@@ -8849,6 +8850,7 @@ int main (int argc, char **argv) {
         [SSL_CIPHERS] = "ssl_ciphers",
         [SSL_CA_CERT] = "ssl_ca_cert",
         [SSL_WBUF_SIZE] = "ssl_wbuf_size",
+        [SSL_SESSION_CACHE] = "ssl_session_cache",
 #endif
 #ifdef MEMCACHED_DEBUG
         [RELAXED_PRIVILEGES] = "relaxed_privileges",
@@ -8917,7 +8919,6 @@ int main (int argc, char **argv) {
           "a:"  /* access mask for unix socket */
           "A"   /* enable admin shutdown command */
           "Z"   /* enable SSL */
-          "z"   /* enable SSL server session cache */
           "p:"  /* TCP port number to listen on */
           "s:"  /* unix socket path to listen on */
           "U:"  /* UDP port number to listen on */
@@ -8957,7 +8958,6 @@ int main (int argc, char **argv) {
         {"unix-mask", required_argument, 0, 'a'},
         {"enable-shutdown", no_argument, 0, 'A'},
         {"enable-ssl", no_argument, 0, 'Z'},
-        {"enable-ssl-session-cache", no_argument, 0, 'z'},
         {"port", required_argument, 0, 'p'},
         {"unix-socket", required_argument, 0, 's'},
         {"udp-port", required_argument, 0, 'U'},
@@ -9003,20 +9003,15 @@ int main (int argc, char **argv) {
             /* enables "shutdown" command */
             settings.shutdown_command = true;
             break;
-#ifdef TLS
         case 'Z':
             /* enable secure communication*/
+#ifdef TLS
             settings.ssl_enabled = true;
-            break;
-        case 'z':
-            settings.ssl_session_cache = true;
-            break;
 #else
-        case 'Z':
-        case 'z':
             fprintf(stderr, "This server is not built with TLS support.\n");
             exit(EX_USAGE);
 #endif
+            break;
         case 'a':
             /* access for unix domain socket, as octal mask (like chmod)*/
             settings.access= strtol(optarg,NULL,8);
@@ -9527,6 +9522,9 @@ int main (int argc, char **argv) {
                 }
                 settings.ssl_wbuf_size *= 1024; /* kilobytes */
                 break;
+            case SSL_SESSION_CACHE:
+                settings.ssl_session_cache = true;
+                break;
 #endif
 #ifdef EXTSTORE
             case EXT_PAGE_SIZE:
@@ -9869,14 +9867,6 @@ int main (int argc, char **argv) {
 
 
 #ifdef TLS
-    /*
-     * SSL parameter validation
-     */
-    if (settings.ssl_session_cache && !settings.ssl_enabled) {
-        fprintf(stderr, "ERROR: -z (ssl_session_cache) requires -Z (ssl_enabled).\n");
-        exit(EX_USAGE);
-    }
-
     /*
      * Setup SSL if enabled
      */

--- a/memcached.h
+++ b/memcached.h
@@ -464,6 +464,7 @@ struct settings {
 #endif
 #ifdef TLS
     bool ssl_enabled; /* indicates whether SSL is enabled */
+    bool ssl_session_cache; /* enable SSL server session caching */
     SSL_CTX *ssl_ctx; /* holds the SSL server context which has the server certificate */
     char *ssl_chain_cert; /* path to the server SSL chain certificate */
     char *ssl_key; /* path to the server key */
@@ -473,7 +474,6 @@ struct settings {
     char *ssl_ca_cert; /* certificate with CAs. */
     rel_time_t ssl_last_cert_refresh_time; /* time of the last server certificate refresh */
     unsigned int ssl_wbuf_size; /* size of the write buffer used by ssl_sendmsg method */
-    bool ssl_session_cache; /* enable SSL server session caching */
 #endif
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -464,7 +464,6 @@ struct settings {
 #endif
 #ifdef TLS
     bool ssl_enabled; /* indicates whether SSL is enabled */
-    bool ssl_session_cache; /* enable SSL server session caching */
     SSL_CTX *ssl_ctx; /* holds the SSL server context which has the server certificate */
     char *ssl_chain_cert; /* path to the server SSL chain certificate */
     char *ssl_key; /* path to the server key */
@@ -474,6 +473,7 @@ struct settings {
     char *ssl_ca_cert; /* certificate with CAs. */
     rel_time_t ssl_last_cert_refresh_time; /* time of the last server certificate refresh */
     unsigned int ssl_wbuf_size; /* size of the write buffer used by ssl_sendmsg method */
+    bool ssl_session_cache; /* enable SSL server session caching */
 #endif
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -473,6 +473,7 @@ struct settings {
     char *ssl_ca_cert; /* certificate with CAs. */
     rel_time_t ssl_last_cert_refresh_time; /* time of the last server certificate refresh */
     unsigned int ssl_wbuf_size; /* size of the write buffer used by ssl_sendmsg method */
+    bool ssl_session_cache; /* enable SSL server session caching */
 #endif
 };
 

--- a/memcached.h
+++ b/memcached.h
@@ -358,6 +358,7 @@ struct stats {
 #endif
 #ifdef TLS
     uint64_t      ssl_handshake_errors; /* TLS failures at accept/handshake time */
+    uint64_t      ssl_new_sessions; /* successfully negotiated new (non-reused) TLS sessions */
 #endif
     struct timeval maxconns_entered;  /* last time maxconns entered */
 };

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -386,13 +386,13 @@ sub new_sock {
     } elsif (MemcachedTest::enabled_tls_testing()) {
         my $ssl_session_cache = shift;
         my $ssl_version = shift;
-        return IO::Socket::SSL->new(PeerAddr => "$self->{host}:$self->{port}",
-                                    SSL_verify_mode => eval qq{ IO::Socket::SSL::SSL_VERIFY_NONE },
-                                    SSL_session_cache => $ssl_session_cache,
-                                    SSL_version => "$ssl_version",
-                                    SSL_cert_file => "$client_crt",
-                                    SSL_key_file => "$client_key");
-
+        return eval qq{ IO::Socket::SSL->new(PeerAddr => "$self->{host}:$self->{port}",
+                                    SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,
+                                    SSL_session_cache => \$ssl_session_cache,
+                                    SSL_version => '$ssl_version',
+                                    SSL_cert_file => '$client_crt',
+                                    SSL_key_file => '$client_key');
+                                    };
     } else {
         return IO::Socket::INET->new(PeerAddr => "$self->{host}:$self->{port}");
     }

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -384,11 +384,15 @@ sub new_sock {
     if ($self->{domainsocket}) {
         return IO::Socket::UNIX->new(Peer => $self->{domainsocket});
     } elsif (MemcachedTest::enabled_tls_testing()) {
-        return eval qq{ IO::Socket::SSL->new(PeerAddr => "$self->{host}:$self->{port}",
-                                    SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,
-                                    SSL_cert_file => '$client_crt',
-                                    SSL_key_file => '$client_key');
-                                    };
+        my $ssl_session_cache = shift;
+        my $ssl_version = shift;
+        return IO::Socket::SSL->new(PeerAddr => "$self->{host}:$self->{port}",
+                                    SSL_verify_mode => eval qq{ IO::Socket::SSL::SSL_VERIFY_NONE },
+                                    SSL_session_cache => $ssl_session_cache,
+                                    SSL_version => "$ssl_version",
+                                    SSL_cert_file => "$client_crt",
+                                    SSL_key_file => "$client_key");
+
     } else {
         return IO::Socket::INET->new(PeerAddr => "$self->{host}:$self->{port}");
     }

--- a/t/ssl_session_resumption.t
+++ b/t/ssl_session_resumption.t
@@ -39,7 +39,10 @@ $server = new_memcached("-o ssl_session_cache");
 $sock = $server->new_sock($session_cache, 'TLSv1_2');
 $stats = mem_stats($sock);
 cmp_ok($stats->{total_connections}, '>', 0, "initial connection is established");
-cmp_ok($stats->{ssl_new_sessions}, '>', 0, "successful new SSL session");
+SKIP: {
+    skip "sessions counter accuracy requires OpenSSL 1.1.1 or newer", 1;
+    cmp_ok($stats->{ssl_new_sessions}, '>', 0, "successful new SSL session");
+}
 my $enabled_initial_ssl_sessions = $stats->{ssl_new_sessions};
 my $enabled_initial_total_conns = $stats->{total_connections};
 

--- a/t/ssl_session_resumption.t
+++ b/t/ssl_session_resumption.t
@@ -15,7 +15,7 @@ my $server;
 my $sock;
 my $stats;
 
-my $session_cache = IO::Socket::SSL::Session_Cache->new(1);
+my $session_cache = eval qq{ IO::Socket::SSL::Session_Cache->new(1); };
 
 ### Disabled SSL session cache
 

--- a/t/ssl_session_resumption.t
+++ b/t/ssl_session_resumption.t
@@ -29,10 +29,7 @@ $sock = $server->new_sock($session_cache, 'TLSv1_2');
 $stats = mem_stats($sock);
 cmp_ok($stats->{total_connections}, '>', $disabled_initial_total_conns,
     "client-side session cache is noop in establishing a new connection");
-SKIP: {
-    skip "get_session_reused is only available in newer versions of IO::Socket::SSL", 1;
-    is($sock->get_session_reused(), 0, "client-side session cache is unused");
-}
+is($sock->get_session_reused(), 0, "client-side session cache is unused");
 
 ### Enabled SSL session cache
 
@@ -53,9 +50,7 @@ cmp_ok($stats->{total_connections}, '>', $enabled_initial_total_conns,
     "new connection is established");
 is($stats->{ssl_new_sessions}, $enabled_initial_ssl_sessions,
     "no new SSL sessions are created on the server");
-SKIP: {
-    skip "get_session_reused is only available in newer versions of IO::Socket::SSL", 1;
-    is($sock->get_session_reused(), 1, "client-persisted session is reused");
-}
+is($sock->get_session_reused(), 1,
+    "client-persisted session is reused");
 
 done_testing();

--- a/t/ssl_session_resumption.t
+++ b/t/ssl_session_resumption.t
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+if (!enabled_tls_testing()) {
+    plan skip_all => 'SSL testing is not enabled';
+    exit 0;
+}
+
+my $server;
+my $sock;
+my $stats;
+
+my $session_cache = IO::Socket::SSL::Session_Cache->new(1);
+
+### Disabled SSL session cache
+
+$server = new_memcached();
+$stats = mem_stats($server->sock);
+is($stats->{ssl_new_sessions}, undef,
+    "new SSL sessions not recorded when session cache is disabled");
+my $disabled_initial_total_conns = $stats->{total_connections};
+
+$sock = $server->new_sock($session_cache, 'TLSv1_2');
+$stats = mem_stats($sock);
+cmp_ok($stats->{total_connections}, '>', $disabled_initial_total_conns,
+    "client-side session cache is noop in establishing a new connection");
+is($sock->get_session_reused(), 0, "client-side session cache is unused");
+
+### Enabled SSL session cache
+
+$server = new_memcached("-o ssl_session_cache");
+# Support for session caching in IO::Socket::SSL for TLS v1.3 is incomplete.
+# Here, we will deliberately force TLS v1.2 to test session caching.
+$sock = $server->new_sock($session_cache, 'TLSv1_2');
+$stats = mem_stats($sock);
+cmp_ok($stats->{total_connections}, '>', 0, "initial connection is established");
+cmp_ok($stats->{ssl_new_sessions}, '>', 0, "successful new SSL session");
+my $enabled_initial_ssl_sessions = $stats->{ssl_new_sessions};
+my $enabled_initial_total_conns = $stats->{total_connections};
+
+# Create a new client with the same session cache
+$sock = $server->new_sock($session_cache, 'TLSv1_2');
+$stats = mem_stats($sock);
+cmp_ok($stats->{total_connections}, '>', $enabled_initial_total_conns,
+    "new connection is established");
+is($stats->{ssl_new_sessions}, $enabled_initial_ssl_sessions,
+    "no new SSL sessions are created on the server");
+is($sock->get_session_reused(), 1,
+    "client-persisted session is reused");
+
+done_testing();

--- a/t/ssl_session_resumption.t
+++ b/t/ssl_session_resumption.t
@@ -29,7 +29,10 @@ $sock = $server->new_sock($session_cache, 'TLSv1_2');
 $stats = mem_stats($sock);
 cmp_ok($stats->{total_connections}, '>', $disabled_initial_total_conns,
     "client-side session cache is noop in establishing a new connection");
-is($sock->get_session_reused(), 0, "client-side session cache is unused");
+SKIP: {
+    skip "get_session_reused is only available in newer versions of IO::Socket::SSL", 1;
+    is($sock->get_session_reused(), 0, "client-side session cache is unused");
+}
 
 ### Enabled SSL session cache
 
@@ -50,7 +53,9 @@ cmp_ok($stats->{total_connections}, '>', $enabled_initial_total_conns,
     "new connection is established");
 is($stats->{ssl_new_sessions}, $enabled_initial_ssl_sessions,
     "no new SSL sessions are created on the server");
-is($sock->get_session_reused(), 1,
-    "client-persisted session is reused");
+SKIP: {
+    skip "get_session_reused is only available in newer versions of IO::Socket::SSL", 1;
+    is($sock->get_session_reused(), 1, "client-persisted session is reused");
+}
 
 done_testing();

--- a/t/ssl_settings.t
+++ b/t/ssl_settings.t
@@ -20,6 +20,7 @@ my $cert = getcwd ."/t/". MemcachedTest::SRV_CRT;
 my $key = getcwd ."/t/". MemcachedTest::SRV_KEY;
 
 is($settings->{'ssl_enabled'}, 'yes');
+is($settings->{'ssl_session_cache'}, 'no');
 is($settings->{'ssl_chain_cert'}, $cert);
 is($settings->{'ssl_key'}, $key);
 is($settings->{'ssl_verify_mode'}, 0);

--- a/tls.c
+++ b/tls.c
@@ -143,7 +143,7 @@ int ssl_init(void) {
     settings.ssl_ctx = SSL_CTX_new(TLS_server_method());
     // Clients should use at least TLSv1.2
     int flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 |
-                SSL_OP_NO_TLSv1 |SSL_OP_NO_TLSv1_1;
+                SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
     SSL_CTX_set_options(settings.ssl_ctx, flags);
 
     // The server certificate, private key and validations.
@@ -173,6 +173,8 @@ int ssl_init(void) {
         SSL_CTX_set_session_id_context(settings.ssl_ctx,
                                        (const unsigned char *) SESSION_ID_CONTEXT,
                                        strlen(SESSION_ID_CONTEXT));
+    } else {
+        SSL_CTX_set_session_cache_mode(settings.ssl_ctx, SSL_SESS_CACHE_OFF);
     }
 
     return 0;

--- a/tls.c
+++ b/tls.c
@@ -167,6 +167,11 @@ int ssl_init(void) {
         exit(EX_USAGE);
     }
 
+    // Optional session caching; default disabled.
+    if (settings.ssl_session_cache) {
+        SSL_CTX_set_session_cache_mode(settings.ssl_ctx, SSL_SESS_CACHE_SERVER);
+    }
+
     return 0;
 }
 

--- a/tls.c
+++ b/tls.c
@@ -170,6 +170,9 @@ int ssl_init(void) {
     // Optional session caching; default disabled.
     if (settings.ssl_session_cache) {
         SSL_CTX_set_session_cache_mode(settings.ssl_ctx, SSL_SESS_CACHE_SERVER);
+        SSL_CTX_set_session_id_context(settings.ssl_ctx,
+                                       (const unsigned char *) SESSION_ID_CONTEXT,
+                                       strlen(SESSION_ID_CONTEXT));
     }
 
     return 0;

--- a/tls.h
+++ b/tls.h
@@ -14,5 +14,6 @@ ssize_t ssl_write(conn *c, void *buf, size_t count);
 int ssl_init(void);
 bool refresh_certs(char **errmsg);
 void ssl_callback(const SSL *s, int where, int ret);
+int ssl_new_session_callback(SSL *s, SSL_SESSION *sess);
 
 #endif

--- a/tls.h
+++ b/tls.h
@@ -1,6 +1,10 @@
 #ifndef TLS_H
 #define TLS_H
 
+/* constant session ID context for application-level SSL session scoping.
+ * used in server-side SSL session caching, when enabled. */
+#define SESSION_ID_CONTEXT "memcached"
+
 void SSL_LOCK(void);
 void SSL_UNLOCK(void);
 ssize_t ssl_read(conn *c, void *buf, size_t count);


### PR DESCRIPTION
Optionally enable server-only session caching with `SSL_CTX_set_session_cache_mode` if the binary is invoked with extended option `ssl_session_cache`. Useful for clients that support TLS session resumption (immediate use case is [mcrouter](https://github.com/facebook/mcrouter/blob/1c4b4838d7758d396fab7fa541c8f908d0b008ee/mcrouter/mcrouter_options_list.h#L379)).

This change also introduces a change in behavior to default the session cache to off. It also introduces a new gauge to keep track of new successful handshakes, `ssl_new_sessions`, enabled only when session caching is enabled.