### PR TITLE
timedrun proper signal handler initialization.

### DIFF
--- a/timedrun.c
+++ b/timedrun.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include <signal.h>
 #include <sys/wait.h>
 #include <sysexits.h>
@@ -21,6 +22,7 @@ static int wait_for_process(pid_t pid)
     int i = 0;
     struct sigaction sig_handler;
 
+    memset(&sig_handler, 0, sizeof(struct sigaction));
     sig_handler.sa_handler = signal_handler;
     sig_handler.sa_flags = 0;
 
@@ -89,10 +91,16 @@ static int spawn_and_wait(char **argv)
     return rv;
 }
 
+static void usage(void) {
+    fprintf(stderr, "./timedrun <naptime in sec> args...\n");
+    exit(-1);
+}
+
 int main(int argc, char **argv)
 {
     int naptime = 0;
-    assert(argc > 2);
+    if (argc < 3)
+        usage();
 
     naptime = atoi(argv[1]);
     assert(naptime > 0 && naptime < 1800);


### PR DESCRIPTION
being 'nicer' when forgetting arguments.