### PR TITLE
Meta protocol updates

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -655,9 +655,9 @@ may decide to retry later or take some other action.
 Meta Set
 --------
 
-The meta set command a generic command for storing data to memcached. Based on
-the flags supplied, it can replace the commands: "set", "cas". as well as
-adding new options.
+The meta set command a generic command for storing data to memcached. Based
+on the flags supplied, it can replace all storage commands (see token M) as
+well as adds new options.
 
 ms <key> <flags>*\r\n
 
@@ -702,6 +702,7 @@ The flags used by the 'ms' command are:
 - q: use noreply semantics for return codes
 - S(token): size of <data block> to store
 - T(token): Time-To-Live for item, see "Expiration" above.
+- M(token): mode switch to change behavior to add, replace, append, prepend
 
 The flags are now repeated with detailed information where useful:
 
@@ -727,11 +728,22 @@ See description under 'Meta Get'
 - q: use noreply semantics for return codes
 
 Noreply is a method of reducing the amount of data sent back by memcached to
-the client for normal responses. In the case of metaset, a response that would
-start with "OK" will not be sent. Any other code, such as "EX"
+the client for normal responses. In the case of metaset, a response that
+would start with "OK" will not be sent. Any other code, such as "EX"
 (EXISTS) will still be returned.
 
 Errors are always returned.
+
+- M(token): mode switch. Takes a single character for the mode.
+
+E: "add" command. LRU bump and return NS if item exists. Else
+add.
+A: "append" command. If item exists, append the new value to its data.
+P: "prepend" command. If item exists, prepend the new value to its data.
+S: "set" command. The default mode, added for completeness.
+
+The "cas" command is supplanted by specifying the cas value with the 'C' flag.
+Append and Prepend modes will also respect a supplied cas value.
 
 Meta Delete
 -----------

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -740,6 +740,7 @@ E: "add" command. LRU bump and return NS if item exists. Else
 add.
 A: "append" command. If item exists, append the new value to its data.
 P: "prepend" command. If item exists, prepend the new value to its data.
+R: "replace" command. Set only if item already exists.
 S: "set" command. The default mode, added for completeness.
 
 The "cas" command is supplanted by specifying the cas value with the 'C' flag.
@@ -848,9 +849,10 @@ The flags used by the 'ma' command are:
 - C(token): compare CAS value (see mset)
 - N(token): auto create item on miss with supplied TTL
 - J(token): initial value to use if auto created after miss (default 0)
-- D(token): delta to apply (unsigned int, default 1)
+- D(token): delta to apply (decimal unsigned 64-bit number, default 1)
 - T(token): update TTL on success
 - M(token): mode switch to change between incr and decr modes.
+- q: use noreply semantics for return codes (see details under mset)
 - t: return current TTL
 - c: return current CAS
 - v: return new value
@@ -870,7 +872,7 @@ seeded using the J flag.
 
 - J(token): initial value
 
-An unsigned integer which will be seeded as the value on a miss. Must be
+An unsigned 64-bit integer which will be seeded as the value on a miss. Must be
 combined with an N flag.
 
 - D(token): delta to apply

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -807,6 +807,88 @@ When marking an item as stale with 'I', the 'T' flag can be used to update the
 TTL as well; limiting the amount of time an item will live while stale and
 waiting to be recached.
 
+Meta Arithmetic
+---------------
+
+The meta arithmetic command allows for basic operations against numerical
+values. This replaces the "incr" and "decr" commands. Values are unsigned
+64bit integers. Decrementing will reach 0 rather than underflow. Incrementing
+can overflow.
+
+ma <key> <flags>*\r\n
+
+- <key> means one key string.
+
+- <flags> are a set of single character codes ended with a space or newline.
+  flags may have strings after the initial character.
+
+The response is in the format:
+
+<CD> <flags> <tokens>*\r\n
+
+Where CD is one of:
+
+- "OK" to indicate success
+
+- "NF" (NOT_FOUND), to indicate that the item with this key was not found.
+
+- "NS" (NOT_STORED), to indicate that the item was not created as requested
+  after a miss.
+
+- "EX" (EXISTS), to indicate that the supplied CAS token does not match the
+  stored item.
+
+If the 'v' flag is supplied, the response is formatted as:
+
+VA <size> <flags>*\r\n
+<number>\r\n
+
+The flags used by the 'ma' command are:
+
+- C(token): compare CAS value (see mset)
+- N(token): auto create item on miss with supplied TTL
+- J(token): initial value to use if auto created after miss (default 0)
+- D(token): delta to apply (unsigned int, default 1)
+- T(token): update TTL on success
+- M(token): mode switch to change between incr and decr modes.
+- t: return current TTL
+- c: return current CAS
+- v: return new value
+
+The flags are now repeated with detailed information where useful:
+
+- C(token): compare CAS value
+
+Can be used to only incr/decr if a supplied CAS value matches. A new CAS value
+is generated after a delta is applied. Add the 'c' flag to get the new CAS
+value after success.
+
+- N(token): auto create item on miss with supplied TTL
+
+Similar to mget, on a miss automatically create the item. A value can be
+seeded using the J flag.
+
+- J(token): initial value
+
+An unsigned integer which will be seeded as the value on a miss. Must be
+combined with an N flag.
+
+- D(token): delta to apply
+
+An unsigned integer to either add or subtract from the currently stored
+number.
+
+- T(token): update TTL
+
+On success, sets the remaining TTL to the supplied value.
+
+-M(token): mode switch. Takes a single character for the mode.
+
+I: Increment mode (default)
++: Alias for increment
+D: Decrement mode
+-: Alias for decrement
+
 Meta No-Op
 ----------
 

--- a/memcached.c
+++ b/memcached.c
@@ -1116,9 +1116,6 @@ static void out_errstring(conn *c, const char *str) {
     out_string(c, str);
 }
 
-#define ALLOW_NOREPLY true
-#define DISABLE_NOREPLY false
-
 /*
  * Outputs a protocol-specific "out of memory" error. For ASCII clients,
  * this is equivalent to out_string().

--- a/memcached.c
+++ b/memcached.c
@@ -4676,7 +4676,7 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
     }
 
     // We attempt to process as much as we can in hopes of getting a valid and
-    // adjusted vlen, or else the data swallow after error will be for 0b.
+    // adjusted vlen, or else the data swallowed after error will be for 0b.
     if (has_error)
         goto error;
 

--- a/memcached.h
+++ b/memcached.h
@@ -778,7 +778,8 @@ void do_accept_new_conns(const bool do_accept);
 enum delta_result_type do_add_delta(conn *c, const char *key,
                                     const size_t nkey, const bool incr,
                                     const int64_t delta, char *buf,
-                                    uint64_t *cas, const uint32_t hv);
+                                    uint64_t *cas, const uint32_t hv,
+                                    item **it_ret);
 enum store_item_type do_store_item(item *item, int comm, conn* c, const uint32_t hv);
 conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size,
     enum network_transport transport, struct event_base *base, void *ssl);

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -364,6 +364,11 @@ my $sock = $server->sock;
     like(scalar <$sock>, qr/^VA 2/, "get response");
     like(scalar <$sock>, qr/^bo/, "get value");
     like(scalar <$sock>, qr/^MN/, "end token");
+
+    # "quiet" won't do anything with autoviv, since the only case (miss)
+    # should return data anyway.
+    print $sock "mg quietautov s N30 t q\r\n";
+    like(scalar <$sock>, qr/^OK s0/, "quiet doesn't override autovivication");
 }
 
 {

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -532,7 +532,7 @@ my $sock = $server->sock;
 {
     diag "flag and token count errors";
     print $sock "mg foo m o o o o o o o o o\r\n";
-    like(scalar <$sock>, qr/^CLIENT_ERROR invalid or duplicate flag/, "gone silly with flags");
+    like(scalar <$sock>, qr/^CLIENT_ERROR invalid flag/, "gone silly with flags");
 }
 
 {

--- a/thread.c
+++ b/thread.c
@@ -750,7 +750,7 @@ enum delta_result_type add_delta(conn *c, const char *key,
 
     hv = hash(key, nkey);
     item_lock(hv);
-    ret = do_add_delta(c, key, nkey, incr, delta, buf, cas, hv);
+    ret = do_add_delta(c, key, nkey, incr, delta, buf, cas, hv, NULL);
     item_unlock(hv);
     return ret;
 }


### PR DESCRIPTION
Commits fleshing out the TODO's from #546 

- fixes a refcount leak (oops!)
- some missing tests/cleanup
- refactors some core code
- adds the mode switch to metaset: set, add, cas, replace, append, prepend are now all just the `ms` command.
- adds meta arithmetic (`ma`) command.