### PR TITLE
Add stdio.h,stddef.h to storage.c

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -4,6 +4,8 @@
 
 #include "storage.h"
 #include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
 #include <string.h>
 #include <limits.h>
 #include <ctype.h>


### PR DESCRIPTION
A compilation error occurs.
My compiler is "Apple LLVM version 7.3.0 (clang-703.0.31)"
The error log is shown below.
```
storage.c:72:43: error: implicit declaration of function 'offsetof' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                    memcpy((char *)io.buf+STORE_OFFSET, (char *)it+STORE_OFFSET, hdrtotal - STORE_OFFSET);
                                          ^
./storage.h:13:22: note: expanded from macro 'STORE_OFFSET'
#define STORE_OFFSET offsetof(item, nbytes)
                     ^
storage.c:72:43: error: unexpected type name 'item': expected expression
./storage.h:13:31: note: expanded from macro 'STORE_OFFSET'
#define STORE_OFFSET offsetof(item, nbytes)
                              ^
storage.c:72:43: error: use of undeclared identifier 'nbytes'
./storage.h:13:37: note: expanded from macro 'STORE_OFFSET'
#define STORE_OFFSET offsetof(item, nbytes)
                                    ^
storage.c:72:68: error: unexpected type name 'item': expected expression
                    memcpy((char *)io.buf+STORE_OFFSET, (char *)it+STORE_OFFSET, hdrtotal - STORE_OFFSET);
                                                                   ^
./storage.h:13:31: note: expanded from macro 'STORE_OFFSET'
#define STORE_OFFSET offsetof(item, nbytes)
...
```

if add stddef.h then...

```
storage.c:130:9: error: implicit declaration of function 'fprintf' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        fprintf(stderr, "Failed to allocate logger for storage compaction thread\n");
        ^
storage.c:130:9: error: declaration of built-in function 'fprintf' requires inclusion of the header <stdio.h> [-Werror,-Wbuiltin-requires-header]
storage.c:130:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "Failed to allocate logger for storage compaction thread\n");
                ^
storage.c:228:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "Can't create storage_write thread: %s\n",
                ^
storage.c:447:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "Failed to allocate logger for storage compaction thread\n");
                ^
storage.c:453:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "Failed to allocate readback buffer for storage compaction thread\n");
                ^
storage.c:561:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "Can't create storage_compact thread: %s\n",
                ^
storage.c:587:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "must supply size to ext_path, ie: ext_path=/f/e:64m (M|G|T|P supported)\n");
                ^
storage.c:629:21: error: use of undeclared identifier 'stderr'
            fprintf(stderr, "Unknown extstore bucket: %s\n", p);
                    ^
storage.c:639:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "ext_path only presently supports the default bucket\n");
```

In short, storage.c should include stdio.h, stddef.h.