### PR TITLE
proto: clean process_command()

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -2932,10 +2932,7 @@ typedef struct token_s {
 
 #define WANT_TOKENS(ntokens, min, max) \
     do { \
-        if (min != -1 && ntokens < min) { \
-            out_string(c, "ERROR"); \
-            return; \
-        } else if (max != -1 && ntokens > max) { \
+        if ((min != -1 && ntokens < min) || (max != -1 && ntokens > max)) { \
             out_string(c, "ERROR"); \
             return; \
         } \
@@ -6099,7 +6096,6 @@ static void process_command(conn *c, char *command) {
             process_stat(c, tokens, ntokens);
         } else if (strcmp(tokens[COMMAND_TOKEN].value, "shutdown") == 0) {
 
-            WANT_TOKENS_OR(ntokens, 2, 2);
             process_shutdown_command(c);
         } else if (strcmp(tokens[COMMAND_TOKEN].value, "slabs") == 0) {
 
@@ -6177,12 +6173,10 @@ static void process_command(conn *c, char *command) {
 
     } else if (strcmp(tokens[COMMAND_TOKEN].value, "version") == 0) {
 
-        WANT_TOKENS_OR(ntokens, 2, 2);
         process_version_command(c);
 
     } else if (strcmp(tokens[COMMAND_TOKEN].value, "quit") == 0) {
 
-        WANT_TOKENS_OR(ntokens, 2, 2);
         process_quit_command(c);
 
     } else if (strcmp(tokens[COMMAND_TOKEN].value, "lru_crawler") == 0) {
@@ -6202,7 +6196,6 @@ static void process_command(conn *c, char *command) {
 #ifdef MEMCACHED_DEBUG
     // commands which exist only for testing the memcached's security protection
     } else if (strcmp(tokens[COMMAND_TOKEN].value, "misbehave") == 0) {
-        WANT_TOKENS_OR(ntokens, 2, 2);
         process_misbehave_command(c);
 #endif
 #ifdef EXTSTORE
@@ -6212,7 +6205,6 @@ static void process_command(conn *c, char *command) {
 #endif
 #ifdef TLS
     } else if (strcmp(tokens[COMMAND_TOKEN].value, "refresh_certs") == 0) {
-        WANT_TOKENS_OR(ntokens, 2, 2);
         process_refresh_certs_command(c, tokens, ntokens);
 #endif
     } else {

--- a/memcached.c
+++ b/memcached.c
@@ -5991,7 +5991,7 @@ static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t n
     }
 }
 #ifdef TLS
-static void process_refresh_certs_command(conn *c) {
+static void process_refresh_certs_command(conn *c, token_t *tokens, const size_t ntokens) {
     set_noreply_maybe(c, tokens, ntokens);
     char *errmsg = NULL;
     if (refresh_certs(&errmsg)) {
@@ -6193,7 +6193,7 @@ static void process_command(conn *c, char *command) {
 #ifdef TLS
     } else if (strcmp(tokens[COMMAND_TOKEN].value, "refresh_certs") == 0) {
         WANT_TOKENS_OR(ntokens, 2, 2);
-        process_refresh_certs_command(c);
+        process_refresh_certs_command(c, tokens, ntokens);
 #endif
     } else {
         if (strncmp(tokens[ntokens - 2].value, "HTTP/", 5) == 0) {

--- a/memcached.c
+++ b/memcached.c
@@ -2930,6 +2930,33 @@ typedef struct token_s {
 
 #define MAX_TOKENS 24
 
+#define WANT_TOKENS(ntokens, min, max) \
+    do { \
+        if (min != -1 && ntokens < min) { \
+            out_string(c, "CLIENT_ERROR wrong number of command tokens"); \
+            return; \
+        } else if (max != -1 && ntokens > max) { \
+            out_string(c, "CLIENT_ERROR wrong number of command tokens"); \
+            return; \
+        } \
+    } while (0)
+
+#define WANT_TOKENS_OR(ntokens, a, b) \
+    do { \
+        if (ntokens != a && ntokens != b) { \
+            out_string(c, "CLIENT_ERROR wrong number of command tokens"); \
+            return; \
+        } \
+    } while (0)
+
+#define WANT_TOKENS_MIN(ntokens, min) \
+    do { \
+        if (ntokens < min) { \
+            out_string(c, "CLIENT_ERROR wrong number of command tokens"); \
+            return; \
+        } \
+    } while (0)
+
 /*
  * Tokenize the command string by replacing whitespace with '\0' and update
  * the token array tokens with pointer to start of each token and length.
@@ -4309,6 +4336,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
     char *p = resp->wbuf;
 
     assert(c != NULL);
+    WANT_TOKENS_MIN(ntokens, 3);
 
     if (tokens[KEY_TOKEN].length > KEY_MAX_LENGTH) {
         out_errstring(c, "CLIENT_ERROR bad command line format");
@@ -4603,6 +4631,7 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
     char *p = resp->wbuf;
 
     assert(c != NULL);
+    WANT_TOKENS_MIN(ntokens, 3);
 
     // TODO: most of this is identical to mget.
     if (tokens[KEY_TOKEN].length > KEY_MAX_LENGTH) {
@@ -4774,6 +4803,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
     char *p = resp->wbuf + 3;
 
     assert(c != NULL);
+    WANT_TOKENS_MIN(ntokens, 3);
 
     // TODO: most of this is identical to mget.
     if (tokens[KEY_TOKEN].length > KEY_MAX_LENGTH) {
@@ -4903,6 +4933,7 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
     item *it = NULL; // item returned by do_add_delta.
 
     assert(c != NULL);
+    WANT_TOKENS_MIN(ntokens, 3);
 
     // TODO: most of this is identical to mget.
     if (tokens[KEY_TOKEN].length > KEY_MAX_LENGTH) {
@@ -5558,6 +5589,11 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
         return;
     }
 
+    if (resp_has_stack(c)) {
+        out_string(c, "ERROR cannot pipeline other commands before watch");
+        return;
+    }
+
     if (ntokens > 2) {
         for (x = COMMAND_TOKEN + 1; x < ntokens - 1; x++) {
             if ((strcmp(tokens[x].value, "rawcmds") == 0)) {
@@ -5734,6 +5770,239 @@ static void process_extstore_command(conn *c, token_t *tokens, const size_t ntok
     }
 }
 #endif
+static void process_flush_all_command(conn *c, token_t *tokens, const size_t ntokens) {
+    time_t exptime = 0;
+    rel_time_t new_oldest = 0;
+
+    set_noreply_maybe(c, tokens, ntokens);
+
+    pthread_mutex_lock(&c->thread->stats.mutex);
+    c->thread->stats.flush_cmds++;
+    pthread_mutex_unlock(&c->thread->stats.mutex);
+
+    if (!settings.flush_enabled) {
+        // flush_all is not allowed but we log it on stats
+        out_string(c, "CLIENT_ERROR flush_all not allowed");
+        return;
+    }
+
+    if (ntokens != (c->noreply ? 3 : 2)) {
+        exptime = strtol(tokens[1].value, NULL, 10);
+        if(errno == ERANGE) {
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+    }
+
+    /*
+      If exptime is zero realtime() would return zero too, and
+      realtime(exptime) - 1 would overflow to the max unsigned
+      value.  So we process exptime == 0 the same way we do when
+      no delay is given at all.
+    */
+    if (exptime > 0) {
+        new_oldest = realtime(exptime);
+    } else { /* exptime == 0 */
+        new_oldest = current_time;
+    }
+
+    if (settings.use_cas) {
+        settings.oldest_live = new_oldest - 1;
+        if (settings.oldest_live <= current_time)
+            settings.oldest_cas = get_cas_id();
+    } else {
+        settings.oldest_live = new_oldest;
+    }
+    out_string(c, "OK");
+}
+
+static void process_version_command(conn *c) {
+    out_string(c, "VERSION " VERSION);
+}
+
+static void process_quit_command(conn *c) {
+    conn_set_state(c, conn_mwrite);
+    c->close_after_write = true;
+}
+
+static void process_shutdown_command(conn *c) {
+    if (settings.shutdown_command) {
+        conn_set_state(c, conn_closing);
+        raise(SIGINT);
+    } else {
+        out_string(c, "ERROR: shutdown not enabled");
+    }
+}
+
+static void process_slabs_command(conn *c, token_t *tokens, const size_t ntokens) {
+    if (ntokens == 5 && strcmp(tokens[COMMAND_TOKEN + 1].value, "reassign") == 0) {
+        int src, dst, rv;
+
+        if (settings.slab_reassign == false) {
+            out_string(c, "CLIENT_ERROR slab reassignment disabled");
+            return;
+        }
+
+        src = strtol(tokens[2].value, NULL, 10);
+        dst = strtol(tokens[3].value, NULL, 10);
+
+        if (errno == ERANGE) {
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+
+        rv = slabs_reassign(src, dst);
+        switch (rv) {
+        case REASSIGN_OK:
+            out_string(c, "OK");
+            break;
+        case REASSIGN_RUNNING:
+            out_string(c, "BUSY currently processing reassign request");
+            break;
+        case REASSIGN_BADCLASS:
+            out_string(c, "BADCLASS invalid src or dst class id");
+            break;
+        case REASSIGN_NOSPARE:
+            out_string(c, "NOSPARE source class has no spare pages");
+            break;
+        case REASSIGN_SRC_DST_SAME:
+            out_string(c, "SAME src and dst class are identical");
+            break;
+        }
+        return;
+    } else if (ntokens >= 4 &&
+        (strcmp(tokens[COMMAND_TOKEN + 1].value, "automove") == 0)) {
+        process_slabs_automove_command(c, tokens, ntokens);
+    } else {
+        out_string(c, "ERROR");
+    }
+}
+
+static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t ntokens) {
+    if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "crawl") == 0) {
+        int rv;
+        if (settings.lru_crawler == false) {
+            out_string(c, "CLIENT_ERROR lru crawler disabled");
+            return;
+        }
+
+        rv = lru_crawler_crawl(tokens[2].value, CRAWLER_EXPIRED, NULL, 0,
+                settings.lru_crawler_tocrawl);
+        switch(rv) {
+        case CRAWLER_OK:
+            out_string(c, "OK");
+            break;
+        case CRAWLER_RUNNING:
+            out_string(c, "BUSY currently processing crawler request");
+            break;
+        case CRAWLER_BADCLASS:
+            out_string(c, "BADCLASS invalid class id");
+            break;
+        case CRAWLER_NOTSTARTED:
+            out_string(c, "NOTSTARTED no items to crawl");
+            break;
+        case CRAWLER_ERROR:
+            out_string(c, "ERROR an unknown error happened");
+            break;
+        }
+        return;
+    } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "metadump") == 0) {
+        if (settings.lru_crawler == false) {
+            out_string(c, "CLIENT_ERROR lru crawler disabled");
+            return;
+        }
+        if (!settings.dump_enabled) {
+            out_string(c, "ERROR metadump not allowed");
+            return;
+        }
+        if (resp_has_stack(c)) {
+            out_string(c, "ERROR cannot pipeline other commands before metadump");
+            return;
+        }
+
+        int rv = lru_crawler_crawl(tokens[2].value, CRAWLER_METADUMP,
+                c, c->sfd, LRU_CRAWLER_CAP_REMAINING);
+        switch(rv) {
+            case CRAWLER_OK:
+                // TODO: documentation says this string is returned, but
+                // it never was before. We never switch to conn_write so
+                // this o_s call never worked. Need to talk to users and
+                // decide if removing the OK from docs is fine.
+                //out_string(c, "OK");
+                // TODO: Don't reuse conn_watch here.
+                conn_set_state(c, conn_watch);
+                event_del(&c->event);
+                break;
+            case CRAWLER_RUNNING:
+                out_string(c, "BUSY currently processing crawler request");
+                break;
+            case CRAWLER_BADCLASS:
+                out_string(c, "BADCLASS invalid class id");
+                break;
+            case CRAWLER_NOTSTARTED:
+                out_string(c, "NOTSTARTED no items to crawl");
+                break;
+            case CRAWLER_ERROR:
+                out_string(c, "ERROR an unknown error happened");
+                break;
+        }
+        return;
+    } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "tocrawl") == 0) {
+        uint32_t tocrawl;
+         if (!safe_strtoul(tokens[2].value, &tocrawl)) {
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+        settings.lru_crawler_tocrawl = tocrawl;
+        out_string(c, "OK");
+        return;
+    } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "sleep") == 0) {
+        uint32_t tosleep;
+        if (!safe_strtoul(tokens[2].value, &tosleep)) {
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+        if (tosleep > 1000000) {
+            out_string(c, "CLIENT_ERROR sleep must be one second or less");
+            return;
+        }
+        settings.lru_crawler_sleep = tosleep;
+        out_string(c, "OK");
+        return;
+    } else if (ntokens == 3) {
+        if ((strcmp(tokens[COMMAND_TOKEN + 1].value, "enable") == 0)) {
+            if (start_item_crawler_thread() == 0) {
+                out_string(c, "OK");
+            } else {
+                out_string(c, "ERROR failed to start lru crawler thread");
+            }
+        } else if ((strcmp(tokens[COMMAND_TOKEN + 1].value, "disable") == 0)) {
+            if (stop_item_crawler_thread(CRAWLER_NOWAIT) == 0) {
+                out_string(c, "OK");
+            } else {
+                out_string(c, "ERROR failed to stop lru crawler thread");
+            }
+        } else {
+            out_string(c, "ERROR");
+        }
+        return;
+    } else {
+        out_string(c, "ERROR");
+    }
+}
+#ifdef TLS
+static void process_refresh_certs_command(conn *c) {
+    set_noreply_maybe(c, tokens, ntokens);
+    char *errmsg = NULL;
+    if (refresh_certs(&errmsg)) {
+        out_string(c, "OK");
+    } else {
+        write_and_free(c, errmsg, strlen(errmsg));
+    }
+    return;
+}
+#endif
+
 // TODO: pipelined commands are incompatible with shifting connections to a
 // side thread. Given this only happens in two instances (watch and
 // lru_crawler metadump) it should be fine for things to bail. It _should_ be
@@ -5767,321 +6036,162 @@ static void process_command(conn *c, char *command) {
     }
 
     ntokens = tokenize_command(command, tokens, MAX_TOKENS);
-    if (ntokens >= 3 &&
-        ((strcmp(tokens[COMMAND_TOKEN].value, "get") == 0) ||
-         (strcmp(tokens[COMMAND_TOKEN].value, "bget") == 0))) {
 
-        process_get_command(c, tokens, ntokens, false, false);
+    // Meta commands are all 2-char in length.
+    if (tokens[COMMAND_TOKEN].length == 2 &&
+            tokens[COMMAND_TOKEN].value[0] == 'm') {
+        switch (tokens[COMMAND_TOKEN].value[1]) {
+            case 'g':
+                process_mget_command(c, tokens, ntokens);
+                break;
+            case 's':
+                process_mset_command(c, tokens, ntokens);
+                break;
+            case 'd':
+                process_mdelete_command(c, tokens, ntokens);
+                break;
+            case 'n':
+                out_string(c, "MN");
+                // mn command forces immediate writeback flush.
+                conn_set_state(c, conn_mwrite);
+                break;
+            case 'a':
+                process_marithmetic_command(c, tokens, ntokens);
+                break;
+            case 'e':
+                process_meta_command(c, tokens, ntokens);
+                break;
+        }
+    } else if (tokens[COMMAND_TOKEN].value[0] == 'g') {
+        // Various get commands are very common; short out the branch.
+        if (strcmp(tokens[COMMAND_TOKEN].value, "get") == 0) {
 
-    } else if ((ntokens == 6 || ntokens == 7) &&
+            WANT_TOKENS_MIN(ntokens, 3);
+            process_get_command(c, tokens, ntokens, false, false);
+        } else if (strcmp(tokens[COMMAND_TOKEN].value, "gets") == 0) {
+
+            WANT_TOKENS_MIN(ntokens, 3);
+            process_get_command(c, tokens, ntokens, true, false);
+
+        } else if (strcmp(tokens[COMMAND_TOKEN].value, "gat") == 0) {
+
+            WANT_TOKENS_MIN(ntokens, 3);
+            process_get_command(c, tokens, ntokens, false, true);
+
+        } else if (strcmp(tokens[COMMAND_TOKEN].value, "gats") == 0) {
+
+            WANT_TOKENS_MIN(ntokens, 3);
+            process_get_command(c, tokens, ntokens, true, true);
+
+        } else {
+            out_string(c, "ERROR");
+        }
+    } else if (
                ((strcmp(tokens[COMMAND_TOKEN].value, "add") == 0 && (comm = NREAD_ADD)) ||
                 (strcmp(tokens[COMMAND_TOKEN].value, "set") == 0 && (comm = NREAD_SET)) ||
                 (strcmp(tokens[COMMAND_TOKEN].value, "replace") == 0 && (comm = NREAD_REPLACE)) ||
                 (strcmp(tokens[COMMAND_TOKEN].value, "prepend") == 0 && (comm = NREAD_PREPEND)) ||
                 (strcmp(tokens[COMMAND_TOKEN].value, "append") == 0 && (comm = NREAD_APPEND)) )) {
 
+        WANT_TOKENS_OR(ntokens, 6, 7);
         process_update_command(c, tokens, ntokens, comm, false);
 
-    } else if ((ntokens == 7 || ntokens == 8) && (strcmp(tokens[COMMAND_TOKEN].value, "cas") == 0 && (comm = NREAD_CAS))) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "cas") == 0 && (comm = NREAD_CAS)) {
 
+        WANT_TOKENS_OR(ntokens, 7, 8);
         process_update_command(c, tokens, ntokens, comm, true);
 
-    } else if ((ntokens == 4 || ntokens == 5) && (strcmp(tokens[COMMAND_TOKEN].value, "incr") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "incr") == 0) {
 
+        WANT_TOKENS_OR(ntokens, 4, 5);
         process_arithmetic_command(c, tokens, ntokens, 1);
 
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "gets") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "decr") == 0) {
 
-        process_get_command(c, tokens, ntokens, true, false);
-
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "mg") == 0)) {
-        process_mget_command(c, tokens, ntokens);
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "ms") == 0)) {
-        process_mset_command(c, tokens, ntokens);
-    } else if (ntokens >= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "md") == 0)) {
-        process_mdelete_command(c, tokens, ntokens);
-    } else if (ntokens >= 2 && (strcmp(tokens[COMMAND_TOKEN].value, "mn") == 0)) {
-        out_string(c, "MN");
-        // mn command forces immediate writeback flush.
-        conn_set_state(c, conn_mwrite);
-        return;
-    } else if (ntokens >= 2 && (strcmp(tokens[COMMAND_TOKEN].value, "ma") == 0)) {
-        process_marithmetic_command(c, tokens, ntokens);
-    } else if (ntokens >= 2 && (strcmp(tokens[COMMAND_TOKEN].value, "me") == 0)) {
-        process_meta_command(c, tokens, ntokens);
-        return;
-    } else if ((ntokens == 4 || ntokens == 5) && (strcmp(tokens[COMMAND_TOKEN].value, "decr") == 0)) {
-
+        WANT_TOKENS_OR(ntokens, 4, 5);
         process_arithmetic_command(c, tokens, ntokens, 0);
 
-    } else if (ntokens >= 3 && ntokens <= 5 && (strcmp(tokens[COMMAND_TOKEN].value, "delete") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "delete") == 0) {
 
+        WANT_TOKENS(ntokens, 3, 5);
         process_delete_command(c, tokens, ntokens);
 
-    } else if ((ntokens == 4 || ntokens == 5) && (strcmp(tokens[COMMAND_TOKEN].value, "touch") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "touch") == 0) {
 
+        WANT_TOKENS_OR(ntokens, 4, 5);
         process_touch_command(c, tokens, ntokens);
 
-    } else if (ntokens >= 4 && (strcmp(tokens[COMMAND_TOKEN].value, "gat") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "bget") == 0) {
+        // ancient "binary get" command which isn't in any documentation, was
+        // removed > 10 years ago, etc. Keeping for compatibility reasons but
+        // we should look deeper into client code and remove this.
+        WANT_TOKENS_MIN(ntokens, 3);
+        process_get_command(c, tokens, ntokens, false, false);
 
-        process_get_command(c, tokens, ntokens, false, true);
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "stats") == 0) {
 
-    } else if (ntokens >= 4 && (strcmp(tokens[COMMAND_TOKEN].value, "gats") == 0)) {
-
-        process_get_command(c, tokens, ntokens, true, true);
-
-    } else if (ntokens >= 2 && (strcmp(tokens[COMMAND_TOKEN].value, "stats") == 0)) {
-
+        WANT_TOKENS_MIN(ntokens, 2);
         process_stat(c, tokens, ntokens);
 
-    } else if (ntokens >= 2 && ntokens <= 4 && (strcmp(tokens[COMMAND_TOKEN].value, "flush_all") == 0)) {
-        time_t exptime = 0;
-        rel_time_t new_oldest = 0;
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "flush_all") == 0) {
 
-        set_noreply_maybe(c, tokens, ntokens);
+        WANT_TOKENS(ntokens, 2, 4);
+        process_flush_all_command(c, tokens, ntokens);
 
-        pthread_mutex_lock(&c->thread->stats.mutex);
-        c->thread->stats.flush_cmds++;
-        pthread_mutex_unlock(&c->thread->stats.mutex);
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "version") == 0) {
 
-        if (!settings.flush_enabled) {
-            // flush_all is not allowed but we log it on stats
-            out_string(c, "CLIENT_ERROR flush_all not allowed");
-            return;
-        }
+        WANT_TOKENS_OR(ntokens, 2, 2);
+        process_version_command(c);
 
-        if (ntokens != (c->noreply ? 3 : 2)) {
-            exptime = strtol(tokens[1].value, NULL, 10);
-            if(errno == ERANGE) {
-                out_string(c, "CLIENT_ERROR bad command line format");
-                return;
-            }
-        }
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "quit") == 0) {
 
-        /*
-          If exptime is zero realtime() would return zero too, and
-          realtime(exptime) - 1 would overflow to the max unsigned
-          value.  So we process exptime == 0 the same way we do when
-          no delay is given at all.
-        */
-        if (exptime > 0) {
-            new_oldest = realtime(exptime);
-        } else { /* exptime == 0 */
-            new_oldest = current_time;
-        }
+        WANT_TOKENS_OR(ntokens, 2, 2);
+        process_quit_command(c);
 
-        if (settings.use_cas) {
-            settings.oldest_live = new_oldest - 1;
-            if (settings.oldest_live <= current_time)
-                settings.oldest_cas = get_cas_id();
-        } else {
-            settings.oldest_live = new_oldest;
-        }
-        out_string(c, "OK");
-        return;
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "shutdown") == 0) {
 
-    } else if (ntokens == 2 && (strcmp(tokens[COMMAND_TOKEN].value, "version") == 0)) {
+        WANT_TOKENS_OR(ntokens, 2, 2);
+        process_shutdown_command(c);
 
-        out_string(c, "VERSION " VERSION);
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "slabs") == 0) {
 
-    } else if (ntokens == 2 && (strcmp(tokens[COMMAND_TOKEN].value, "quit") == 0)) {
+        WANT_TOKENS_MIN(ntokens, 2);
+        process_slabs_command(c, tokens, ntokens);
 
-        conn_set_state(c, conn_mwrite);
-        c->close_after_write = true;
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "lru_crawler") == 0) {
 
-    } else if (ntokens == 2 && (strcmp(tokens[COMMAND_TOKEN].value, "shutdown") == 0)) {
+        WANT_TOKENS_MIN(ntokens, 2);
+        process_lru_crawler_command(c, tokens, ntokens);
 
-        if (settings.shutdown_command) {
-            conn_set_state(c, conn_closing);
-            raise(SIGINT);
-        } else {
-            out_string(c, "ERROR: shutdown not enabled");
-        }
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "watch") == 0) {
 
-    } else if (ntokens > 1 && strcmp(tokens[COMMAND_TOKEN].value, "slabs") == 0) {
-        if (ntokens == 5 && strcmp(tokens[COMMAND_TOKEN + 1].value, "reassign") == 0) {
-            int src, dst, rv;
-
-            if (settings.slab_reassign == false) {
-                out_string(c, "CLIENT_ERROR slab reassignment disabled");
-                return;
-            }
-
-            src = strtol(tokens[2].value, NULL, 10);
-            dst = strtol(tokens[3].value, NULL, 10);
-
-            if (errno == ERANGE) {
-                out_string(c, "CLIENT_ERROR bad command line format");
-                return;
-            }
-
-            rv = slabs_reassign(src, dst);
-            switch (rv) {
-            case REASSIGN_OK:
-                out_string(c, "OK");
-                break;
-            case REASSIGN_RUNNING:
-                out_string(c, "BUSY currently processing reassign request");
-                break;
-            case REASSIGN_BADCLASS:
-                out_string(c, "BADCLASS invalid src or dst class id");
-                break;
-            case REASSIGN_NOSPARE:
-                out_string(c, "NOSPARE source class has no spare pages");
-                break;
-            case REASSIGN_SRC_DST_SAME:
-                out_string(c, "SAME src and dst class are identical");
-                break;
-            }
-            return;
-        } else if (ntokens >= 4 &&
-            (strcmp(tokens[COMMAND_TOKEN + 1].value, "automove") == 0)) {
-            process_slabs_automove_command(c, tokens, ntokens);
-        } else {
-            out_string(c, "ERROR");
-        }
-    } else if (ntokens > 1 && strcmp(tokens[COMMAND_TOKEN].value, "lru_crawler") == 0) {
-        if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "crawl") == 0) {
-            int rv;
-            if (settings.lru_crawler == false) {
-                out_string(c, "CLIENT_ERROR lru crawler disabled");
-                return;
-            }
-
-            rv = lru_crawler_crawl(tokens[2].value, CRAWLER_EXPIRED, NULL, 0,
-                    settings.lru_crawler_tocrawl);
-            switch(rv) {
-            case CRAWLER_OK:
-                out_string(c, "OK");
-                break;
-            case CRAWLER_RUNNING:
-                out_string(c, "BUSY currently processing crawler request");
-                break;
-            case CRAWLER_BADCLASS:
-                out_string(c, "BADCLASS invalid class id");
-                break;
-            case CRAWLER_NOTSTARTED:
-                out_string(c, "NOTSTARTED no items to crawl");
-                break;
-            case CRAWLER_ERROR:
-                out_string(c, "ERROR an unknown error happened");
-                break;
-            }
-            return;
-        } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "metadump") == 0) {
-            if (settings.lru_crawler == false) {
-                out_string(c, "CLIENT_ERROR lru crawler disabled");
-                return;
-            }
-            if (!settings.dump_enabled) {
-                out_string(c, "ERROR metadump not allowed");
-                return;
-            }
-            if (resp_has_stack(c)) {
-                out_string(c, "ERROR cannot pipeline other commands before metadump");
-                return;
-            }
-
-            int rv = lru_crawler_crawl(tokens[2].value, CRAWLER_METADUMP,
-                    c, c->sfd, LRU_CRAWLER_CAP_REMAINING);
-            switch(rv) {
-                case CRAWLER_OK:
-                    // TODO: documentation says this string is returned, but
-                    // it never was before. We never switch to conn_write so
-                    // this o_s call never worked. Need to talk to users and
-                    // decide if removing the OK from docs is fine.
-                    //out_string(c, "OK");
-                    // TODO: Don't reuse conn_watch here.
-                    conn_set_state(c, conn_watch);
-                    event_del(&c->event);
-                    break;
-                case CRAWLER_RUNNING:
-                    out_string(c, "BUSY currently processing crawler request");
-                    break;
-                case CRAWLER_BADCLASS:
-                    out_string(c, "BADCLASS invalid class id");
-                    break;
-                case CRAWLER_NOTSTARTED:
-                    out_string(c, "NOTSTARTED no items to crawl");
-                    break;
-                case CRAWLER_ERROR:
-                    out_string(c, "ERROR an unknown error happened");
-                    break;
-            }
-            return;
-        } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "tocrawl") == 0) {
-            uint32_t tocrawl;
-             if (!safe_strtoul(tokens[2].value, &tocrawl)) {
-                out_string(c, "CLIENT_ERROR bad command line format");
-                return;
-            }
-            settings.lru_crawler_tocrawl = tocrawl;
-            out_string(c, "OK");
-            return;
-        } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "sleep") == 0) {
-            uint32_t tosleep;
-            if (!safe_strtoul(tokens[2].value, &tosleep)) {
-                out_string(c, "CLIENT_ERROR bad command line format");
-                return;
-            }
-            if (tosleep > 1000000) {
-                out_string(c, "CLIENT_ERROR sleep must be one second or less");
-                return;
-            }
-            settings.lru_crawler_sleep = tosleep;
-            out_string(c, "OK");
-            return;
-        } else if (ntokens == 3) {
-            if ((strcmp(tokens[COMMAND_TOKEN + 1].value, "enable") == 0)) {
-                if (start_item_crawler_thread() == 0) {
-                    out_string(c, "OK");
-                } else {
-                    out_string(c, "ERROR failed to start lru crawler thread");
-                }
-            } else if ((strcmp(tokens[COMMAND_TOKEN + 1].value, "disable") == 0)) {
-                if (stop_item_crawler_thread(CRAWLER_NOWAIT) == 0) {
-                    out_string(c, "OK");
-                } else {
-                    out_string(c, "ERROR failed to stop lru crawler thread");
-                }
-            } else {
-                out_string(c, "ERROR");
-            }
-            return;
-        } else {
-            out_string(c, "ERROR");
-        }
-    } else if (ntokens > 1 && strcmp(tokens[COMMAND_TOKEN].value, "watch") == 0) {
-        if (resp_has_stack(c)) {
-            out_string(c, "ERROR cannot pipeline other commands before watch");
-            return;
-        }
+        WANT_TOKENS_MIN(ntokens, 2);
         process_watch_command(c, tokens, ntokens);
-    } else if ((ntokens == 3 || ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "cache_memlimit") == 0)) {
+
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "cache_memlimit") == 0) {
+        WANT_TOKENS_OR(ntokens, 3, 4);
         process_memlimit_command(c, tokens, ntokens);
-    } else if ((ntokens == 3 || ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "verbosity") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "verbosity") == 0) {
+        WANT_TOKENS_OR(ntokens, 3, 4);
         process_verbosity_command(c, tokens, ntokens);
-    } else if (ntokens >= 3 && strcmp(tokens[COMMAND_TOKEN].value, "lru") == 0) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "lru") == 0) {
+        WANT_TOKENS_MIN(ntokens, 3);
         process_lru_command(c, tokens, ntokens);
 #ifdef MEMCACHED_DEBUG
     // commands which exist only for testing the memcached's security protection
-    } else if (ntokens == 2 && (strcmp(tokens[COMMAND_TOKEN].value, "misbehave") == 0)) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "misbehave") == 0) {
+        WANT_TOKENS_OR(ntokens, 2, 2);
         process_misbehave_command(c);
 #endif
 #ifdef EXTSTORE
-    } else if (ntokens >= 3 && strcmp(tokens[COMMAND_TOKEN].value, "extstore") == 0) {
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "extstore") == 0) {
+        WANT_TOKENS_MIN(ntokens, 3);
         process_extstore_command(c, tokens, ntokens);
 #endif
 #ifdef TLS
-    } else if (ntokens == 2 && strcmp(tokens[COMMAND_TOKEN].value, "refresh_certs") == 0) {
-        set_noreply_maybe(c, tokens, ntokens);
-        char *errmsg = NULL;
-        if (refresh_certs(&errmsg)) {
-            out_string(c, "OK");
-        } else {
-            write_and_free(c, errmsg, strlen(errmsg));
-        }
-        return;
+    } else if (strcmp(tokens[COMMAND_TOKEN].value, "refresh_certs") == 0) {
+        WANT_TOKENS_OR(ntokens, 2, 2);
+        process_refresh_certs_command(c);
 #endif
     } else {
         if (ntokens >= 2 && strncmp(tokens[ntokens - 2].value, "HTTP/", 5) == 0) {

--- a/t/cas.t
+++ b/t/cas.t
@@ -70,7 +70,7 @@ is(scalar <$sock>, "NOT_FOUND\r\n", "cas failed, foo does not exist");
 
 # cas empty
 print $sock "cas foo 0 0 6 \r\nbarva2\r\n";
-is(scalar <$sock>, "CLIENT_ERROR wrong number of command tokens\r\n", "cas empty, throw error");
+is(scalar <$sock>, "ERROR\r\n", "cas empty, throw error");
 # cant parse barval2\r\n
 is(scalar <$sock>, "ERROR\r\n", "error out on barval2 parsing");
 

--- a/t/cas.t
+++ b/t/cas.t
@@ -70,7 +70,7 @@ is(scalar <$sock>, "NOT_FOUND\r\n", "cas failed, foo does not exist");
 
 # cas empty
 print $sock "cas foo 0 0 6 \r\nbarva2\r\n";
-is(scalar <$sock>, "ERROR\r\n", "cas empty, throw error");
+is(scalar <$sock>, "CLIENT_ERROR wrong number of command tokens\r\n", "cas empty, throw error");
 # cant parse barval2\r\n
 is(scalar <$sock>, "ERROR\r\n", "error out on barval2 parsing");
 

--- a/t/chunked-extstore.t
+++ b/t/chunked-extstore.t
@@ -144,10 +144,13 @@ wait_for_ext();
     }
     print $sock "extstore compact_under 4\r\n";
     my $res = <$sock>;
+    is($res, "OK\r\n", 'set compact_under');
     print $sock "extstore drop_under 3\r\n";
     $res = <$sock>;
+    is($res, "OK\r\n", 'set drop_under');
     print $sock "extstore max_frag 0.9\r\n";
     $res = <$sock>;
+    is($res, "OK\r\n", 'set max_frag');
 
     # Give compaction some time to run.
     for (1 .. 30) {

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -113,6 +113,12 @@ my $sock = $server->sock;
 # - raw mget miss
 # - raw mget bad key
 
+# Test basic parser.
+{
+    print $sock " \n";
+    is(scalar <$sock>, "ERROR\r\n", "error from blank command");
+}
+
 {
     print $sock "set foo 0 0 2\r\nhi\r\n";
     is(scalar <$sock>, "STORED\r\n", "stored test value");


### PR DESCRIPTION
Pulled almost all of the inlined commands out of the function. Also
abstract out the token count checks.

Meta commands have a special fast handler

also reordered/restructured the rest of the commands. cleaner code and
should be same/similar performance for the common commands.

Need to do a quick verification bench and wait a bit to see if I still like the token macros later.

edit: also need to finish TLS mode