### PR TITLE
ssl_errors stat

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1621,6 +1621,23 @@ The value of the "state" stat may be one of the following:
 |                | sending back multiple lines of response data).            |
 |----------------+-----------------------------------------------------------|
 
+TLS statistics
+--------------
+
+TLS is a compile-time opt-in feature available in versions 1.5.13 and later.
+When compiled with TLS support and TLS termination is enabled at runtime, the
+following additional statistics are available via the "stats" command.
+
+|--------------------------------+----------+--------------------------------|
+| Name                           | Type     | Meaning                        |
+|--------------------------------+----------+--------------------------------|
+| ssl_handshake_errors           | 64u      | Number of times the server has |
+|                                |          | encountered an OpenSSL error   |
+|                                |          | during handshake (SSL_accept). |
+| time_since_server_cert_refresh | 32u      | Number of seconds that have    |
+|                                |          | elapsed since the last time    |
+|                                |          | certs were reloaded from disk. |
+|--------------------------------+----------+--------------------------------|
 
 
 Other commands

--- a/memcached.c
+++ b/memcached.c
@@ -3192,6 +3192,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
 #endif
 #ifdef TLS
     if (settings.ssl_enabled) {
+        APPEND_STAT("ssl_errors", "%llu", (unsigned long long)stats.ssl_errors);
         APPEND_STAT("time_since_server_cert_refresh", "%u", now - settings.ssl_last_cert_refresh_time);
     }
 #endif
@@ -7028,6 +7029,9 @@ static void drive_machine(conn *c) {
                             }
                             SSL_free(ssl);
                             close(sfd);
+                            STATS_LOCK();
+                            stats.ssl_errors++;
+                            STATS_UNLOCK();
                             break;
                         }
                     }

--- a/memcached.c
+++ b/memcached.c
@@ -3192,7 +3192,7 @@ static void server_stats(ADD_STAT add_stats, conn *c) {
 #endif
 #ifdef TLS
     if (settings.ssl_enabled) {
-        APPEND_STAT("ssl_errors", "%llu", (unsigned long long)stats.ssl_errors);
+        APPEND_STAT("ssl_handshake_errors", "%llu", (unsigned long long)stats.ssl_handshake_errors);
         APPEND_STAT("time_since_server_cert_refresh", "%u", now - settings.ssl_last_cert_refresh_time);
     }
 #endif
@@ -7030,7 +7030,7 @@ static void drive_machine(conn *c) {
                             SSL_free(ssl);
                             close(sfd);
                             STATS_LOCK();
-                            stats.ssl_errors++;
+                            stats.ssl_handshake_errors++;
                             STATS_UNLOCK();
                             break;
                         }

--- a/memcached.h
+++ b/memcached.h
@@ -357,7 +357,7 @@ struct stats {
     uint64_t      extstore_compact_skipped; /* unhit items skipped during compaction */
 #endif
 #ifdef TLS
-    uint64_t      ssl_errors; /* TLS failures at accept/handshake time */
+    uint64_t      ssl_handshake_errors; /* TLS failures at accept/handshake time */
 #endif
     struct timeval maxconns_entered;  /* last time maxconns entered */
 };

--- a/memcached.h
+++ b/memcached.h
@@ -356,6 +356,9 @@ struct stats {
     uint64_t      extstore_compact_rescues; /* items re-written during compaction */
     uint64_t      extstore_compact_skipped; /* unhit items skipped during compaction */
 #endif
+#ifdef TLS
+    uint64_t      ssl_errors; /* TLS failures at accept/handshake time */
+#endif
     struct timeval maxconns_entered;  /* last time maxconns entered */
 };
 

--- a/t/stats.t
+++ b/t/stats.t
@@ -26,7 +26,7 @@ my $stats = mem_stats($sock);
 # Test number of keys
 if (MemcachedTest::enabled_tls_testing()) {
     # when TLS is enabled, stats contains additional keys:
-    #   - ssl_errors
+    #   - ssl_handshake_errors
     #   - time_since_server_cert_refresh
     is(scalar(keys(%$stats)), 80, "expected count of stats values");
 } else {

--- a/t/stats.t
+++ b/t/stats.t
@@ -25,8 +25,10 @@ my $stats = mem_stats($sock);
 
 # Test number of keys
 if (MemcachedTest::enabled_tls_testing()) {
-    # when TLS is enabled, stats contains time_since_server_cert_refresh
-    is(scalar(keys(%$stats)), 79, "expected count of stats values");
+    # when TLS is enabled, stats contains additional keys:
+    #   - ssl_errors
+    #   - time_since_server_cert_refresh
+    is(scalar(keys(%$stats)), 80, "expected count of stats values");
 } else {
     is(scalar(keys(%$stats)), 78, "expected count of stats values");
 }


### PR DESCRIPTION
This PR proposes the addition of new stats key `ssl_errors` to keep track of the number of times the server encounters an OpenSSL error during `SSL_accept`.

Since we only permit TLS v1.2+ clients, I tested by forcing TLS 1.1 on client-side and observing `ssl_errors` increment on each accept failure:

```
$ openssl s_client -tls1_1 -key t/client_key.pem -cert t/client_crt.pem -CAfile t/cacert.pem -connect localhost:11211
```