### PR TITLE
Fix t/64bit.t test failure in Windows.

### DIFF
--- a/slabs.c
+++ b/slabs.c
@@ -279,7 +279,10 @@ void slabs_init(const size_t limit, const double factor, const bool prealloc, co
     {
         char *t_initial_malloc = getenv("T_MEMD_INITIAL_MALLOC");
         if (t_initial_malloc) {
-            mem_malloced = (size_t)atol(t_initial_malloc);
+            int64_t env_malloced;
+            if (safe_strtoll((const char *)t_initial_malloc, &env_malloced)) {
+                mem_malloced = (size_t)env_malloced;
+            }
         }
 
     }


### PR DESCRIPTION
In Windows, long is just 32-bit even for 64-bit platforms causing the faked **_mem_malloced_** to overflow if **T_MEMD_INITIAL_MALLOC** > **INT_MAX**. This fix is compatible for Windows and *nix. Refer below for the error:
<pre>
t/64bit.t .. 1/6
#   Failed test 'expected (faked) value of total_malloced'
#   at t/64bit.t line 30.
#          got: '32'
#     expected: '4294967328'
#   Failed test 'hit size limit'
#   at t/64bit.t line 41.
</pre>

This PR will only affect testing with **T_MEMD_INITIAL_MALLOC** defined.