### PR TITLE
Add build option to disable unix socket

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,9 @@ AC_ARG_ENABLE(asan,
 AC_ARG_ENABLE(static,
   [AS_HELP_STRING([--enable-static], [Compile a statically linked binary])])
 
+AC_ARG_ENABLE(unix_socket,
+  [AS_HELP_STRING([--disable-unix-socket], [Disable unix domain socket])])
+
 dnl **********************************************************************
 dnl DETECT_SASL_CB_GETCONF
 dnl
@@ -213,6 +216,10 @@ if test "x$enable_static" = "xyes"; then
     AC_DEFINE([STATIC],1,[Set to nonzero if you want to compile a statically linked binary])
 fi
 
+if test "x$enable_unix_socket" = "xno"; then
+    AC_DEFINE([DISABLE_UNIX_SOCKET],1,[Set to nonzero if you want to disable unix domain socket])
+fi
+
 AM_CONDITIONAL([BUILD_DTRACE],[test "$build_dtrace" = "yes"])
 AM_CONDITIONAL([DTRACE_INSTRUMENT_OBJ],[test "$dtrace_instrument_obj" = "yes"])
 AM_CONDITIONAL([ENABLE_SASL],[test "$enable_sasl" = "yes"])
@@ -221,6 +228,7 @@ AM_CONDITIONAL([ENABLE_ARM_CRC32],[test "$enable_arm_crc32" = "yes"])
 AM_CONDITIONAL([ENABLE_TLS],[test "$enable_tls" = "yes"])
 AM_CONDITIONAL([ENABLE_ASAN],[test "$enable_asan" = "yes"])
 AM_CONDITIONAL([ENABLE_STATIC],[test "$enable_static" = "yes"])
+AM_CONDITIONAL([DISABLE_UNIX_SOCKET],[test "$enable_unix_socket" = "no"])
 
 
 AC_SUBST(DTRACE)

--- a/t/binary.t
+++ b/t/binary.t
@@ -443,7 +443,7 @@ $mc->silent_mutation(::CMD_ADDQ, 'silentadd', 'silentaddval');
     is(1024, $stats{'maxconns'});
     # we run SSL tests over TCP; hence the domain_socket
     # is expected to be NULL.
-    if (enabled_tls_testing()) {
+    if (enabled_tls_testing() || !supports_unix_socket()) {
         is('NULL', $stats{'domain_socket'});
     } else {
         isnt('NULL', $stats{'domain_socket'});

--- a/t/stats-conns.t
+++ b/t/stats-conns.t
@@ -1,65 +1,70 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 12;
+use Test::More;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
 ## First make sure we report UNIX-domain sockets correctly
+if (supports_unix_socket()) {
+    plan tests => 12;
 
-my $filename = "/tmp/memcachetest$$";
+    my $filename = "/tmp/memcachetest$$";
 
-my $server = new_memcached("-s $filename");
-my $sock = $server->sock;
-my $stats_sock = $server->new_sock;
+    my $server = new_memcached("-s $filename");
+    my $sock = $server->sock;
+    my $stats_sock = $server->new_sock;
 
-ok(-S $filename, "creating unix domain socket $filename");
+    ok(-S $filename, "creating unix domain socket $filename");
 
-print $sock "set foo 0 0 6\r\n";
-sleep(1);    # so we can test secs_since_last_cmd is nonzero
-print $stats_sock "stats conns\r\n";
+    print $sock "set foo 0 0 6\r\n";
+    sleep(1);    # so we can test secs_since_last_cmd is nonzero
+    print $stats_sock "stats conns\r\n";
 
-my $stats;
-while (<$stats_sock>) {
-    last if /^(\.|END)/;
-    $stats .= $_;
+    my $stats;
+    while (<$stats_sock>) {
+        last if /^(\.|END)/;
+        $stats .= $_;
+    }
+
+    like($stats, qr/STAT \d+:addr /);
+    $stats =~ m/STAT (\d+):addr unix:(.*[^\r\n])/g;
+    my $listen_fd = $1;
+    my $socket_path = $2;
+    # getsockname(2) doesn't return socket path on GNU/Hurd (and maybe others)
+    SKIP: {
+        skip "socket path checking on GNU kernel", 1 if ($^O eq 'gnu');
+        is($socket_path, $filename, "unix domain socket path reported correctly");
+    };
+    $stats =~ m/STAT (\d+):state conn_listening\r\n/g;
+    is($1, $listen_fd, "listen socket fd reported correctly");
+
+    like($stats, qr/STAT \d+:state conn_nread/,
+         "one client is sending data");
+    like($stats, qr/STAT \d+:state conn_parse_cmd/,
+         "one client is in command processing");
+    like($stats, qr/STAT \d+:secs_since_last_cmd [1-9]\r/,
+         "nonzero secs_since_last_cmd");
+    like($stats, qr/STAT \d+:listen_addr unix:\/tmp\/memcachetest\d+\r/,
+         "found listen_addr for the UNIX-domain socket");
+
+    $server->stop;
+    unlink($filename);
+} else {
+    plan tests => 4;
 }
-
-like($stats, qr/STAT \d+:addr /);
-$stats =~ m/STAT (\d+):addr unix:(.*[^\r\n])/g;
-my $listen_fd = $1;
-my $socket_path = $2;
-# getsockname(2) doesn't return socket path on GNU/Hurd (and maybe others)
-SKIP: {
-    skip "socket path checking on GNU kernel", 1 if ($^O eq 'gnu');
-    is($socket_path, $filename, "unix domain socket path reported correctly");
-};
-$stats =~ m/STAT (\d+):state conn_listening\r\n/g;
-is($1, $listen_fd, "listen socket fd reported correctly");
-
-like($stats, qr/STAT \d+:state conn_nread/,
-     "one client is sending data");
-like($stats, qr/STAT \d+:state conn_parse_cmd/,
-     "one client is in command processing");
-like($stats, qr/STAT \d+:secs_since_last_cmd [1-9]\r/,
-     "nonzero secs_since_last_cmd");
-like($stats, qr/STAT \d+:listen_addr unix:\/tmp\/memcachetest\d+\r/,
-     "found listen_addr for the UNIX-domain socket");
-
-$server->stop;
-unlink($filename);
 
 ## Now look at TCP
 
-$server = new_memcached("-l 0.0.0.0");
-$sock = $server->sock;
-$stats_sock = $server->new_sock;
+my $server = new_memcached("-l 0.0.0.0");
+my $sock = $server->sock;
+my $stats_sock = $server->new_sock;
 
 print $sock "set foo 0 0 6\r\n";
 print $stats_sock "stats conns\r\n";
 
-$stats = '';
+my $stats = '';
 while (<$stats_sock>) {
     last if /^(\.|END)/;
     $stats .= $_;

--- a/t/stats.t
+++ b/t/stats.t
@@ -139,7 +139,7 @@ my $settings = mem_stats($sock, ' settings');
 is(1024, $settings->{'maxconns'});
 # we run SSL tests over TCP; hence the domain_socket
 # is expected to be NULL.
-if (enabled_tls_testing()) {
+if (enabled_tls_testing() || !supports_unix_socket()) {
     is('NULL', $settings->{'domain_socket'});
 } else {
     isnt('NULL', $settings->{'domain_socket'});


### PR DESCRIPTION
1. **configure.ac** - Add **_--disable-unix-socket_** to disable and define **DISABLE_UNIX_SOCKET**.
2. **memcached.*** - Guard all unix socket-related codes with **DISABLE_UNIX_SOCKET**. Take note of negative checking (**_#ifndef DISABLE_UNIX_SOCKET_** instead of **_#ifdef UNIX_SOCKET_**). This is just to make sure that current code even without a config file is the default or supports unix socket.
3. **t/** - Check first if unix socket is supported before executing unix socket-related tests.

**Tests:**
1. [test_default_build_(unix_socket_supported).log](https://github.com/memcached/memcached/files/4436455/test_default_build_.unix_socket_supported.log) - **_t/unixsocket.t .............. ok_. All tests successful. Files=78, Tests=104868,**
2. [test_disable-unix-socket_build.log](https://github.com/memcached/memcached/files/4436456/test_disable-unix-socket_build.log) - **_t/unixsocket.t .............. skipped: Unix domain socket is not supported._. All tests successful. Files=78, Tests=104425,**

