### PR TITLE
Fix build warnings in Windows.

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -89,7 +89,7 @@ static pthread_mutex_t init_lock;
 static pthread_cond_t init_cond;
 
 
-static void thread_libevent_process(int fd, short which, void *arg);
+static void thread_libevent_process(evutil_socket_t fd, short which, void *arg);
 
 /* item_lock() must be held for an item before any modifications to either its
  * associated hash bucket, or the structure itself.
@@ -505,7 +505,7 @@ static void *worker_libevent(void *arg) {
  * Processes an incoming "handle a new connection" item. This is called when
  * input arrives on the libevent wakeup pipe.
  */
-static void thread_libevent_process(int fd, short which, void *arg) {
+static void thread_libevent_process(evutil_socket_t fd, short which, void *arg) {
     LIBEVENT_THREAD *me = arg;
     CQ_ITEM *item;
     char buf[1];


### PR DESCRIPTION
1. **_warning: passing argument 4 of 'event_set' from incompatible pointer type [-Wincompatible-pointer-types]_**
   --> libevent expects callbacks to use **evutil_socket_t** for fd instead of int. Current code works fine in *nix because it's just **int** but not in Windows because it's defined as **intptr_t**.
2. **_warning: passing argument 4 of 'getsockopt' from incompatible pointer type [-Wincompatible-pointer-types]_**
   --> Apply casting for Windows' **getsockopt** call
3. **_warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]_**
   --> Replace **%lx** with more portable **%p**. **long** is just 32-bit in 64-bit Windows.

[fix_windows_warnings_test.log](https://github.com/memcached/memcached/files/4464890/fix_windows_warnings_test.log) is the test log of this change.