### PR TITLE
Add BoringSSL support.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -701,7 +701,9 @@ conn *conn_new(const int sfd, enum conn_states init_state,
         c->sendmsg = ssl_sendmsg;
         c->write = ssl_write;
         c->ssl_enabled = true;
+#ifndef OPENSSL_IS_BORINGSSL
         SSL_set_info_callback(c->ssl, ssl_callback);
+#endif /* #ifndef OPENSSL_IS_BORINGSSL */
     } else
 #else
     // This must be NULL if TLS is not enabled.

--- a/tls.c
+++ b/tls.c
@@ -181,6 +181,10 @@ int ssl_init(void) {
     return 0;
 }
 
+/* BoringSSL rejects peer renegotiations by default.
+ * See https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md
+ */
+#ifndef OPENSSL_IS_BORINGSSL
 /*
  * This method is registered with each SSL connection and abort the SSL session
  * if a client initiates a renegotiation.
@@ -199,6 +203,7 @@ void ssl_callback(const SSL *s, int where, int ret) {
         return;
     }
 }
+#endif /* #ifndef OPENSSL_IS_BORINGSSL */
 
 /*
  * This method is invoked with every new successfully negotiated SSL session,


### PR DESCRIPTION
This won't really matter in *nix since OpenSSL/LibreSSL is shipped by default but in Windows, statically linking TLS library is preferred just like cURL and Chromium. Statically linking with Google's [BoringSSL](https://boringssl.googlesource.com/boringssl) generates at least 30% smaller executable than with OpenSSL.
[BoringSSL](https://boringssl.googlesource.com/boringssl) is an OpenSSL derivative and is mostly source-compatible, for the subset of OpenSSL retained. [SSL_in_before](https://www.openssl.org/docs/manmaster/man3/SSL_in_before.html) API used in memcached is not available in [BoringSSL](https://boringssl.googlesource.com/boringssl) but this can be disabled. memcached is using this API for rejecting peer renegotiations which is already the default in [BoringSSL](https://boringssl.googlesource.com/boringssl).

[boringssl_support_test.log](https://github.com/memcached/memcached/files/4465054/boringssl_support_test.log) contains **_make_**, **_make test_**, & **_SSL_TEST=1 make test_** logs.
