### PR TITLE
Fix error: unknown type name 'evutil_socket_t'

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -52,6 +52,11 @@
 #include <openssl/ssl.h>
 #endif
 
+/** libevent < release-2.0.3-alpha does not define/support evutil_socket_t */
+#ifndef evutil_socket_t
+#define evutil_socket_t int
+#endif /* #ifndef evutil_socket_t */
+
 /** Maximum length of a key. */
 #define KEY_MAX_LENGTH 250
 


### PR DESCRIPTION
memcached.c:106:1: error: unknown type name '**evutil_socket_t**'
 static void event_handler(const evutil_socket_t fd, const short which, void *arg);
 ^

#647 (3d0697e) introduced this build error.

libevent [1120f04f3eaafe98259ef286eecb648337b2214f](https://github.com/libevent/libevent/commit/1120f04f3eaafe98259ef286eecb648337b2214f) (**2007-11-25 16:52:53 -0500**) submit introduced **evutil_socket_t** change. Unfortunately, this is incompatible with older versions of libevent that memcached still supports (e.g. [1.4.13-stable](https://github.com/libevent/libevent/releases/tag/release-1.4.13-stable)).

Fix is just to define if not defined. No need to check for libevent version. **evutil_socket_t** is a definition in libevent.

See #654 for the issue details.