### PR TITLE
Improve sig_handler function

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -233,6 +233,12 @@ enum pause_thread_types {
     RESUME_WORKER_THREADS
 };
 
+enum stop_reasons {
+    NOT_STOP,
+    GRACE_STOP,
+    EXIT_NORMALLY
+};
+
 #define IS_TCP(x) (x == tcp_transport)
 #define IS_UDP(x) (x == udp_transport)
 


### PR DESCRIPTION
Wait until all currently running callbacks are finished and then
break the base loop.
Do not exit from sig_handler.
This approach has the advantage that we should be out of all
critical sections and memcached elegantly exits with return
from main.
Another advantage is that it does not matter which thread will
be assigned with executing sig handler because exit will be
always done from the root thread and thus we can avoid further
desynchronizations.

Resolves #669