### PR TITLE
Setrlimit fix

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -10052,7 +10052,7 @@ int main (int argc, char **argv) {
         exit(EX_OSERR);
     } else {
 #ifdef MEMCACHED_DEBUG
-        if (rlim.rlim_cur < settings.maxconns && rlim.rlim_max < settings.maxconns) {
+        if (rlim.rlim_cur < settings.maxconns || rlim.rlim_max < settings.maxconns) {
 #endif
         rlim.rlim_cur = settings.maxconns;
         rlim.rlim_max = settings.maxconns;

--- a/memcached.c
+++ b/memcached.c
@@ -10051,12 +10051,18 @@ int main (int argc, char **argv) {
         fprintf(stderr, "failed to getrlimit number of files\n");
         exit(EX_OSERR);
     } else {
+#ifdef MEMCACHED_DEBUG
+        if (rlim.rlim_cur < settings.maxconns && rlim.rlim_max < settings.maxconns) {
+#endif
         rlim.rlim_cur = settings.maxconns;
         rlim.rlim_max = settings.maxconns;
         if (setrlimit(RLIMIT_NOFILE, &rlim) != 0) {
             fprintf(stderr, "failed to set rlimit for open files. Try starting as root or requesting smaller maxconns value.\n");
             exit(EX_OSERR);
         }
+#ifdef MEMCACHED_DEBUG
+        }
+#endif
     }
 
     /* lose root privileges if we have them */


### PR DESCRIPTION
fixes https://github.com/memcached/memcached/issues/420

In debug builds, if the soft and hard limits are already greater than the enforced limit, skip calling setrlimit. Calling setrlimit is not allowed when calling under valgrind.

We can always set the the hard and soft limits outside the memcached process and not let memcached take this code path for debug builds.

