### PR TITLE
Use signal function instead of sigignore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -630,7 +630,6 @@ AC_CHECK_FUNCS(mlockall)
 AC_CHECK_FUNCS(getpagesizes)
 AC_CHECK_FUNCS(sysconf)
 AC_CHECK_FUNCS(memcntl)
-AC_CHECK_FUNCS(sigignore)
 AC_CHECK_FUNCS(clock_gettime)
 AC_CHECK_FUNCS(preadv)
 AC_CHECK_FUNCS(pread)
@@ -779,7 +778,7 @@ if test "$ICC" = "yes"
 then
    dnl ICC trying to be gcc.
    CFLAGS="$CFLAGS -diag-disable 187 -Wall -Werror"
-   AC_DEFINE([_GNU_SOURCE],[1],[find sigignore on Linux])
+   AC_DEFINE([_GNU_SOURCE],[1],[make sure IOV_MAX is defined])
 elif test "$GCC" = "yes"
 then
   GCC_VERSION=`$CC -dumpversion`
@@ -792,7 +791,7 @@ then
     CFLAGS="$CFLAGS -fno-strict-aliasing"
     ;;
   esac
-  AC_DEFINE([_GNU_SOURCE],[1],[find sigignore on Linux])
+  AC_DEFINE([_GNU_SOURCE],[1],[make sure IOV_MAX is defined])
 elif test "$SUNCC" = "yes"
 then
   CFLAGS="$CFLAGS -errfmt=error -errwarn -errshort=tags"

--- a/memcached.c
+++ b/memcached.c
@@ -8400,18 +8400,6 @@ static void sig_usrhandler(const int sig) {
     stop_main_loop = GRACE_STOP;
 }
 
-#ifndef HAVE_SIGIGNORE
-static int sigignore(int sig) {
-    struct sigaction sa = { .sa_handler = SIG_IGN, .sa_flags = 0 };
-
-    if (sigemptyset(&sa.sa_mask) == -1 || sigaction(sig, &sa, 0) == -1) {
-        return -1;
-    }
-    return 0;
-}
-#endif
-
-
 /*
  * On systems that supports multiple page sizes we may reduce the
  * number of TLB-misses by using the biggest available page size
@@ -10097,7 +10085,7 @@ int main (int argc, char **argv) {
     /* daemonize if requested */
     /* if we want to ensure our ability to dump core, don't chdir to / */
     if (do_daemonize) {
-        if (sigignore(SIGHUP) == -1) {
+        if (signal(SIGHUP, SIG_IGN) == SIG_ERR) {
             perror("Failed to ignore SIGHUP");
         }
         if (daemonize(maxcore, settings.verbose) == -1) {
@@ -10247,7 +10235,7 @@ int main (int argc, char **argv) {
      * ignore SIGPIPE signals; we can use errno == EPIPE if we
      * need that information
      */
-    if (sigignore(SIGPIPE) == -1) {
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
         perror("failed to ignore SIGPIPE; sigaction");
         exit(EX_OSERR);
     }


### PR DESCRIPTION
Sigignore has been marked as deprecated on Fedora rawhide and
signal function is used already on multiple places in memcached.c

fix #690

I also removed the static definition of function sigignore.
Looking forward for your opinion.