### PR TITLE
fix leak in merged resp/read buffers

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1204,6 +1204,8 @@ integers separated by a colon (treat this as a floating point number).
 |                       |         | by the server                             |
 | response_obj_oom      | 64u     | Connections closed by lack of memory      |
 | response_obj_count    | 64u     | Total response objects in use             |
+| response_obj_bytes    | 64u     | Total bytes used for resp. objects. is a  |
+|                       |         | subset of bytes from read_buf_bytes.      |
 | read_buf_count        | 64u     | Total read/resp buffers allocated         |
 | read_buf_bytes        | 64u     | Total read/resp buffer bytes allocated    |
 | read_buf_bytes_free   | 64u     | Total read/resp buffer bytes cached       |

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1203,6 +1203,7 @@ integers separated by a colon (treat this as a floating point number).
 | connection_structures | 32u     | Number of connection structures allocated |
 |                       |         | by the server                             |
 | response_obj_oom      | 64u     | Connections closed by lack of memory      |
+| response_obj_count    | 64u     | Total response objects in use             |
 | read_buf_count        | 64u     | Total read/resp buffers allocated         |
 | read_buf_bytes        | 64u     | Total read/resp buffer bytes allocated    |
 | read_buf_bytes_free   | 64u     | Total read/resp buffer bytes cached       |

--- a/memcached.c
+++ b/memcached.c
@@ -1060,12 +1060,12 @@ static mc_resp* resp_allocate(conn *c) {
             b->refcount++;
             resp->free = false;
             if (b->refcount == MAX_RESP_PER_BUNDLE) {
-                assert(b->next == NULL);
+                assert(b->prev == NULL);
                 // We only allocate off the head. Assign new head.
-                th->open_bundle = b->prev;
+                th->open_bundle = b->next;
                 // Remove ourselves from the list.
-                if (b->prev) {
-                    b->prev->next = 0;
+                if (b->next) {
+                    b->next->prev = 0;
                 }
             }
         }
@@ -1085,6 +1085,7 @@ static mc_resp* resp_allocate(conn *c) {
             b->prev = 0;
             th->open_bundle = b;
             resp = &b->r[0];
+            resp->free = false;
         } else {
             return NULL;
         }

--- a/memcached.c
+++ b/memcached.c
@@ -1066,6 +1066,7 @@ static mc_resp* resp_allocate(conn *c) {
                 // Remove ourselves from the list.
                 if (b->next) {
                     b->next->prev = 0;
+                    b->next = 0;
                 }
             }
         }

--- a/memcached.h
+++ b/memcached.h
@@ -303,6 +303,7 @@ struct slab_stats {
     X(idle_kicks) /* idle connections killed */ \
     X(response_obj_oom) \
     X(response_obj_count) \
+    X(response_obj_bytes) \
     X(read_buf_oom)
 
 #ifdef EXTSTORE

--- a/memcached.h
+++ b/memcached.h
@@ -302,6 +302,7 @@ struct slab_stats {
     X(auth_errors) \
     X(idle_kicks) /* idle connections killed */ \
     X(response_obj_oom) \
+    X(response_obj_count) \
     X(read_buf_oom)
 
 #ifdef EXTSTORE

--- a/t/stats.t
+++ b/t/stats.t
@@ -28,9 +28,9 @@ if (MemcachedTest::enabled_tls_testing()) {
     # when TLS is enabled, stats contains additional keys:
     #   - ssl_handshake_errors
     #   - time_since_server_cert_refresh
-    is(scalar(keys(%$stats)), 78, "expected count of stats values");
+    is(scalar(keys(%$stats)), 79, "expected count of stats values");
 } else {
-    is(scalar(keys(%$stats)), 76, "expected count of stats values");
+    is(scalar(keys(%$stats)), 77, "expected count of stats values");
 }
 
 # Test initial state

--- a/t/stats.t
+++ b/t/stats.t
@@ -28,9 +28,9 @@ if (MemcachedTest::enabled_tls_testing()) {
     # when TLS is enabled, stats contains additional keys:
     #   - ssl_handshake_errors
     #   - time_since_server_cert_refresh
-    is(scalar(keys(%$stats)), 79, "expected count of stats values");
+    is(scalar(keys(%$stats)), 80, "expected count of stats values");
 } else {
-    is(scalar(keys(%$stats)), 77, "expected count of stats values");
+    is(scalar(keys(%$stats)), 78, "expected count of stats values");
 }
 
 # Test initial state


### PR DESCRIPTION
the list grows toward next, not prev.

also didn't unmark free for first resp object. (thanks Prudhviraj!)

- [x] add response_obj_count counter back. I removed a little too much.
- [x] add response_obj_bytes counter. which should be size of bundles * rbuf_size.

I think this is right:
- bundles are only dangling if they're at max refcount.
- drop below max refcount and you get linked.
- if refcount hits 0, you must be linked or head.

paranoid there's a case where I'm not clearing prev/next so I'll check one more time.
edit: there wassss. wasn't clearing next.