### PR TITLE
Dockerfile - allow override of config opts

### DIFF
--- a/devtools/Dockerfile.alpine
+++ b/devtools/Dockerfile.alpine
@@ -1,12 +1,14 @@
 FROM alpine:latest
 
+ARG CONFIGURE_OPTS="--enable-seccomp"
+
 RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf perl-test-harness-utils
 
 ADD . /src
 WORKDIR /src
 
 RUN ./autogen.sh
-RUN ./configure --enable-seccomp
+RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
 
 CMD make test

--- a/devtools/Dockerfile.arch
+++ b/devtools/Dockerfile.arch
@@ -1,5 +1,7 @@
 FROM archlinux/base:latest
 
+ARG CONFIGURE_OPTS="--enable-seccomp"
+
 RUN pacman -Sy && pacman --noconfirm -S gcc automake autoconf libevent libseccomp git make perl
 RUN ln -s /usr/bin/core_perl/prove /usr/bin/prove
 
@@ -11,7 +13,7 @@ RUN autoheader
 RUN automake --gnu --add-missing
 RUN autoconf
 
-RUN ./configure --enable-seccomp
+RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
 
 CMD make test

--- a/devtools/Dockerfile.fedora
+++ b/devtools/Dockerfile.fedora
@@ -1,12 +1,14 @@
 FROM fedora:latest
 
+ARG CONFIGURE_OPTS="--enable-seccomp"
+
 RUN dnf install -y perl automake autoconf libseccomp-devel libevent-devel gcc make git
 
 ADD . /src
 WORKDIR /src
 
 RUN aclocal && autoheader && automake --foreign --add-missing && autoconf
-RUN ./configure --enable-seccomp
+RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
 
 CMD make test

--- a/devtools/Dockerfile.ubuntu
+++ b/devtools/Dockerfile.ubuntu
@@ -1,12 +1,14 @@
 FROM ubuntu:latest
 
+ARG CONFIGURE_OPTS="--enable-seccomp"
+
 RUN apt-get update && apt-get install -y build-essential automake1.11 autoconf libevent-dev libseccomp-dev git
 
 ADD . /src
 WORKDIR /src
 
 RUN ./autogen.sh
-RUN ./configure --enable-seccomp
+RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
 
 CMD make test


### PR DESCRIPTION
Extend Dockerfile to allow `./configure` options override during build time.

Example: 
```
docker build \
    --no-cache \
    --build-arg CONFIGURE_OPTS="--enable-seccomp --enable-static" \
    -t "memcached" \
    -f "devtools/Dockerfile.ubuntu" .
```