### PR TITLE
extstore: support direct I/O and async I/O

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,8 @@ AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
 AC_ARG_ENABLE(tls,
   [AS_HELP_STRING([--enable-tls], [Enable Transport Layer Security EXPERIMENTAL ])])
 
+AC_ARG_ENABLE(liburing,
+  [AS_HELP_STRING([--enable-liburing], [Enable liburing])])
 
 AC_ARG_ENABLE(asan,
   [AS_HELP_STRING([--enable-asan], [Compile with ASAN EXPERIMENTAL ])])
@@ -205,6 +207,10 @@ if test "x$enable_tls" = "xyes"; then
     AC_DEFINE([TLS],1,[Set to nonzero if you want to enable TLS])
 fi
 
+if test "x$enable_liburing" = "xyes"; then
+    AC_DEFINE([LIBURING],1,[Set to nonzero if you want to enable liburing])
+fi
+
 if test "x$enable_asan" = "xyes"; then
     AC_DEFINE([ASAN],1,[Set to nonzero if you want to compile using ASAN])
 fi
@@ -223,6 +229,7 @@ AM_CONDITIONAL([ENABLE_SASL],[test "$enable_sasl" = "yes"])
 AM_CONDITIONAL([ENABLE_EXTSTORE],[test "$enable_extstore" != "no"])
 AM_CONDITIONAL([ENABLE_ARM_CRC32],[test "$enable_arm_crc32" = "yes"])
 AM_CONDITIONAL([ENABLE_TLS],[test "$enable_tls" = "yes"])
+AM_CONDITIONAL([ENABLE_LIBURING],[test "$enable_liburing" = "yes"])
 AM_CONDITIONAL([ENABLE_ASAN],[test "$enable_asan" = "yes"])
 AM_CONDITIONAL([ENABLE_STATIC],[test "$enable_static" = "yes"])
 AM_CONDITIONAL([DISABLE_UNIX_SOCKET],[test "$enable_unix_socket" = "no"])
@@ -492,6 +499,99 @@ if test "x$enable_tls" = "xyes"; then
     fi
   fi
 fi
+
+tryliburingdir=""
+AC_ARG_WITH(liburing,
+       [  --with-liburing=PATH     Specify path to liburing installation ],
+       [
+                if test "x$withval" != "xno" ; then
+                        tryliburingdir=$withval
+                fi
+       ]
+)
+
+dnl ----------------------------------------------------------------------------
+dnl liburing detection.  swiped from libssl.  modified for liburing detection.
+
+LIBURING_URL=https://github.com/axboe/liburing
+if test "x$enable_liburing" = "xyes"; then
+  AC_CACHE_CHECK([for liburing directory], ac_cv_liburing_dir, [
+    saved_LIBS="$LIBS"
+    saved_LDFLAGS="$LDFLAGS"
+    saved_CPPFLAGS="$CPPFLAGS"
+    le_found=no
+    for ledir in $tryliburingdir "" $prefix /usr/local ; do
+      LDFLAGS="$saved_LDFLAGS"
+      LIBS="-luring $saved_LIBS"
+
+      # Skip the directory if it isn't there.
+      if test ! -z "$ledir" -a ! -d "$ledir" ; then
+         continue;
+      fi
+      if test ! -z "$ledir" ; then
+        if test -d "$ledir/lib" ; then
+          LDFLAGS="-L$ledir/lib $LDFLAGS"
+        else
+          LDFLAGS="-L$ledir $LDFLAGS"
+        fi
+        if test -d "$ledir/include" ; then
+          CPPFLAGS="-I$ledir/include $CPPFLAGS"
+        else
+          CPPFLAGS="-I$ledir $CPPFLAGS"
+        fi
+      fi
+      # Can I compile and link it?
+      AC_TRY_LINK([
+#include <sys/time.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <liburing.h>
+         ], [
+  struct io_uring ring;
+  io_uring_queue_init(4, &ring, 0);
+         ],[ liburing_linked=yes ], [ liburing_linked=no ])
+      if test $liburing_linked = yes; then
+         if test ! -z "$ledir" ; then
+           ac_cv_liburing_dir=$ledir
+           _myos=`echo $target_os | cut -f 1 -d .`
+           AS_IF(test "$SUNCC" = "yes" -o "x$_myos" = "xsolaris2",
+                 [saved_LDFLAGS="$saved_LDFLAGS -Wl,-R$ledir/lib"],
+                 [AS_IF(test "$GCC" = "yes",
+                       [saved_LDFLAGS="$saved_LDFLAGS -Wl,-rpath,$ledir/lib"])])
+         else
+           ac_cv_liburing_dir="(system)"
+         fi
+         le_found=yes
+         break
+      fi
+    done
+    LIBS="$saved_LIBS"
+    LDFLAGS="$saved_LDFLAGS"
+    CPPFLAGS="$saved_CPPFLAGS"
+    if test $le_found = no ; then
+      AC_MSG_ERROR([liburing is required.  You can get it from $LIBURING_URL
+
+        If it's already installed, specify its path using --with-liburing=/dir/
+  ])
+    fi
+  ])
+  LIBS="-luring $LIBS"
+  if test $ac_cv_liburing_dir != "(system)"; then
+    if test -d "$ac_cv_liburing_dir/lib" ; then
+      LDFLAGS="-L$ac_cv_liburing_dir/lib $LDFLAGS"
+      le_libdir="$ac_cv_liburing_dir/lib"
+    else
+      LDFLAGS="-L$ac_cv_liburing_dir $LDFLAGS"
+      le_libdir="$ac_cv_liburing_dir"
+    fi
+    if test -d "$ac_cv_liburing_dir/include" ; then
+      CPPFLAGS="-I$ac_cv_liburing_dir/include $CPPFLAGS"
+    else
+      CPPFLAGS="-I$ac_cv_liburing_dir $CPPFLAGS"
+    fi
+  fi
+fi
+
 
 if test "x$enable_static" = "xyes"; then
   LIBS="$LIBS -ldl"

--- a/extstore.h
+++ b/extstore.h
@@ -40,6 +40,7 @@ struct extstore_stats {
 
 enum extstore_io_engine {
     EXTSTORE_IO_ENGINE_SYNC = 0,
+    EXTSTORE_IO_ENGINE_IO_URING,
 };
 
 // TODO: Temporary configuration structure. A "real" library should have an
@@ -56,7 +57,7 @@ struct extstore_conf {
     unsigned int io_depth; // with normal I/O, hits locks less. req'd for AIO
     unsigned int io_align; // boundary to which memcached will align direct I/O units
     unsigned int max_io_size; // maximum size in bytes of a single direct I/O
-    enum extstore_io_engine io_engine; // "sync"
+    enum extstore_io_engine io_engine; // "sync" or "io_uring"
     bool direct; // use direct I/O (O_DIRECT)
 };
 
@@ -101,6 +102,7 @@ struct _obj_io {
 enum extstore_res {
     EXTSTORE_INIT_BAD_WBUF_SIZE = 1,
     EXTSTORE_INIT_BAD_IO_SIZE,
+    EXTSTORE_INIT_IO_URING_FAIL,
     EXTSTORE_INIT_NEED_MORE_WBUF,
     EXTSTORE_INIT_NEED_MORE_BUCKETS,
     EXTSTORE_INIT_PAGE_WBUF_ALIGNMENT,

--- a/extstore.h
+++ b/extstore.h
@@ -54,7 +54,10 @@ struct extstore_conf {
     unsigned int wbuf_count; // this might get locked to "2 per active page"
     unsigned int io_threadcount;
     unsigned int io_depth; // with normal I/O, hits locks less. req'd for AIO
+    unsigned int io_align; // boundary to which memcached will align direct I/O units
+    unsigned int max_io_size; // maximum size in bytes of a single direct I/O
     enum extstore_io_engine io_engine; // "sync"
+    bool direct; // use direct I/O (O_DIRECT)
 };
 
 struct extstore_conf_file {
@@ -97,6 +100,7 @@ struct _obj_io {
 
 enum extstore_res {
     EXTSTORE_INIT_BAD_WBUF_SIZE = 1,
+    EXTSTORE_INIT_BAD_IO_SIZE,
     EXTSTORE_INIT_NEED_MORE_WBUF,
     EXTSTORE_INIT_NEED_MORE_BUCKETS,
     EXTSTORE_INIT_PAGE_WBUF_ALIGNMENT,

--- a/memcached.h
+++ b/memcached.h
@@ -624,6 +624,7 @@ typedef struct {
     cache_t *io_cache;          /* IO objects */
 #ifdef EXTSTORE
     void *storage;              /* data object for storage system */
+    void *storage_ctx;          /* thread-specific data object for storage system */
 #endif
     logger *l;                  /* logger buffer */
     void *lru_bump_buf;         /* async LRU bump buffer */
@@ -869,6 +870,7 @@ void redispatch_conn(conn *c);
 void dispatch_conn_new(int sfd, enum conn_states init_state, int event_flags, int read_buffer_size,
     enum network_transport transport, void *ssl);
 void sidethread_conn_close(conn *c);
+struct event_base *event_base_new_with_nolock_config(void);
 
 /* Lock wrappers for cache functions that are called from main loop. */
 enum delta_result_type add_delta(conn *c, const char *key,

--- a/storage.c
+++ b/storage.c
@@ -1277,10 +1277,12 @@ int storage_read_config(void *conf, char **subopt) {
                 fprintf(stderr, "Missing ext_io_engine argument\n");
                 return 1;
             }
-            if (strcmp(subopts_value, "sync") == 0) {
+            if (strcmp(subopts_value, "io_uring") == 0) {
+                ext_cf->io_engine = EXTSTORE_IO_ENGINE_IO_URING;
+            } else if (strcmp(subopts_value, "sync") == 0) {
                 ext_cf->io_engine = EXTSTORE_IO_ENGINE_SYNC;
             } else {
-                fprintf(stderr, "Unknown ext_io_engine option\n");
+                fprintf(stderr, "Unknown ext_io_engine option (sync or io_uring)\n");
                 return 1;
             }
             break;

--- a/storage.c
+++ b/storage.c
@@ -227,7 +227,12 @@ static void _storage_get_item_cb(void *e, obj_io *io, int ret) {
     // All IO's have returned, lets re-attach this connection to our original
     // thread.
     if (p->q->count == 0) {
-        redispatch_conn(c);
+        if (io->offload) {
+            redispatch_conn(c);
+        } else {
+            //conn_worker_readd(c);
+            redispatch_conn(c);
+        }
     }
 }
 
@@ -364,8 +369,10 @@ int storage_get_item(conn *c, item *it, mc_resp *resp) {
 }
 
 void storage_submit_cb(void *ctx, void *stack) {
+    LIBEVENT_THREAD *thread = ctx;
+
     // Don't need to do anything special for extstore.
-    extstore_submit(ctx, stack);
+    extstore_submit(thread->storage_ctx, stack);
 }
 
 static void recache_or_free(io_pending_t *pending) {
@@ -464,7 +471,7 @@ void storage_finalize_cb(io_pending_t *pending) {
  * WRITE FLUSH THREAD
  */
 
-static int storage_write(void *storage, const int clsid, const int item_age) {
+static int storage_write(struct extstore_context *ctx, const int clsid, const int item_age) {
     int did_moves = 0;
     struct lru_pull_tail_return it_info;
 
@@ -502,7 +509,7 @@ static int storage_write(void *storage, const int clsid, const int item_age) {
             assert(it->refcount >= 2);
             // NOTE: write bucket vs free page bucket will disambiguate once
             // lowttl feature is better understood.
-            if (extstore_write_request(storage, bucket, bucket, &io) == 0) {
+            if (extstore_write_request(ctx, bucket, bucket, &io) == 0) {
                 // cuddle the hash value into the time field so we don't have
                 // to recalculate it.
                 item *buf_it = (item *) io.buf;
@@ -533,7 +540,7 @@ static int storage_write(void *storage, const int clsid, const int item_age) {
                 // crc what we copied so we can do it sequentially.
                 buf_it->it_flags &= ~ITEM_LINKED;
                 buf_it->exptime = crc32c(0, (char*)io.buf+STORE_OFFSET, orig_ntotal-STORE_OFFSET);
-                extstore_write(storage, &io);
+                extstore_write(ctx->e, &io);
                 item_hdr *hdr = (item_hdr *) ITEM_data(hdr_it);
                 hdr->page_version = io.page_version;
                 hdr->page_id = io.page_id;
@@ -567,6 +574,8 @@ static pthread_mutex_t storage_write_plock;
 
 static void *storage_write_thread(void *arg) {
     void *storage = arg;
+    void *storage_ctx;
+    struct event_base *base;
     // NOTE: ignoring overflow since that would take years of uptime in a
     // specific load pattern of never going to sleep.
     unsigned int backoff[MAX_NUMBER_OF_SLAB_CLASSES] = {0};
@@ -577,6 +586,9 @@ static void *storage_write_thread(void *arg) {
         fprintf(stderr, "Failed to allocate logger for storage compaction thread\n");
         abort();
     }
+
+    base = event_base_new_with_nolock_config();
+    storage_ctx = storage_init_context(storage, base);
 
     pthread_mutex_lock(&storage_write_plock);
 
@@ -613,7 +625,7 @@ static void *storage_write_thread(void *arg) {
                 } else {
                     item_age = settings.ext_item_age;
                 }
-                if (storage_write(storage, x, item_age)) {
+                if (storage_write(storage_ctx, x, item_age)) {
                     chunks_free++; // Allow stopping if we've done enough this loop
                     did_move = true;
                     do_sleep = false;
@@ -637,6 +649,7 @@ static void *storage_write_thread(void *arg) {
             usleep(to_sleep);
             to_sleep *= 2;
         }
+        event_base_loop(base, EVLOOP_NONBLOCK);
         pthread_mutex_lock(&storage_write_plock);
     }
     return NULL;
@@ -766,9 +779,9 @@ struct storage_compact_wrap {
     bool miss; // version flipped out from under us
 };
 
-static void storage_compact_readback(void *storage, logger *l,
+static void storage_compact_readback(struct extstore_context *ctx, logger *l,
         bool drop_unread, char *readback_buf,
-        uint32_t page_id, uint64_t page_version, uint64_t read_size) {
+        uint32_t page_id, uint64_t page_version, uint64_t read_size, struct event_base *base) {
     uint64_t offset = 0;
     unsigned int rescues = 0;
     unsigned int lost = 0;
@@ -799,7 +812,7 @@ static void storage_compact_readback(void *storage, logger *l,
                 hdr = (item_hdr *)ITEM_data(hdr_it);
                 if (hdr->page_id == page_id && hdr->page_version == page_version) {
                     // Item header is still completely valid.
-                    extstore_delete(storage, page_id, page_version, 1, ntotal);
+                    extstore_delete(ctx->e, page_id, page_version, 1, ntotal);
                     // drop inactive items.
                     if (drop_unread && GET_LRU(hdr_it->slabs_clsid) == COLD_LRU) {
                         do_write = false;
@@ -817,13 +830,14 @@ static void storage_compact_readback(void *storage, logger *l,
                 io.len = ntotal;
                 io.mode = OBJ_IO_WRITE;
                 for (tries = 10; tries > 0; tries--) {
-                    if (extstore_write_request(storage, PAGE_BUCKET_COMPACT, PAGE_BUCKET_COMPACT, &io) == 0) {
+                    if (extstore_write_request(ctx, PAGE_BUCKET_COMPACT, PAGE_BUCKET_COMPACT, &io) == 0) {
                         memcpy(io.buf, it, io.len);
-                        extstore_write(storage, &io);
+                        extstore_write(ctx->e, &io);
                         do_update = true;
                         break;
                     } else {
                         usleep(1000);
+                        event_base_loop(base, EVLOOP_NONBLOCK);
                     }
                 }
 
@@ -863,15 +877,16 @@ static void storage_compact_readback(void *storage, logger *l,
 static void _storage_compact_cb(void *e, obj_io *io, int ret) {
     struct storage_compact_wrap *wrap = (struct storage_compact_wrap *)io->data;
     assert(wrap->submitted == true);
-
-    pthread_mutex_lock(&wrap->lock);
+    if (io->offload)
+        pthread_mutex_lock(&wrap->lock);
 
     if (ret < 1) {
         wrap->miss = true;
     }
     wrap->done = true;
 
-    pthread_mutex_unlock(&wrap->lock);
+    if (io->offload)
+        pthread_mutex_unlock(&wrap->lock);
 }
 
 // TODO: hoist the storage bits from lru_maintainer_thread in here.
@@ -879,6 +894,8 @@ static void _storage_compact_cb(void *e, obj_io *io, int ret) {
 // I guess it's only COLD. that's probably fine.
 static void *storage_compact_thread(void *arg) {
     void *storage = arg;
+    void *storage_ctx;
+    struct event_base *base;
     useconds_t to_sleep = MAX_STORAGE_COMPACT_SLEEP;
     bool compacting = false;
     uint64_t page_version = 0;
@@ -894,6 +911,9 @@ static void *storage_compact_thread(void *arg) {
         fprintf(stderr, "Failed to allocate logger for storage compaction thread\n");
         abort();
     }
+
+    base = event_base_new_with_nolock_config();
+    storage_ctx = storage_init_context(storage, base);
 
     readback_buf = malloc(settings.ext_wbuf_size);
     if (readback_buf == NULL) {
@@ -919,6 +939,7 @@ static void *storage_compact_thread(void *arg) {
             extstore_run_maint(storage);
             usleep(to_sleep);
         }
+        event_base_loop(base, EVLOOP_NONBLOCK);
         pthread_mutex_lock(&storage_compact_plock);
 
         if (!compacting && storage_compact_check(storage, l,
@@ -940,7 +961,7 @@ static void *storage_compact_thread(void *arg) {
                 wrap.submitted = true;
                 wrap.miss = false;
 
-                extstore_submit(storage, &wrap.io);
+                extstore_submit(storage_ctx, &wrap.io);
             } else if (wrap.miss) {
                 LOGGER_LOG(l, LOG_SYSEVENTS, LOGGER_COMPACT_ABORT,
                         NULL, page_id);
@@ -950,8 +971,8 @@ static void *storage_compact_thread(void *arg) {
             } else if (wrap.submitted && wrap.done) {
                 LOGGER_LOG(l, LOG_SYSEVENTS, LOGGER_COMPACT_READ_START,
                         NULL, page_id, page_offset);
-                storage_compact_readback(storage, l, drop_unread,
-                        readback_buf, page_id, page_version, settings.ext_wbuf_size);
+                storage_compact_readback(storage_ctx, l, drop_unread,
+                        readback_buf, page_id, page_version, settings.ext_wbuf_size, base);
                 page_offset += settings.ext_wbuf_size;
                 wrap.done = false;
                 wrap.submitted = false;
@@ -1122,6 +1143,7 @@ void *storage_init_config(struct settings *s) {
     cf->ext_cf.wbuf_size = settings.ext_wbuf_size;
     cf->ext_cf.io_threadcount = settings.ext_io_threadcount;
     cf->ext_cf.io_depth = 1;
+    cf->ext_cf.io_engine = EXTSTORE_IO_ENGINE_SYNC;
     cf->ext_cf.page_buckets = 4;
     cf->ext_cf.wbuf_count = cf->ext_cf.page_buckets;
 
@@ -1139,6 +1161,7 @@ int storage_read_config(void *conf, char **subopt) {
         EXT_WBUF_SIZE,
         EXT_THREADS,
         EXT_IO_DEPTH,
+        EXT_IO_ENGINE,
         EXT_PATH,
         EXT_ITEM_SIZE,
         EXT_ITEM_AGE,
@@ -1156,6 +1179,7 @@ int storage_read_config(void *conf, char **subopt) {
         [EXT_WBUF_SIZE] = "ext_wbuf_size",
         [EXT_THREADS] = "ext_threads",
         [EXT_IO_DEPTH] = "ext_io_depth",
+        [EXT_IO_ENGINE] = "ext_io_engine",
         [EXT_PATH] = "ext_path",
         [EXT_ITEM_SIZE] = "ext_item_size",
         [EXT_ITEM_AGE] = "ext_item_age",
@@ -1214,6 +1238,18 @@ int storage_read_config(void *conf, char **subopt) {
             }
             if (!safe_strtoul(subopts_value, &ext_cf->io_depth)) {
                 fprintf(stderr, "could not parse argument to ext_io_depth\n");
+                return 1;
+            }
+            break;
+        case EXT_IO_ENGINE:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_io_engine argument\n");
+                return 1;
+            }
+            if (strcmp(subopts_value, "sync") == 0) {
+                ext_cf->io_engine = EXTSTORE_IO_ENGINE_SYNC;
+            } else {
+                fprintf(stderr, "Unknown ext_io_engine option\n");
                 return 1;
             }
             break;
@@ -1374,6 +1410,27 @@ void *storage_init(void *conf) {
     }
 
     return storage;
+}
+
+void *storage_init_context(void *e, struct event_base *base) {
+    enum extstore_res eres;
+    struct extstore_context *ctx = extstore_init_context(e, &eres);
+
+    if (eres) {
+        fprintf(stderr, "Failed to initialize external storage for each thread: %s\n",
+            extstore_err(eres));
+        abort();
+    }
+
+    if (ctx) {
+        event_base_set(base, &ctx->event);
+        if (event_add(&ctx->event, 0) == -1) {
+            fprintf(stderr, "Can't monitor libevent storage\n");
+            abort();
+        }
+    }
+
+    return ctx;
 }
 
 #endif

--- a/storage.h
+++ b/storage.h
@@ -36,6 +36,7 @@ void *storage_init_config(struct settings *s);
 int storage_read_config(void *conf, char **subopt);
 int storage_check_config(void *conf);
 void *storage_init(void *conf);
+void *storage_init_context(void *e, struct event_base *base);
 
 // Ignore pointers and header bits from the CRC
 #define STORE_OFFSET offsetof(item, nbytes)

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -307,6 +307,10 @@ sub new_memcached {
         push(@unixsockets, $file);
     }
 
+    if ($ENV{MEMCACHED_EXTRA_ARGS}) {
+        $args .= " $ENV{MEMCACHED_EXTRA_ARGS}";
+    }
+
     my $childpid = fork();
 
     my $exe = get_memcached_exe();

--- a/util.h
+++ b/util.h
@@ -41,3 +41,8 @@ extern uint64_t ntohll(uint64_t);
  */
 void vperror(const char *fmt, ...)
     __gcc_attribute__ ((format (printf, 1, 2)));
+
+#define mc_powerof2(n) ((n) && !(((n) - 1) & (n)))
+#define mc_rounddown(x, y) ((x) - ((x) % (y)))
+#define mc_roundup(x, y) ((((x) + ((y) - 1)) / (y)) * (y))
+#define mc_is_aligned(x, a) (((x) & ((typeof(x))(a) - 1)) == 0)


### PR DESCRIPTION
This adds support for direct I/O and async I/O on extstore.

With `-o ext_direct` at startup, memcached opens the extstore files with
the O_DIRECT flag.  When direct I/O is used, extstore reads and writes
bypass the operating system caches.

To build with async I/O support you will have to install io_uring library
(http://git.kernel.dk/cgit/liburing/) and ./configure --enable-liburing.
With `-o ext_io_engine=io_uring` and I/O depth > 1
(e.g. `-o ext_io_depth=64), the IO threads execute each IO object on their
queues in asynchronous manner.

This maximizes I/O throughput with smaller number of the IO threads when
direct I/O is used.