### PR TITLE
arm64: Re-add arm crc32c hw acceleration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = memcached-debug sizes testapp timedrun
 
 BUILT_SOURCES=
 
-testapp_SOURCES = testapp.c util.c util.h stats_prefix.c stats_prefix.h jenkins_hash.c murmur3_hash.c hash.h cache.c
+testapp_SOURCES = testapp.c util.c util.h stats_prefix.c stats_prefix.h jenkins_hash.c murmur3_hash.c hash.h cache.c crc32c.c
 
 timedrun_SOURCES = timedrun.c
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,17 +75,16 @@ AS_IF([test "$ICC" = "yes" -o "$GCC" = "yes"],
     AS_IF(test "$CLANG" = "no",[CFLAGS="$CFLAGS -pthread"])
 ])
 
+dnl clang will error .arch_extension crc32 assembler directives to allow
+dnl assembling crc instructions without this
+AS_IF(test "$CLANG" = "yes",[CFLAGS="$CFLAGS -Wno-language-extension-token"])
+
 if test "$ICC" = "no"; then
    AC_PROG_CC_C99
 fi
 
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
-
-dnl ARM crc32 optimization is disabled until we have hardware for an automated
-dnl regression test.
-dnl AC_ARG_ENABLE(arm_crc32,
-dnl  [AS_HELP_STRING([--enable-arm-crc32], [Enable ARMv8 CRC32 instructions])])
 
 AC_ARG_ENABLE(extstore,
   [AS_HELP_STRING([--disable-extstore], [Disable external storage (extstore)])])
@@ -204,10 +203,6 @@ fi
 
 if test "x$enable_tls" = "xyes"; then
     AC_DEFINE([TLS],1,[Set to nonzero if you want to enable TLS])
-fi
-
-if test "x$enable_arm_crc32" = "xyes"; then
-    AC_DEFINE([ARM_CRC32],1,[Set to nonzero if you want to enable ARMv8 crc32])
 fi
 
 if test "x$enable_asan" = "xyes"; then

--- a/crc32c.h
+++ b/crc32c.h
@@ -17,4 +17,7 @@ extern crc_func crc32c;
 
 void crc32c_init(void);
 
+// Expose a prototype for the crc32c software variant simply for testing purposes
+uint32_t crc32c_sw(uint32_t crc, void const *buf, size_t len);
+
 #endif    /* CRC32C_H */

--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -1,4 +1,3 @@
-%bcond_with arm_crc32
 %bcond_with extstore
 %bcond_with seccomp
 %bcond_with sasl
@@ -66,7 +65,6 @@ web applications by alleviating database load.
 
 %build
 %configure \
-  %{?with_arm_crc32:--enable-arm-crc32} \
   %{?with_extstore:--enable-extstore} \
   %{?with_seccomp:--enable-seccomp} \
   %{?with_sasl:--enable-sasl} \

--- a/testapp.c
+++ b/testapp.c
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "cache.h"
+#include "crc32c.h"
 #include "hash.h"
 #include "jenkins_hash.h"
 #include "stats_prefix.h"
@@ -842,6 +843,34 @@ static enum test_return test_issue_92(void) {
     close_conn();
     con = connect_server("127.0.0.1", port, false, enable_ssl);
     assert(con);
+    return TEST_PASS;
+}
+
+static enum test_return test_crc32c(void) {
+    uint32_t crc_hw, crc_sw;
+
+    char buffer[256];
+    for (int x = 0; x < 256; x++)
+        buffer[x] = x;
+
+    /* Compare harware to software implementaiton */
+    crc_hw = crc32c(0, buffer, 256);
+    crc_sw = crc32c_sw(0, buffer, 256);
+    assert(crc_hw == 0x9c44184b);
+    assert(crc_sw == 0x9c44184b);
+
+    /* Test that passing a CRC in also works */
+    crc_hw = crc32c(crc_hw, buffer, 256);
+    crc_sw = crc32c_sw(crc_sw, buffer, 256);
+    assert(crc_hw == 0xae10ee5a);
+    assert(crc_sw == 0xae10ee5a);
+
+    /* Test odd offsets/sizes */
+    crc_hw = crc32c(crc_hw, buffer + 1, 256 - 2);
+    crc_sw = crc32c_sw(crc_sw, buffer + 1, 256 - 2);
+    assert(crc_hw == 0xed37b906);
+    assert(crc_sw == 0xed37b906);
+
     return TEST_PASS;
 }
 
@@ -2243,6 +2272,7 @@ struct testcase testcases[] = {
     { "issue_44", test_issue_44 },
     { "vperror", test_vperror },
     { "issue_101", test_issue_101 },
+    { "crc32c", test_crc32c },
     /* The following tests all run towards the same server */
     { "start_server", start_memcached_server },
     { "issue_92", test_issue_92 },
@@ -2308,6 +2338,8 @@ int main(int argc, char **argv)
        the definition of settings struct from memcached.h */
     hash = jenkins_hash;
     stats_prefix_init(':');
+
+    crc32c_init();
 
     for (num_cases = 0; testcases[num_cases].description; num_cases++) {
         /* Just counting */


### PR DESCRIPTION
Use the .arch_extension directive so that a config options and
special cflags aren't required. Add a few tests for both the
software and hardware implementations

tested with both clang and llvm on Ubuntu