### PR TITLE
generalized deferred IO queue

### DIFF
--- a/crawler.c
+++ b/crawler.c
@@ -6,6 +6,7 @@
 
 /* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 #include "memcached.h"
+#include "storage.h"
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/resource.h>
@@ -186,9 +187,7 @@ static void crawler_expired_eval(crawler_module_t *cm, item *search, uint32_t hv
 #ifdef EXTSTORE
     bool is_valid = true;
     if (search->it_flags & ITEM_HDR) {
-        item_hdr *hdr = (item_hdr *)ITEM_data(search);
-        if (extstore_check(storage, hdr->page_id, hdr->page_version) != 0)
-            is_valid = false;
+        is_valid = storage_validate_item(storage, search);
     }
 #endif
     if ((search->exptime != 0 && search->exptime < current_time)

--- a/items.c
+++ b/items.c
@@ -2,8 +2,8 @@
 #include "memcached.h"
 #include "bipbuffer.h"
 #include "slab_automove.h"
-#ifdef EXTSTORE
 #include "storage.h"
+#ifdef EXTSTORE
 #include "slab_automove_extstore.h"
 #endif
 #include <sys/stat.h>

--- a/items.h
+++ b/items.h
@@ -84,16 +84,3 @@ void lru_maintainer_pause(void);
 void lru_maintainer_resume(void);
 
 void *lru_bump_buf_create(void);
-
-#ifdef EXTSTORE
-#define STORAGE_delete(e, it) \
-    do { \
-        if (it->it_flags & ITEM_HDR) { \
-            item_hdr *hdr = (item_hdr *)ITEM_data(it); \
-            extstore_delete(e, hdr->page_id, hdr->page_version, \
-                    1, ITEM_ntotal(it)); \
-        } \
-    } while (0)
-#else
-#define STORAGE_delete(...)
-#endif

--- a/memcached.h
+++ b/memcached.h
@@ -43,7 +43,6 @@
 #include "logger.h"
 
 #ifdef EXTSTORE
-#include "extstore.h"
 #include "crc32c.h"
 #endif
 
@@ -925,11 +924,6 @@ bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 void stats_reset(void);
 void process_stat_settings(ADD_STAT add_stats, void *c);
 void process_stats_conns(ADD_STAT add_stats, void *c);
-
-#ifdef EXTSTORE
-void process_extstore_stats(ADD_STAT add_stats, conn *c);
-int _get_extstore(conn *c, item *it, mc_resp *resp);
-#endif
 
 #if HAVE_DROP_PRIVILEGES
 extern void setup_privilege_violations_handler(void);

--- a/memcached.h
+++ b/memcached.h
@@ -670,15 +670,9 @@ typedef struct conn conn;
 #define IO_QUEUE_EXTSTORE 1
 typedef struct _io_pending_t {
     struct _io_pending_t *next;
-    void *io_ctx;
     conn *c;
-    item *hdr_it;             /* original header item. */
     mc_resp *resp;            /* associated response object */
-    unsigned int iovec_data;  /* specific index of data iovec */
-    bool noreply;             /* whether the response had noreply set */
-    bool miss;                /* signal a miss to unlink hdr_it */
-    bool badcrc;              /* signal a crc failure */
-    bool active;              /* tells if IO was dispatched or not */
+    char data[120];
 } io_pending_t;
 
 typedef void (*io_queue_add_cb)(void *ctx, io_pending_t *pending);

--- a/memcached.h
+++ b/memcached.h
@@ -611,8 +611,8 @@ typedef struct {
     struct conn_queue *new_conn_queue; /* queue of new connections to handle */
     cache_t *rbuf_cache;        /* static-sized read buffers */
     mc_resp_bundle *open_bundle;
-#ifdef EXTSTORE
     cache_t *io_cache;          /* IO objects */
+#ifdef EXTSTORE
     void *storage;              /* data object for storage system */
 #endif
     logger *l;                  /* logger buffer */
@@ -665,7 +665,7 @@ struct _mc_resp_bundle {
 };
 
 typedef struct conn conn;
-#ifdef EXTSTORE
+
 #define IO_QUEUE_NONE 0
 #define IO_QUEUE_EXTSTORE 1
 typedef struct _io_pending_t {
@@ -690,7 +690,7 @@ typedef struct {
     io_queue_free_cb free_cb;
     int type;
 } io_queue_t;
-#endif
+
 /**
  * The structure representing a connection into memcached.
  */
@@ -736,11 +736,9 @@ struct conn {
     /* data for the swallow state */
     int    sbytes;    /* how many bytes to swallow */
 
-#ifdef EXTSTORE
-    int io_pending;
+    int io_pending; /* number of deferred IO requests */
     io_queue_t io_queues[3]; /* set of deferred IO queues. */
     bool io_queued; /* IO's were queued. */
-#endif
 #ifdef EXTSTORE
     unsigned int recache_counter;
 #endif
@@ -815,10 +813,8 @@ enum delta_result_type do_add_delta(conn *c, const char *key,
                                     uint64_t *cas, const uint32_t hv,
                                     item **it_ret);
 enum store_item_type do_store_item(item *item, int comm, conn* c, const uint32_t hv);
-#ifdef EXTSTORE
 void conn_io_queue_add(conn *c, int type, void *ctx, io_queue_add_cb cb, io_queue_free_cb free_cb);
 io_queue_t *conn_io_queue_get(conn *c, int type);
-#endif
 conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size,
     enum network_transport transport, struct event_base *base, void *ssl);
 

--- a/proto_bin.c
+++ b/proto_bin.c
@@ -6,6 +6,7 @@
 
 #include "memcached.h"
 #include "proto_bin.h"
+#include "storage.h"
 #ifdef TLS
 #include "tls.h"
 #endif
@@ -523,7 +524,7 @@ static void process_bin_get_or_touch(conn *c, char *extbuf) {
             /* Add the data minus the CRLF */
 #ifdef EXTSTORE
             if (it->it_flags & ITEM_HDR) {
-                if (_get_extstore(c, it, c->resp) != 0) {
+                if (storage_get_item(c, it, c->resp) != 0) {
                     pthread_mutex_lock(&c->thread->stats.mutex);
                     c->thread->stats.get_oom_extstore++;
                     pthread_mutex_unlock(&c->thread->stats.mutex);

--- a/proto_text.c
+++ b/proto_text.c
@@ -6,6 +6,7 @@
 #include "memcached.h"
 #include "proto_text.h"
 #include "authfile.h"
+#include "storage.h"
 #ifdef TLS
 #include "tls.h"
 #endif
@@ -520,7 +521,7 @@ static inline void process_get_command(conn *c, token_t *tokens, size_t ntokens,
 
 #ifdef EXTSTORE
                   if (it->it_flags & ITEM_HDR) {
-                      if (_get_extstore(c, it, resp) != 0) {
+                      if (storage_get_item(c, it, resp) != 0) {
                           pthread_mutex_lock(&c->thread->stats.mutex);
                           c->thread->stats.get_oom_extstore++;
                           pthread_mutex_unlock(&c->thread->stats.mutex);
@@ -1165,7 +1166,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
         if (of.value) {
 #ifdef EXTSTORE
             if (it->it_flags & ITEM_HDR) {
-                if (_get_extstore(c, it, resp) != 0) {
+                if (storage_get_item(c, it, resp) != 0) {
                     pthread_mutex_lock(&c->thread->stats.mutex);
                     c->thread->stats.get_oom_extstore++;
                     pthread_mutex_unlock(&c->thread->stats.mutex);

--- a/slabs.c
+++ b/slabs.c
@@ -8,6 +8,7 @@
  * memcached protocol.
  */
 #include "memcached.h"
+#include "storage.h"
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/socket.h>

--- a/storage.c
+++ b/storage.c
@@ -3,6 +3,7 @@
 #ifdef EXTSTORE
 
 #include "storage.h"
+#include "extstore.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <stddef.h>
@@ -14,6 +15,342 @@
 #define PAGE_BUCKET_COMPACT 1
 #define PAGE_BUCKET_CHUNKED 2
 #define PAGE_BUCKET_LOWTTL  3
+
+/*
+ * API functions
+ */
+
+// Only call this if item has ITEM_HDR
+bool storage_validate_item(void *e, item *it) {
+    item_hdr *hdr = (item_hdr *)ITEM_data(it);
+    if (extstore_check(e, hdr->page_id, hdr->page_version) != 0) {
+        return false;
+    } else {
+        return true;
+    }
+
+}
+
+void storage_delete(void *e, item *it) {
+    if (it->it_flags & ITEM_HDR) {
+        item_hdr *hdr = (item_hdr *)ITEM_data(it);
+        extstore_delete(e, hdr->page_id, hdr->page_version,
+                1, ITEM_ntotal(it));
+    }
+}
+
+// Function for the extra stats called from a protocol.
+// NOTE: This either needs a name change or a wrapper, perhaps?
+// it's defined here to reduce exposure of extstore.h to the rest of memcached
+// but feels a little off being defined here.
+// At very least maybe "process_storage_stats" in line with making this more
+// of a generic wrapper module.
+void process_extstore_stats(ADD_STAT add_stats, conn *c) {
+    int i;
+    char key_str[STAT_KEY_LEN];
+    char val_str[STAT_VAL_LEN];
+    int klen = 0, vlen = 0;
+    struct extstore_stats st;
+
+    assert(add_stats);
+
+    void *storage = c->thread->storage;
+    extstore_get_stats(storage, &st);
+    st.page_data = calloc(st.page_count, sizeof(struct extstore_page_data));
+    extstore_get_page_data(storage, &st);
+
+    for (i = 0; i < st.page_count; i++) {
+        APPEND_NUM_STAT(i, "version", "%llu",
+                (unsigned long long) st.page_data[i].version);
+        APPEND_NUM_STAT(i, "bytes", "%llu",
+                (unsigned long long) st.page_data[i].bytes_used);
+        APPEND_NUM_STAT(i, "bucket", "%u",
+                st.page_data[i].bucket);
+        APPEND_NUM_STAT(i, "free_bucket", "%u",
+                st.page_data[i].free_bucket);
+    }
+}
+
+// Additional storage stats for the main stats output.
+void storage_stats(ADD_STAT add_stats, conn *c) {
+    struct extstore_stats st;
+    if (c->thread->storage) {
+        STATS_LOCK();
+        APPEND_STAT("extstore_compact_lost", "%llu", (unsigned long long)stats.extstore_compact_lost);
+        APPEND_STAT("extstore_compact_rescues", "%llu", (unsigned long long)stats.extstore_compact_rescues);
+        APPEND_STAT("extstore_compact_skipped", "%llu", (unsigned long long)stats.extstore_compact_skipped);
+        STATS_UNLOCK();
+        extstore_get_stats(c->thread->storage, &st);
+        APPEND_STAT("extstore_page_allocs", "%llu", (unsigned long long)st.page_allocs);
+        APPEND_STAT("extstore_page_evictions", "%llu", (unsigned long long)st.page_evictions);
+        APPEND_STAT("extstore_page_reclaims", "%llu", (unsigned long long)st.page_reclaims);
+        APPEND_STAT("extstore_pages_free", "%llu", (unsigned long long)st.pages_free);
+        APPEND_STAT("extstore_pages_used", "%llu", (unsigned long long)st.pages_used);
+        APPEND_STAT("extstore_objects_evicted", "%llu", (unsigned long long)st.objects_evicted);
+        APPEND_STAT("extstore_objects_read", "%llu", (unsigned long long)st.objects_read);
+        APPEND_STAT("extstore_objects_written", "%llu", (unsigned long long)st.objects_written);
+        APPEND_STAT("extstore_objects_used", "%llu", (unsigned long long)st.objects_used);
+        APPEND_STAT("extstore_bytes_evicted", "%llu", (unsigned long long)st.bytes_evicted);
+        APPEND_STAT("extstore_bytes_written", "%llu", (unsigned long long)st.bytes_written);
+        APPEND_STAT("extstore_bytes_read", "%llu", (unsigned long long)st.bytes_read);
+        APPEND_STAT("extstore_bytes_used", "%llu", (unsigned long long)st.bytes_used);
+        APPEND_STAT("extstore_bytes_fragmented", "%llu", (unsigned long long)st.bytes_fragmented);
+        APPEND_STAT("extstore_limit_maxbytes", "%llu", (unsigned long long)(st.page_count * st.page_size));
+        APPEND_STAT("extstore_io_queue", "%llu", (unsigned long long)(st.io_queue));
+    }
+
+}
+
+
+// FIXME: This runs in the IO thread. to get better IO performance this should
+// simply mark the io wrapper with the return value and decrement wrapleft, if
+// zero redispatching. Still a bit of work being done in the side thread but
+// minimized at least.
+// TODO: wrap -> p?
+static void _storage_get_item_cb(void *e, obj_io *io, int ret) {
+    // FIXME: assumes success
+    io_pending_t *wrap = (io_pending_t *)io->data;
+    mc_resp *resp = wrap->resp;
+    conn *c = wrap->c;
+    assert(wrap->active == true);
+    item *read_it = (item *)io->buf;
+    bool miss = false;
+
+    // TODO: How to do counters for hit/misses?
+    if (ret < 1) {
+        miss = true;
+    } else {
+        uint32_t crc2;
+        uint32_t crc = (uint32_t) read_it->exptime;
+        int x;
+        // item is chunked, crc the iov's
+        if (io->iov != NULL) {
+            // first iov is the header, which we don't use beyond crc
+            crc2 = crc32c(0, (char *)io->iov[0].iov_base+STORE_OFFSET, io->iov[0].iov_len-STORE_OFFSET);
+            // make sure it's not sent. hack :(
+            io->iov[0].iov_len = 0;
+            for (x = 1; x < io->iovcnt; x++) {
+                crc2 = crc32c(crc2, (char *)io->iov[x].iov_base, io->iov[x].iov_len);
+            }
+        } else {
+            crc2 = crc32c(0, (char *)read_it+STORE_OFFSET, io->len-STORE_OFFSET);
+        }
+
+        if (crc != crc2) {
+            miss = true;
+            wrap->badcrc = true;
+        }
+    }
+
+    if (miss) {
+        if (wrap->noreply) {
+            // In all GET cases, noreply means we send nothing back.
+            resp->skip = true;
+        } else {
+            // TODO: This should be movable to the worker thread.
+            // Convert the binprot response into a miss response.
+            // The header requires knowing a bunch of stateful crap, so rather
+            // than simply writing out a "new" miss response we mangle what's
+            // already there.
+            if (c->protocol == binary_prot) {
+                protocol_binary_response_header *header =
+                    (protocol_binary_response_header *)resp->wbuf;
+
+                // cut the extra nbytes off of the body_len
+                uint32_t body_len = ntohl(header->response.bodylen);
+                uint8_t hdr_len = header->response.extlen;
+                body_len -= resp->iov[wrap->iovec_data].iov_len + hdr_len;
+                resp->tosend -= resp->iov[wrap->iovec_data].iov_len + hdr_len;
+                header->response.extlen = 0;
+                header->response.status = (uint16_t)htons(PROTOCOL_BINARY_RESPONSE_KEY_ENOENT);
+                header->response.bodylen = htonl(body_len);
+
+                // truncate the data response.
+                resp->iov[wrap->iovec_data].iov_len = 0;
+                // wipe the extlen iov... wish it was just a flat buffer.
+                resp->iov[wrap->iovec_data-1].iov_len = 0;
+                resp->chunked_data_iov = 0;
+            } else {
+                int i;
+                // Meta commands have EN status lines for miss, rather than
+                // END as a trailer as per normal ascii.
+                if (resp->iov[0].iov_len >= 3
+                        && memcmp(resp->iov[0].iov_base, "VA ", 3) == 0) {
+                    // TODO: These miss translators should use specific callback
+                    // functions attached to the io wrap. This is weird :(
+                    resp->iovcnt = 1;
+                    resp->iov[0].iov_len = 4;
+                    resp->iov[0].iov_base = "EN\r\n";
+                    resp->tosend = 4;
+                } else {
+                    // Wipe the iovecs up through our data injection.
+                    // Allows trailers to be returned (END)
+                    for (i = 0; i <= wrap->iovec_data; i++) {
+                        resp->tosend -= resp->iov[i].iov_len;
+                        resp->iov[i].iov_len = 0;
+                        resp->iov[i].iov_base = NULL;
+                    }
+                }
+                resp->chunked_total = 0;
+                resp->chunked_data_iov = 0;
+            }
+        }
+        wrap->miss = true;
+    } else {
+        assert(read_it->slabs_clsid != 0);
+        // TODO: should always use it instead of ITEM_data to kill more
+        // chunked special casing.
+        if ((read_it->it_flags & ITEM_CHUNKED) == 0) {
+            resp->iov[wrap->iovec_data].iov_base = ITEM_data(read_it);
+        }
+        wrap->miss = false;
+    }
+
+    c->io_pending--;
+    wrap->active = false;
+    //assert(c->io_wrapleft >= 0);
+
+    // All IO's have returned, lets re-attach this connection to our original
+    // thread.
+    if (c->io_pending == 0) {
+        assert(c->io_queued == true);
+        redispatch_conn(c);
+    }
+}
+
+int storage_get_item(conn *c, item *it, mc_resp *resp) {
+#ifdef NEED_ALIGN
+    item_hdr hdr;
+    memcpy(&hdr, ITEM_data(it), sizeof(hdr));
+#else
+    item_hdr *hdr = (item_hdr *)ITEM_data(it);
+#endif
+    io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_EXTSTORE);
+    size_t ntotal = ITEM_ntotal(it);
+    unsigned int clsid = slabs_clsid(ntotal);
+    item *new_it;
+    bool chunked = false;
+    if (ntotal > settings.slab_chunk_size_max) {
+        // Pull a chunked item header.
+        uint32_t flags;
+        FLAGS_CONV(it, flags);
+        new_it = item_alloc(ITEM_key(it), it->nkey, flags, it->exptime, it->nbytes);
+        assert(new_it == NULL || (new_it->it_flags & ITEM_CHUNKED));
+        chunked = true;
+    } else {
+        new_it = do_item_alloc_pull(ntotal, clsid);
+    }
+    if (new_it == NULL)
+        return -1;
+    assert(!c->io_queued); // FIXME: debugging.
+    // so we can free the chunk on a miss
+    new_it->slabs_clsid = clsid;
+
+    io_pending_t *p = do_cache_alloc(c->thread->io_cache);
+    p->active = true;
+    p->miss = false;
+    p->badcrc = false;
+    p->noreply = c->noreply;
+    // io_pending owns the reference for this object now.
+    p->hdr_it = it;
+    p->resp = resp;
+    obj_io *eio = calloc(1, sizeof(obj_io));
+    p->io_ctx = eio;
+
+    // FIXME: error handling.
+    if (chunked) {
+        unsigned int ciovcnt = 0;
+        size_t remain = new_it->nbytes;
+        item_chunk *chunk = (item_chunk *) ITEM_schunk(new_it);
+        // TODO: This might make sense as a _global_ cache vs a per-thread.
+        // but we still can't load objects requiring > IOV_MAX iovs.
+        // In the meantime, these objects are rare/slow enough that
+        // malloc/freeing a statically sized object won't cause us much pain.
+        eio->iov = malloc(sizeof(struct iovec) * IOV_MAX);
+        if (eio->iov == NULL) {
+            item_remove(new_it);
+            free(eio);
+            do_cache_free(c->thread->io_cache, p);
+            return -1;
+        }
+
+        // fill the header so we can get the full data + crc back.
+        eio->iov[0].iov_base = new_it;
+        eio->iov[0].iov_len = ITEM_ntotal(new_it) - new_it->nbytes;
+        ciovcnt++;
+
+        while (remain > 0) {
+            chunk = do_item_alloc_chunk(chunk, remain);
+            // FIXME: _pure evil_, silently erroring if item is too large.
+            if (chunk == NULL || ciovcnt > IOV_MAX-1) {
+                item_remove(new_it);
+                free(eio->iov);
+                // TODO: wrapper function for freeing up an io wrap?
+                eio->iov = NULL;
+                free(eio);
+                do_cache_free(c->thread->io_cache, p);
+                return -1;
+            }
+            eio->iov[ciovcnt].iov_base = chunk->data;
+            eio->iov[ciovcnt].iov_len = (remain < chunk->size) ? remain : chunk->size;
+            chunk->used = (remain < chunk->size) ? remain : chunk->size;
+            remain -= chunk->size;
+            ciovcnt++;
+        }
+
+        eio->iovcnt = ciovcnt;
+    }
+
+    // Chunked or non chunked we reserve a response iov here.
+    p->iovec_data = resp->iovcnt;
+    int iovtotal = (c->protocol == binary_prot) ? it->nbytes - 2 : it->nbytes;
+    if (chunked) {
+        resp_add_chunked_iov(resp, new_it, iovtotal);
+    } else {
+        resp_add_iov(resp, "", iovtotal);
+    }
+
+    eio->buf = (void *)new_it;
+    p->c = c;
+
+    // We need to stack the sub-struct IO's together as well.
+    if (q->head_pending) {
+        eio->next = q->head_pending->io_ctx;
+    } else {
+        eio->next = NULL;
+    }
+
+    // IO queue for this connection.
+    p->next = q->head_pending;
+    q->head_pending = p;
+    assert(c->io_pending >= 0);
+    c->io_pending++;
+    // reference ourselves for the callback.
+    eio->data = (void *)p;
+
+    // Now, fill in io->io based on what was in our header.
+#ifdef NEED_ALIGN
+    eio->page_version = hdr.page_version;
+    eio->page_id = hdr.page_id;
+    eio->offset = hdr.offset;
+#else
+    eio->page_version = hdr->page_version;
+    eio->page_id = hdr->page_id;
+    eio->offset = hdr->offset;
+#endif
+    eio->len = ntotal;
+    eio->mode = OBJ_IO_READ;
+    eio->cb = _storage_get_item_cb;
+
+    // FIXME: This stat needs to move to reflect # of flash hits vs misses
+    // for now it's a good gauge on how often we request out to flash at
+    // least.
+    pthread_mutex_lock(&c->thread->stats.mutex);
+    c->thread->stats.get_extstore++;
+    pthread_mutex_unlock(&c->thread->stats.mutex);
+
+    return 0;
+}
 
 void storage_submit_cb(void *ctx, io_pending_t *pending) {
     extstore_submit(ctx, pending->io_ctx);
@@ -99,7 +436,9 @@ void storage_free_cb(void *ctx, io_pending_t *pending) {
     free(io);
 }
 
-/*** WRITE FLUSH THREAD ***/
+/*
+ * WRITE FLUSH THREAD
+ */
 
 static int storage_write(void *storage, const int clsid, const int item_age) {
     int did_moves = 0;
@@ -733,6 +1072,284 @@ error:
         free(cf);
     }
     return NULL;
+}
+
+struct storage_settings {
+    struct extstore_conf_file *storage_file;
+    struct extstore_conf ext_cf;
+};
+
+void *storage_init_config(struct settings *s) {
+    struct storage_settings *cf = calloc(1, sizeof(struct storage_settings));
+
+    s->ext_item_size = 512;
+    s->ext_item_age = UINT_MAX;
+    s->ext_low_ttl = 0;
+    s->ext_recache_rate = 2000;
+    s->ext_max_frag = 0.8;
+    s->ext_drop_unread = false;
+    s->ext_wbuf_size = 1024 * 1024 * 4;
+    s->ext_compact_under = 0;
+    s->ext_drop_under = 0;
+    s->slab_automove_freeratio = 0.01;
+    s->ext_page_size = 1024 * 1024 * 64;
+    s->ext_io_threadcount = 1;
+    cf->ext_cf.page_size = settings.ext_page_size;
+    cf->ext_cf.wbuf_size = settings.ext_wbuf_size;
+    cf->ext_cf.io_threadcount = settings.ext_io_threadcount;
+    cf->ext_cf.io_depth = 1;
+    cf->ext_cf.page_buckets = 4;
+    cf->ext_cf.wbuf_count = cf->ext_cf.page_buckets;
+
+    return cf;
+}
+
+// TODO: pass settings struct?
+int storage_read_config(void *conf, char **subopt) {
+    struct storage_settings *cf = conf;
+    struct extstore_conf *ext_cf = &cf->ext_cf;
+    char *subopts_value;
+
+    enum {
+        EXT_PAGE_SIZE,
+        EXT_WBUF_SIZE,
+        EXT_THREADS,
+        EXT_IO_DEPTH,
+        EXT_PATH,
+        EXT_ITEM_SIZE,
+        EXT_ITEM_AGE,
+        EXT_LOW_TTL,
+        EXT_RECACHE_RATE,
+        EXT_COMPACT_UNDER,
+        EXT_DROP_UNDER,
+        EXT_MAX_FRAG,
+        EXT_DROP_UNREAD,
+        SLAB_AUTOMOVE_FREERATIO, // FIXME: move this back?
+    };
+
+    char *const subopts_tokens[] = {
+        [EXT_PAGE_SIZE] = "ext_page_size",
+        [EXT_WBUF_SIZE] = "ext_wbuf_size",
+        [EXT_THREADS] = "ext_threads",
+        [EXT_IO_DEPTH] = "ext_io_depth",
+        [EXT_PATH] = "ext_path",
+        [EXT_ITEM_SIZE] = "ext_item_size",
+        [EXT_ITEM_AGE] = "ext_item_age",
+        [EXT_LOW_TTL] = "ext_low_ttl",
+        [EXT_RECACHE_RATE] = "ext_recache_rate",
+        [EXT_COMPACT_UNDER] = "ext_compact_under",
+        [EXT_DROP_UNDER] = "ext_drop_under",
+        [EXT_MAX_FRAG] = "ext_max_frag",
+        [EXT_DROP_UNREAD] = "ext_drop_unread",
+        [SLAB_AUTOMOVE_FREERATIO] = "slab_automove_freeratio",
+        NULL
+    };
+
+    switch (getsubopt(subopt, subopts_tokens, &subopts_value)) {
+        case EXT_PAGE_SIZE:
+            if (cf->storage_file) {
+                fprintf(stderr, "Must specify ext_page_size before any ext_path arguments\n");
+                return 1;
+            }
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_page_size argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &ext_cf->page_size)) {
+                fprintf(stderr, "could not parse argument to ext_page_size\n");
+                return 1;
+            }
+            ext_cf->page_size *= 1024 * 1024; /* megabytes */
+            break;
+        case EXT_WBUF_SIZE:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_wbuf_size argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &ext_cf->wbuf_size)) {
+                fprintf(stderr, "could not parse argument to ext_wbuf_size\n");
+                return 1;
+            }
+            ext_cf->wbuf_size *= 1024 * 1024; /* megabytes */
+            settings.ext_wbuf_size = ext_cf->wbuf_size;
+            break;
+        case EXT_THREADS:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_threads argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &ext_cf->io_threadcount)) {
+                fprintf(stderr, "could not parse argument to ext_threads\n");
+                return 1;
+            }
+            break;
+        case EXT_IO_DEPTH:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_io_depth argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &ext_cf->io_depth)) {
+                fprintf(stderr, "could not parse argument to ext_io_depth\n");
+                return 1;
+            }
+            break;
+        case EXT_ITEM_SIZE:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_item_size argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &settings.ext_item_size)) {
+                fprintf(stderr, "could not parse argument to ext_item_size\n");
+                return 1;
+            }
+            break;
+        case EXT_ITEM_AGE:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_item_age argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &settings.ext_item_age)) {
+                fprintf(stderr, "could not parse argument to ext_item_age\n");
+                return 1;
+            }
+            break;
+        case EXT_LOW_TTL:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_low_ttl argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &settings.ext_low_ttl)) {
+                fprintf(stderr, "could not parse argument to ext_low_ttl\n");
+                return 1;
+            }
+            break;
+        case EXT_RECACHE_RATE:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_recache_rate argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &settings.ext_recache_rate)) {
+                fprintf(stderr, "could not parse argument to ext_recache_rate\n");
+                return 1;
+            }
+            break;
+        case EXT_COMPACT_UNDER:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_compact_under argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &settings.ext_compact_under)) {
+                fprintf(stderr, "could not parse argument to ext_compact_under\n");
+                return 1;
+            }
+            break;
+        case EXT_DROP_UNDER:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_drop_under argument\n");
+                return 1;
+            }
+            if (!safe_strtoul(subopts_value, &settings.ext_drop_under)) {
+                fprintf(stderr, "could not parse argument to ext_drop_under\n");
+                return 1;
+            }
+            break;
+        case EXT_MAX_FRAG:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing ext_max_frag argument\n");
+                return 1;
+            }
+            if (!safe_strtod(subopts_value, &settings.ext_max_frag)) {
+                fprintf(stderr, "could not parse argument to ext_max_frag\n");
+                return 1;
+            }
+            break;
+        case SLAB_AUTOMOVE_FREERATIO:
+            if (subopts_value == NULL) {
+                fprintf(stderr, "Missing slab_automove_freeratio argument\n");
+                return 1;
+            }
+            if (!safe_strtod(subopts_value, &settings.slab_automove_freeratio)) {
+                fprintf(stderr, "could not parse argument to slab_automove_freeratio\n");
+                return 1;
+            }
+            break;
+        case EXT_DROP_UNREAD:
+            settings.ext_drop_unread = true;
+            break;
+        case EXT_PATH:
+            if (subopts_value) {
+                struct extstore_conf_file *tmp = storage_conf_parse(subopts_value, ext_cf->page_size);
+                if (tmp == NULL) {
+                    fprintf(stderr, "failed to parse ext_path argument\n");
+                    return 1;
+                }
+                if (cf->storage_file != NULL) {
+                    tmp->next = cf->storage_file;
+                }
+                cf->storage_file = tmp;
+            } else {
+                fprintf(stderr, "missing argument to ext_path, ie: ext_path=/d/file:5G\n");
+                return 1;
+            }
+            break;
+        default:
+            fprintf(stderr, "Illegal suboption \"%s\"\n", subopts_value);
+            return 1;
+    }
+
+    return 0;
+}
+
+int storage_check_config(void *conf) {
+    struct storage_settings *cf = conf;
+    struct extstore_conf *ext_cf = &cf->ext_cf;
+
+    if (cf->storage_file) {
+        if (settings.item_size_max > ext_cf->wbuf_size) {
+            fprintf(stderr, "-I (item_size_max: %d) cannot be larger than ext_wbuf_size: %d\n",
+                settings.item_size_max, ext_cf->wbuf_size);
+            return 1;
+        }
+
+        if (settings.udpport) {
+            fprintf(stderr, "Cannot use UDP with extstore enabled (-U 0 to disable)\n");
+            return 1;
+        }
+
+        return 0;
+    }
+
+    return 2;
+}
+
+void *storage_init(void *conf) {
+    struct storage_settings *cf = conf;
+    struct extstore_conf *ext_cf = &cf->ext_cf;
+
+    enum extstore_res eres;
+    void *storage = NULL;
+    if (settings.ext_compact_under == 0) {
+        // If changing the default fraction (4), change the help text as well.
+        settings.ext_compact_under = cf->storage_file->page_count / 4;
+        /* Only rescues non-COLD items if below this threshold */
+        settings.ext_drop_under = cf->storage_file->page_count / 4;
+    }
+    crc32c_init();
+    /* Init free chunks to zero. */
+    for (int x = 0; x < MAX_NUMBER_OF_SLAB_CLASSES; x++) {
+        settings.ext_free_memchunks[x] = 0;
+    }
+    storage = extstore_init(cf->storage_file, ext_cf, &eres);
+    if (storage == NULL) {
+        fprintf(stderr, "Failed to initialize external storage: %s\n",
+                extstore_err(eres));
+        if (eres == EXTSTORE_INIT_OPEN_FAIL) {
+            perror("extstore open");
+        }
+        return NULL;
+    }
+
+    return storage;
 }
 
 #endif

--- a/storage.c
+++ b/storage.c
@@ -15,6 +15,90 @@
 #define PAGE_BUCKET_CHUNKED 2
 #define PAGE_BUCKET_LOWTTL  3
 
+void storage_submit_cb(void *ctx, io_pending_t *pending) {
+    extstore_submit(ctx, pending->io_ctx);
+}
+
+static void recache_or_free(io_pending_t *p) {
+    conn *c = p->c;
+    obj_io *io = p->io_ctx;
+    item *it = (item *)io->buf;
+    assert(c != NULL);
+    assert(io != NULL);
+    bool do_free = true;
+    if (p->active) {
+        // If request never dispatched, free the read buffer but leave the
+        // item header alone.
+        do_free = false;
+        size_t ntotal = ITEM_ntotal(p->hdr_it);
+        slabs_free(it, ntotal, slabs_clsid(ntotal));
+        c->io_pending--;
+        assert(c->io_pending >= 0);
+        pthread_mutex_lock(&c->thread->stats.mutex);
+        c->thread->stats.get_aborted_extstore++;
+        pthread_mutex_unlock(&c->thread->stats.mutex);
+    } else if (p->miss) {
+        // If request was ultimately a miss, unlink the header.
+        do_free = false;
+        size_t ntotal = ITEM_ntotal(p->hdr_it);
+        item_unlink(p->hdr_it);
+        slabs_free(it, ntotal, slabs_clsid(ntotal));
+        pthread_mutex_lock(&c->thread->stats.mutex);
+        c->thread->stats.miss_from_extstore++;
+        if (p->badcrc)
+            c->thread->stats.badcrc_from_extstore++;
+        pthread_mutex_unlock(&c->thread->stats.mutex);
+    } else if (settings.ext_recache_rate) {
+        // hashvalue is cuddled during store
+        uint32_t hv = (uint32_t)it->time;
+        // opt to throw away rather than wait on a lock.
+        void *hold_lock = item_trylock(hv);
+        if (hold_lock != NULL) {
+            item *h_it = p->hdr_it;
+            uint8_t flags = ITEM_LINKED|ITEM_FETCHED|ITEM_ACTIVE;
+            // Item must be recently hit at least twice to recache.
+            if (((h_it->it_flags & flags) == flags) &&
+                    h_it->time > current_time - ITEM_UPDATE_INTERVAL &&
+                    c->recache_counter++ % settings.ext_recache_rate == 0) {
+                do_free = false;
+                // In case it's been updated.
+                it->exptime = h_it->exptime;
+                it->it_flags &= ~ITEM_LINKED;
+                it->refcount = 0;
+                it->h_next = NULL; // might not be necessary.
+                STORAGE_delete(c->thread->storage, h_it);
+                item_replace(h_it, it, hv);
+                pthread_mutex_lock(&c->thread->stats.mutex);
+                c->thread->stats.recache_from_extstore++;
+                pthread_mutex_unlock(&c->thread->stats.mutex);
+            }
+        }
+        if (hold_lock)
+            item_trylock_unlock(hold_lock);
+    }
+    if (do_free)
+        slabs_free(it, ITEM_ntotal(it), ITEM_clsid(it));
+
+    //wrap->io.buf = NULL;
+    //wrap->io.next = NULL;
+    p->next = NULL;
+    p->active = false;
+
+    // TODO: reuse lock and/or hv.
+    item_remove(p->hdr_it);
+}
+
+// TODO: io cache or embed obj_io in space within io_pending_t
+void storage_free_cb(void *ctx, io_pending_t *pending) {
+    recache_or_free(pending);
+    obj_io *io = pending->io_ctx;
+    // malloc'ed iovec list used for chunked extstore fetches.
+    if (io->iov) {
+        free(io->iov);
+    }
+    free(io);
+}
+
 /*** WRITE FLUSH THREAD ***/
 
 static int storage_write(void *storage, const int clsid, const int item_age) {

--- a/storage.h
+++ b/storage.h
@@ -11,18 +11,26 @@ void storage_delete(void *e, item *it);
 #define STORAGE_delete(...)
 #endif
 
+// API.
 void storage_stats(ADD_STAT add_stats, conn *c);
 void process_extstore_stats(ADD_STAT add_stats, conn *c);
 bool storage_validate_item(void *e, item *it);
 int storage_get_item(conn *c, item *it, mc_resp *resp);
-void storage_submit_cb(void *ctx, io_pending_t *pending);
-void storage_free_cb(void *ctx, io_pending_t *pending);
+
+// callbacks for the IO queue subsystem.
+void storage_submit_cb(void *ctx, void *stack);
+void storage_complete_cb(void *ctx, void *stack);
+void storage_finalize_cb(io_pending_t *pending);
+
+// Thread functions.
 int start_storage_write_thread(void *arg);
 void storage_write_pause(void);
 void storage_write_resume(void);
 int start_storage_compact_thread(void *arg);
 void storage_compact_pause(void);
 void storage_compact_resume(void);
+
+// Init functions.
 struct extstore_conf_file *storage_conf_parse(char *arg, unsigned int page_size);
 void *storage_init_config(struct settings *s);
 int storage_read_config(void *conf, char **subopt);

--- a/storage.h
+++ b/storage.h
@@ -1,6 +1,8 @@
 #ifndef STORAGE_H
 #define STORAGE_H
 
+void storage_submit_cb(void *ctx, io_pending_t *pending);
+void storage_free_cb(void *ctx, io_pending_t *pending);
 int start_storage_write_thread(void *arg);
 void storage_write_pause(void);
 void storage_write_resume(void);

--- a/storage.h
+++ b/storage.h
@@ -1,8 +1,24 @@
 #ifndef STORAGE_H
 #define STORAGE_H
 
+void storage_delete(void *e, item *it);
+#ifdef EXTSTORE
+#define STORAGE_delete(e, it) \
+    do { \
+        storage_delete(e, it); \
+    } while (0)
+#else
+#define STORAGE_delete(...)
+#endif
+
+void storage_stats(ADD_STAT add_stats, conn *c);
+void process_extstore_stats(ADD_STAT add_stats, conn *c);
+bool storage_validate_item(void *e, item *it);
+int storage_get_item(conn *c, item *it, mc_resp *resp);
+#ifdef EXTSTORE
 void storage_submit_cb(void *ctx, io_pending_t *pending);
 void storage_free_cb(void *ctx, io_pending_t *pending);
+#endif
 int start_storage_write_thread(void *arg);
 void storage_write_pause(void);
 void storage_write_resume(void);
@@ -10,6 +26,10 @@ int start_storage_compact_thread(void *arg);
 void storage_compact_pause(void);
 void storage_compact_resume(void);
 struct extstore_conf_file *storage_conf_parse(char *arg, unsigned int page_size);
+void *storage_init_config(struct settings *s);
+int storage_read_config(void *conf, char **subopt);
+int storage_check_config(void *conf);
+void *storage_init(void *conf);
 
 // Ignore pointers and header bits from the CRC
 #define STORE_OFFSET offsetof(item, nbytes)

--- a/storage.h
+++ b/storage.h
@@ -15,10 +15,8 @@ void storage_stats(ADD_STAT add_stats, conn *c);
 void process_extstore_stats(ADD_STAT add_stats, conn *c);
 bool storage_validate_item(void *e, item *it);
 int storage_get_item(conn *c, item *it, mc_resp *resp);
-#ifdef EXTSTORE
 void storage_submit_cb(void *ctx, io_pending_t *pending);
 void storage_free_cb(void *ctx, io_pending_t *pending);
-#endif
 int start_storage_write_thread(void *arg);
 void storage_write_pause(void);
 void storage_write_resume(void);

--- a/thread.c
+++ b/thread.c
@@ -441,13 +441,11 @@ static void setup_thread(LIBEVENT_THREAD *me) {
         cache_set_limit(me->rbuf_cache, limit);
     }
 
-#ifdef EXTSTORE
     me->io_cache = cache_create("io", sizeof(io_pending_t), sizeof(char*), NULL, NULL);
     if (me->io_cache == NULL) {
         fprintf(stderr, "Failed to create IO object cache\n");
         exit(EXIT_FAILURE);
     }
-#endif
 #ifdef TLS
     if (settings.ssl_enabled) {
         me->ssl_wbuf = (char *)malloc((size_t)settings.ssl_wbuf_size);
@@ -543,9 +541,7 @@ static void thread_libevent_process(evutil_socket_t fd, short which, void *arg) 
                         conn_io_queue_add(c, IO_QUEUE_EXTSTORE, c->thread->storage, storage_submit_cb, storage_free_cb);
                     }
 #endif
-#ifdef EXTSTORE
                     conn_io_queue_add(c, IO_QUEUE_NONE, NULL, NULL, NULL);
-#endif
 
 #ifdef TLS
                     if (settings.ssl_enabled && c->ssl != NULL) {

--- a/thread.c
+++ b/thread.c
@@ -538,10 +538,11 @@ static void thread_libevent_process(evutil_socket_t fd, short which, void *arg) 
                     c->thread = me;
 #ifdef EXTSTORE
                     if (c->thread->storage) {
-                        conn_io_queue_add(c, IO_QUEUE_EXTSTORE, c->thread->storage, storage_submit_cb, storage_free_cb);
+                        conn_io_queue_add(c, IO_QUEUE_EXTSTORE, c->thread->storage,
+                            storage_submit_cb, storage_complete_cb, storage_finalize_cb);
                     }
 #endif
-                    conn_io_queue_add(c, IO_QUEUE_NONE, NULL, NULL, NULL);
+                    conn_io_queue_add(c, IO_QUEUE_NONE, NULL, NULL, NULL, NULL);
 
 #ifdef TLS
                     if (settings.ssl_enabled && c->ssl != NULL) {


### PR DESCRIPTION
This turns extstore's deferred IO queue into a more general subsystem, allowing other features to hook into it simultaneously. Pulling this work out of another feature I've been working on. 

This finishes abstracting extstore via the storage.c interfacing, which is now the only consumer of extstore.h. Moving storage.c to be a wrapper itself should allow more experimentation or dynamic backends. Finally, this removes the compile gating around the IO queue code.

Together this removes quite a lot of ifdef's, fixes layer violations, and fixes some naming to hopefully make the code more clear.

One more change added: io_pending_t now reserves space at the end. users cast it into a more specific structure, removing the extra allocations and storage-specific fields from io_pending_t.