### PR TITLE
wrong condition check when return item to cache

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -142,7 +142,7 @@ void do_cache_free(cache_t *cache, void *ptr) {
     }
     ptr = pre;
 #endif
-    if (cache->limit > cache->total) {
+    if (cache->limit != 0 && cache->limit < cache->total) {
         /* Allow freeing in case the limit was revised downward */
         if (cache->destructor) {
             cache->destructor(ptr, NULL);


### PR DESCRIPTION
When returning item to the cache and the items allocated exceeded cache->limit, we should free the item and not put it to the cache.

The current code will free any item that tried returned to the cache when cache->total < cache->limit which is true in most cases.