### PR TITLE
Improve opening of authentication file

### DIFF
--- a/authfile.c
+++ b/authfile.c
@@ -33,22 +33,15 @@ enum authfile_ret authfile_load(const char *file) {
     char *auth_data = NULL;
     auth_t auth_entries[MAX_ENTRIES];
 
-    if (stat(file, &sb) == -1) {
-        return AUTHFILE_MISSING;
+    FILE *pwfile = fopen(file, "r");
+    if (pwfile == NULL) {
+        return AUTHFILE_OPENFAIL;
+    } else if (fstat(fileno(pwfile), &sb)) {
+        fclose(pwfile);
+        return AUTHFILE_STATFAIL;
     }
 
     auth_data = calloc(1, sb.st_size);
-
-    if (auth_data == NULL) {
-        return AUTHFILE_OOM;
-    }
-
-    FILE *pwfile = fopen(file, "r");
-    if (pwfile == NULL) {
-        // not strictly necessary but to be safe.
-        free(auth_data);
-        return AUTHFILE_OPENFAIL;
-    }
 
     char *auth_cur = auth_data;
     auth_t *entry_cur = auth_entries;

--- a/authfile.h
+++ b/authfile.h
@@ -3,8 +3,8 @@
 
 enum authfile_ret {
     AUTHFILE_OK = 0,
-    AUTHFILE_MISSING,
     AUTHFILE_OOM,
+    AUTHFILE_STATFAIL, // not likely, but just to be sure
     AUTHFILE_OPENFAIL,
     AUTHFILE_MALFORMED,
 };

--- a/memcached.c
+++ b/memcached.c
@@ -6103,9 +6103,14 @@ int main (int argc, char **argv) {
         }
 
         switch (authfile_load(settings.auth_file)) {
-            case AUTHFILE_MISSING: // fall through.
+            case AUTHFILE_STATFAIL:
+                vperror("Could not stat authfile [%s], error %s", settings.auth_file
+                                                            , strerror(errno));
+                exit(EXIT_FAILURE);
+                break;
             case AUTHFILE_OPENFAIL:
-                vperror("Could not open authfile [%s] for reading", settings.auth_file);
+                vperror("Could not open authfile [%s] for reading, error %s", settings.auth_file
+                                                                           , strerror(errno));
                 exit(EXIT_FAILURE);
                 break;
             case AUTHFILE_OOM:


### PR DESCRIPTION
Hi,
Static code analysers have been complaining about this for a
while, so i decided to improve this code a little. I realize that
there is a little danger in this particular usecase but i think
that the way i updated the code is just safer.

```
memcached-1.6.7/authfile.c:36: fs_check_call: Calling function "stat" to perform check on "file".
memcached-1.6.7/authfile.c:46: toctou: Calling function "fopen" that uses "file" after a check function. This can cause a time-of-check, time-of-use race condition.
#   34|       auth_t auth_entries[MAX_ENTRIES];
#   35|   
#   36|->     if (stat(file, &sb) == -1) {
#   37|           return AUTHFILE_MISSING;
#   38|       }
```
