### PR TITLE
Fix leaking file descriptors

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -67,23 +67,25 @@ int daemonize(int nochdir, int noclose)
     if (noclose == 0 && (fd = open("/dev/null", O_RDWR, 0)) != -1) {
         if(dup2(fd, STDIN_FILENO) < 0) {
             perror("dup2 stdin");
-            return (-1);
+            goto err_cleanup;
         }
         if(dup2(fd, STDOUT_FILENO) < 0) {
             perror("dup2 stdout");
-            return (-1);
+            goto err_cleanup;
         }
         if(dup2(fd, STDERR_FILENO) < 0) {
             perror("dup2 stderr");
-            return (-1);
+            goto err_cleanup;
         }
 
-        if (fd > STDERR_FILENO) {
-            if(close(fd) < 0) {
-                perror("close");
-                return (-1);
-            }
+        if(close(fd) < 0) {
+            perror("close");
+            return (-1);
         }
     }
     return (0);
+
+    err_cleanup:
+        close(fd);
+        return (-1);
 }


### PR DESCRIPTION
Hi @dormando,
This is another change fixing complains from static code analyser.
This change guarantees that file descriptor fd is always closed
before return from daemonize function thus, the handle never
leaks.
I'm not sure about the meaning of condition on line 81 `if (fd > STDERR_FILENO)`.
I removed it but please if it is there for some reason then correct me.