### PR TITLE
configure.ac: use pkg-config to retrieve openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ list to ask questions, github issues aren't seen by everyone!
 * libseccomp, (optional, experimental, linux) - enables process restrictions for
   better security. Tested only on x86-64 architectures.
 * openssl, (optional) - enables TLS support. need relatively up to date
-  version.
+  version. pkg-config is needed to find openssl dependencies (such as -lz).
 
 ## Environment
 

--- a/configure.ac
+++ b/configure.ac
@@ -406,80 +406,83 @@ AC_ARG_WITH(libssl,
 dnl ----------------------------------------------------------------------------
 dnl libssl detection.  swiped from libevent.  modified for openssl detection.
 
+PKG_PROG_PKG_CONFIG
 OPENSSL_URL=https://www.openssl.org/
 if test "x$enable_tls" = "xyes"; then
-  AC_CACHE_CHECK([for libssl directory], ac_cv_libssl_dir, [
-    saved_LIBS="$LIBS"
-    saved_LDFLAGS="$LDFLAGS"
-    saved_CPPFLAGS="$CPPFLAGS"
-    le_found=no
-    for ledir in $trylibssldir "" $prefix /usr/local ; do
+  PKG_CHECK_MODULES(OPENSSL, openssl, [LIBS="$LIBS $OPENSSL_LIBS" CFLAGS="$CFLAGS $OPENSSL_CFLAGS"], [
+    AC_CACHE_CHECK([for libssl directory], ac_cv_libssl_dir, [
+      saved_LIBS="$LIBS"
+      saved_LDFLAGS="$LDFLAGS"
+      saved_CPPFLAGS="$CPPFLAGS"
+      le_found=no
+      for ledir in $trylibssldir "" $prefix /usr/local ; do
+        LDFLAGS="$saved_LDFLAGS"
+        LIBS="-lssl -lcrypto $saved_LIBS"
+
+        # Skip the directory if it isn't there.
+        if test ! -z "$ledir" -a ! -d "$ledir" ; then
+          continue;
+        fi
+        if test ! -z "$ledir" ; then
+          if test -d "$ledir/lib" ; then
+            LDFLAGS="-L$ledir/lib $LDFLAGS"
+          else
+            LDFLAGS="-L$ledir $LDFLAGS"
+          fi
+          if test -d "$ledir/include" ; then
+            CPPFLAGS="-I$ledir/include $CPPFLAGS"
+          else
+            CPPFLAGS="-I$ledir $CPPFLAGS"
+          fi
+        fi
+        # Can I compile and link it?
+        AC_TRY_LINK([#include <sys/time.h>
+    #include <sys/types.h>
+    #include <assert.h>
+    #include <openssl/ssl.h>], [ SSL_CTX* ssl_ctx = SSL_CTX_new(TLS_server_method());
+                                assert(OPENSSL_VERSION_NUMBER >= 0x10100000L);],
+           [ libssl_linked=yes ], [ libssl_linked=no ])
+        if test $libssl_linked = yes; then
+          if test ! -z "$ledir" ; then
+            ac_cv_libssl_dir=$ledir
+            _myos=`echo $target_os | cut -f 1 -d .`
+            AS_IF(test "$SUNCC" = "yes" -o "x$_myos" = "xsolaris2",
+                  [saved_LDFLAGS="$saved_LDFLAGS -Wl,-R$ledir/lib"],
+                  [AS_IF(test "$GCC" = "yes",
+                        [saved_LDFLAGS="$saved_LDFLAGS -Wl,-rpath,$ledir/lib"])])
+           else
+             ac_cv_libssl_dir="(system)"
+           fi
+           le_found=yes
+           break
+        fi
+      done
+      LIBS="$saved_LIBS"
       LDFLAGS="$saved_LDFLAGS"
-      LIBS="-lssl -lcrypto $saved_LIBS"
+      CPPFLAGS="$saved_CPPFLAGS"
+      if test $le_found = no ; then
+        AC_MSG_ERROR([libssl (at least version 1.1.0) is required.  You can get it from $OPENSSL_URL
 
-      # Skip the directory if it isn't there.
-      if test ! -z "$ledir" -a ! -d "$ledir" ; then
-         continue;
+          If it's already installed, specify its path using --with-libssl=/dir/
+    ])
       fi
-      if test ! -z "$ledir" ; then
-        if test -d "$ledir/lib" ; then
-          LDFLAGS="-L$ledir/lib $LDFLAGS"
-        else
-          LDFLAGS="-L$ledir $LDFLAGS"
-        fi
-        if test -d "$ledir/include" ; then
-          CPPFLAGS="-I$ledir/include $CPPFLAGS"
-        else
-          CPPFLAGS="-I$ledir $CPPFLAGS"
-        fi
+    ])
+    LIBS="-lssl -lcrypto $LIBS"
+    if test $ac_cv_libssl_dir != "(system)"; then
+      if test -d "$ac_cv_libssl_dir/lib" ; then
+        LDFLAGS="-L$ac_cv_libssl_dir/lib $LDFLAGS"
+        le_libdir="$ac_cv_libssl_dir/lib"
+      else
+        LDFLAGS="-L$ac_cv_libssl_dir $LDFLAGS"
+        le_libdir="$ac_cv_libssl_dir"
       fi
-      # Can I compile and link it?
-      AC_TRY_LINK([#include <sys/time.h>
-  #include <sys/types.h>
-  #include <assert.h>
-  #include <openssl/ssl.h>], [ SSL_CTX* ssl_ctx = SSL_CTX_new(TLS_server_method());
-                              assert(OPENSSL_VERSION_NUMBER >= 0x10100000L);],
-         [ libssl_linked=yes ], [ libssl_linked=no ])
-      if test $libssl_linked = yes; then
-         if test ! -z "$ledir" ; then
-           ac_cv_libssl_dir=$ledir
-           _myos=`echo $target_os | cut -f 1 -d .`
-           AS_IF(test "$SUNCC" = "yes" -o "x$_myos" = "xsolaris2",
-                 [saved_LDFLAGS="$saved_LDFLAGS -Wl,-R$ledir/lib"],
-                 [AS_IF(test "$GCC" = "yes",
-                       [saved_LDFLAGS="$saved_LDFLAGS -Wl,-rpath,$ledir/lib"])])
-         else
-           ac_cv_libssl_dir="(system)"
-         fi
-         le_found=yes
-         break
+      if test -d "$ac_cv_libssl_dir/include" ; then
+        CPPFLAGS="-I$ac_cv_libssl_dir/include $CPPFLAGS"
+      else
+        CPPFLAGS="-I$ac_cv_libssl_dir $CPPFLAGS"
       fi
-    done
-    LIBS="$saved_LIBS"
-    LDFLAGS="$saved_LDFLAGS"
-    CPPFLAGS="$saved_CPPFLAGS"
-    if test $le_found = no ; then
-      AC_MSG_ERROR([libssl (at least version 1.1.0) is required.  You can get it from $OPENSSL_URL
-
-        If it's already installed, specify its path using --with-libssl=/dir/
-  ])
     fi
   ])
-  LIBS="-lssl -lcrypto $LIBS"
-  if test $ac_cv_libssl_dir != "(system)"; then
-    if test -d "$ac_cv_libssl_dir/lib" ; then
-      LDFLAGS="-L$ac_cv_libssl_dir/lib $LDFLAGS"
-      le_libdir="$ac_cv_libssl_dir/lib"
-    else
-      LDFLAGS="-L$ac_cv_libssl_dir $LDFLAGS"
-      le_libdir="$ac_cv_libssl_dir"
-    fi
-    if test -d "$ac_cv_libssl_dir/include" ; then
-      CPPFLAGS="-I$ac_cv_libssl_dir/include $CPPFLAGS"
-    else
-      CPPFLAGS="-I$ac_cv_libssl_dir $CPPFLAGS"
-    fi
-  fi
 fi
 
 if test "x$enable_static" = "xyes"; then


### PR DESCRIPTION
Use pkg-config to retrieve openssl dependencies such as -latomic or -lz

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>