### PR TITLE
NetBSD support large pages.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4432,6 +4432,8 @@ static int enable_large_pages(void) {
         return -1;
     }
     return 0;
+#elif defined(__NetBSD__)
+    return 0;
 #else
     return -1;
 #endif

--- a/slabs.c
+++ b/slabs.c
@@ -156,6 +156,12 @@ static void * alloc_large_chunk(const size_t limit)
         fprintf(stderr, "Failed to set super pages\n");
         ptr = NULL;
     }
+#elif defined(__NetBSD__)
+    ptr = mmap(NULL, limit, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANON | MAP_ALIGNED(MAP_ALIGNMENT_4GB), -1, 0);
+    if (ptr == MAP_FAILED) {
+        fprintf(stderr, "Failed to set aligned pages\n");
+        ptr = NULL;
+    }
 #else
     ptr = malloc(limit);
 #endif


### PR DESCRIPTION
Implicit promotion to large pages with given 4GB boundary.