### PR TITLE
Adjust "t/idle-timeout.t" be slightly more forgiving of slow systems

### DIFF
--- a/t/idle-timeout.t
+++ b/t/idle-timeout.t
@@ -27,7 +27,7 @@ $stats = mem_stats($sock);
 is($stats->{idle_kicks}, "0", "check stats 2");
 
 # Make sure we do timeout when not
-sleep(5);
+sleep(7);
 mem_stats($sock);   # Network activity, so socket code will see dead socket
 sleep(1);
 # we run SSL tests over TCP; hence IO::Socket::SSL returns


### PR DESCRIPTION
We had some "new" [1] build failures on slower architectures for 1.6.8 in `t/idle-timeout.t` (https://github.com/docker-library/memcached/issues/60) that in my testing seem to be resolved by adjusting `sleep(5)` up to `sleep(7)` in the relevant test (I tried `sleep(6)`, but it was still a bit flaky).

[1]: apparently not actually new, but newly reliably reproduced :speak_no_evil:

I think another approach could be lowering `idle_timeout=3`, but I'm afraid if we go too low we'll create the opposite problem in the block above this that verifies that activity on the socket doesn't get an idle timeout.  Happy to play with that more instead if you'd prefer!

As always, happy to rebase, amend, adjust, close, discuss, force push, etc etc etc. as desired! :heart: