### PR TITLE
Fix long sleep in idle connections checkup thread

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -361,9 +361,10 @@ static void *conn_timeout_thread(void *arg) {
             fprintf(stderr,
                     "idle timeout thread finished pass, sleeping for %ds\n",
                     sleep_time);
-        /* Sleep time may be too long, so split it by 1sec to exit from service normaly */
+        /* Sleep time may be too long, so split it by 0.1 sec to check exit flag and shutdown service gracefuly */
+        sleep_time *= 10;
         while (sleep_time) {
-            usleep((useconds_t) 1000000);
+            usleep((useconds_t) 100000);
             sleep_time--;
             // Service exit called? Check flag here.
             if (!do_run_conn_timeout_thread) break;

--- a/memcached.c
+++ b/memcached.c
@@ -361,7 +361,13 @@ static void *conn_timeout_thread(void *arg) {
             fprintf(stderr,
                     "idle timeout thread finished pass, sleeping for %ds\n",
                     sleep_time);
-        usleep((useconds_t) sleep_time * 1000000);
+        /* Sleep time may be too long, so split it by 1sec to exit from service normaly */
+        while (sleep_time) {
+            usleep((useconds_t) 1000000);
+            sleep_time--;
+            // Service exit called? Check flag here.
+            if (!do_run_conn_timeout_thread) break;
+        }
     }
 
     return NULL;


### PR DESCRIPTION
If `idle_timeout` option is setup to high value, like `610s`, then service can't be gracefuly stopped in short time.
Most init-systems will kill it with <s>fire</s>`SIGKILL` after short wait-time.

As long as `idle_timeout` is set in seconds, we should wait a little and check if thread break flag is set.