### PR TITLE
meta: allow base64'ed binary keys with 'b' flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ memcached_SOURCES = memcached.c memcached.h \
                     util.c util.h \
                     trace.h cache.c cache.h sasl_defs.h \
                     bipbuffer.c bipbuffer.h \
+                    base64.c base64.h \
                     logger.c logger.h \
                     crawler.c crawler.h \
                     itoa_ljust.c itoa_ljust.h \

--- a/base64.c
+++ b/base64.c
@@ -1,0 +1,205 @@
+/*
+ * Base64 encoding/decoding (RFC1341)
+ * Copyright (c) 2005-2011, Jouni Malinen <j@w1.fi>
+ * Modified by Dormando
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * Original license included below:
+ *
+License
+-------
+
+This software may be distributed, used, and modified under the terms of
+BSD license:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name(s) of the above-listed copyright holder(s) nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Changes from original code:
+ * - decode table is pre-generated
+ * - no line splitting on encoder
+ * - output buffers are passed in instead of malloc'ed
+ * - returns encoded/decoded length instead of pointer.
+ */
+
+#include <stddef.h>
+#include "base64.h"
+
+static const unsigned char base64_table[65] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* Original decode function generated the table every time. I used the code to
+ * print this table and pre-generate it instead.
+ */
+static const unsigned char dtable[256] = {
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+62, 128, 128, 128, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+61, 128, 128, 128, 0, 128, 128, 128, 0, 1, 2, 3, 4, 5,
+6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+20, 21, 22, 23, 24, 25, 128, 128, 128, 128, 128, 128, 26, 27,
+28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+128, 128, 128
+};
+
+/**
+ * base64_encode - Base64 encode
+ * @src: Data to be encoded
+ * @len: Length of the data to be encoded
+ * @out: output uffer
+ * @out_len: length of output buffer
+ * Returns: Number of actual bytes encoded into the buffer
+ * or 0 on failure
+ *
+ * Output buffer is nul terminated to make it easier to use as a C string.
+ * The nul terminator is * not included in the return length.
+ */
+size_t base64_encode(const unsigned char *src, size_t len,
+                  unsigned char *out, size_t out_len)
+{
+    unsigned char *pos;
+    const unsigned char *end, *in;
+    size_t olen;
+
+    olen = len * 4 / 3 + 4; /* 3-byte blocks to 4-byte */
+    olen += olen / 72; /* line feeds */
+    olen++; /* nul termination */
+    if (olen < len) {
+        return 0; /* integer overflow */
+    }
+    if (olen > out_len) {
+        return 0; /* not enough space in output buffer */
+    }
+    if (out == NULL) {
+        return 0;
+    }
+
+    end = src + len;
+    in = src;
+    pos = out;
+    while (end - in >= 3) {
+        *pos++ = base64_table[in[0] >> 2];
+        *pos++ = base64_table[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+        *pos++ = base64_table[((in[1] & 0x0f) << 2) | (in[2] >> 6)];
+        *pos++ = base64_table[in[2] & 0x3f];
+        in += 3;
+    }
+
+    if (end - in) {
+        *pos++ = base64_table[in[0] >> 2];
+        if (end - in == 1) {
+            *pos++ = base64_table[(in[0] & 0x03) << 4];
+            *pos++ = '=';
+        } else {
+            *pos++ = base64_table[((in[0] & 0x03) << 4) |
+                          (in[1] >> 4)];
+            *pos++ = base64_table[(in[1] & 0x0f) << 2];
+        }
+        *pos++ = '=';
+    }
+
+    *pos = '\0';
+    return pos - out;
+}
+
+
+/**
+ * base64_decode - Base64 decode
+ * @src: Data to be decoded
+ * @len: Length of the data to be decoded
+ * @out: Output buffer to decode into
+ * @out_len: Length of output buffer
+ * Returns: Length of encoded data, or 0 on failure
+ */
+size_t base64_decode(const unsigned char *src, size_t len,
+                  unsigned char *out, size_t out_len)
+{
+    unsigned char *pos, block[4], tmp;
+    size_t i, count, olen;
+    int pad = 0;
+
+    count = 0;
+    for (i = 0; i < len; i++) {
+        if (dtable[src[i]] != 0x80)
+            count++;
+    }
+
+    if (count == 0 || count % 4)
+        return 0;
+
+    olen = count / 4 * 3;
+    if (olen > out_len) {
+        return 0;
+    }
+    pos = out;
+    if (out == NULL) {
+        return 0;
+    }
+
+    count = 0;
+    for (i = 0; i < len; i++) {
+        tmp = dtable[src[i]];
+        if (tmp == 0x80)
+            continue;
+
+        if (src[i] == '=')
+            pad++;
+        block[count] = tmp;
+        count++;
+        if (count == 4) {
+            *pos++ = (block[0] << 2) | (block[1] >> 4);
+            *pos++ = (block[1] << 4) | (block[2] >> 2);
+            *pos++ = (block[2] << 6) | block[3];
+            count = 0;
+            if (pad) {
+                if (pad == 1)
+                    pos--;
+                else if (pad == 2)
+                    pos -= 2;
+                else {
+                    /* Invalid padding */
+                    return 0;
+                }
+                break;
+            }
+        }
+    }
+
+    return pos - out;
+}

--- a/base64.h
+++ b/base64.h
@@ -1,0 +1,17 @@
+/*
+ * Base64 encoding/decoding (RFC1341)
+ * Copyright (c) 2005, Jouni Malinen <j@w1.fi>
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * See base64.c for more details
+ */
+
+#ifndef BASE64_H
+#define BASE64_H
+
+size_t base64_encode(const unsigned char *src, size_t len,
+                  unsigned char *out, size_t out_len);
+size_t base64_decode(const unsigned char *src, size_t len,
+                  unsigned char *out, size_t out_len);
+
+#endif /* BASE64_H */

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -456,9 +456,11 @@ Meta Debug
 The meta debug command is a human readable dump of all available internal
 metadata of an item, minus the value.
 
-me <key>\r\n
+me <key> <flag>\r\n
 
 - <key> means one key string.
+- if <flag> is 'b', then <key> is a base64 encoded binary value. the response
+  key will also be base64 encoded.
 
 The response looks like:
 
@@ -528,6 +530,7 @@ Unless the (q) flag was supplied, which suppresses the status code for a miss.
 
 The flags used by the 'mg' command are:
 
+- b: interpret key as base64 encoded binary value
 - c: return item cas token
 - f: return client flags token
 - h: return whether item has been hit before as a 0 or 1
@@ -551,6 +554,15 @@ These extra flags can be added to the response:
 - Z: tem has already sent a winning flag
 
 The flags are now repeated with detailed information where useful:
+
+- b: interpret key as base64 encoded binary value
+
+This flag instructs memcached to run a base64 decoder on <key> before looking
+it up. This allows storing and fetching of binary packed keys, so long as they
+are sent to memcached in base64 encoding.
+
+If 'b' flag is sent in the response, and a key is returned via 'k', this
+signals to the client that the key is base64 encoded binary.
 
 - h: return whether item has been hit before as a 0 or 1
 - l: return time since item was last accessed in seconds
@@ -694,6 +706,7 @@ with CAS semantics did not exist.
 
 The flags used by the 'ms' command are:
 
+- b: interpret key as base64 encoded binary value (see metaget)
 - C(token): compare CAS value when storing item
 - F(token): set client flags to token (32 bit unsigned numeric)
 - I: invalidate. set-to-invalid if supplied CAS is older than item's CAS
@@ -774,6 +787,7 @@ Where CD is one of:
 
 The flags used by the 'md' command are:
 
+- b: interpret key as base64 encoded binary value (see metaget)
 - C(token): compare CAS value
 - I: invalidate. mark as stale, bumps CAS.
 - k: return key
@@ -846,6 +860,7 @@ VA <size> <flags>*\r\n
 
 The flags used by the 'ma' command are:
 
+- b: interpret key as base64 encoded binary value (see metaget)
 - C(token): compare CAS value (see mset)
 - N(token): auto create item on miss with supplied TTL
 - J(token): initial value to use if auto created after miss (default 0)

--- a/items.c
+++ b/items.c
@@ -614,7 +614,8 @@ char *item_cachedump(const unsigned int slabs_clsid, const unsigned int limit, u
 
     while (it != NULL && (limit == 0 || shown < limit)) {
         assert(it->nkey <= KEY_MAX_LENGTH);
-        if (it->nbytes == 0 && it->nkey == 0) {
+        // protect from printing binary keys.
+        if ((it->nbytes == 0 && it->nkey == 0) || (it->it_flags & ITEM_KEY_BINARY)) {
             it = it->next;
             continue;
         }

--- a/memcached.h
+++ b/memcached.h
@@ -519,6 +519,8 @@ extern struct settings settings;
 #define ITEM_TOKEN_RESERVED 1024
 /* if item has been marked as a stale value */
 #define ITEM_STALE 2048
+/* if item key was sent in binary */
+#define ITEM_KEY_BINARY 4096
 
 /**
  * Structure for storing items within memcached.

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -149,6 +149,23 @@ my $sock = $server->sock;
 }
 
 {
+    diag "encoded binary keys";
+    # 44OG44K544OI is "tesuto" in katakana
+    my $tesuto = "44OG44K544OI";
+    print $sock "ms $tesuto S2 b\r\npo\r\n";
+    like(scalar <$sock>, qr/^OK /, "set with encoded key");
+
+    my $res = mget($sock, $tesuto, 'v');
+    ok(! exists $res->{val}, "encoded key doesn't exist");
+    $res = mget($sock, $tesuto, 'b v k');
+    ok(exists $res->{val}, "decoded key exists");
+    ok(get_flag($res, 'k') eq $tesuto, "key returned encoded");
+
+    # TODO: test k is returned properly from ms.
+    # validate the store data is smaller somehow?
+}
+
+{
     diag "marithmetic tests";
     print $sock "ma mo\r\n";
     like(scalar <$sock>, qr/^NF/, "incr miss");


### PR DESCRIPTION
ie: ms [key] b
if 'k' flag is given and key is binary, returns as binary encoded.

key is stored in raw binary; ie takes up less storage space. Instead of storing a large UUID as a 40+ character string, you can store as a 24byte or whatever value.

TODO:
- [x] Add 'b' option to `ME` for binary keys
- [x] adding 'b' to response when 'k' is requested is the right thing to do?
- [x] re-audit codebase to ensure binary keys don't leak anywhere. This should've been done a long time ago.
- [x] check against proxy branch: the inline decoding of the key might make things more difficult there? but this only happens when the process_m stuff is actually run.
- [x] doc/protocol.txt updates
- [ ] properly calculate remaining wbuf length in META_KEY()
- [ ] handle key length check in `_meta_preparse` to account for b64 encodings of 250 raw byte keys being longer than 250 bytes.