### PR TITLE
item crawler hash table walk mode

### DIFF
--- a/assoc.h
+++ b/assoc.h
@@ -9,7 +9,7 @@ void stop_assoc_maintenance_thread(void);
 void assoc_start_expand(uint64_t curr_items);
 /* walk functions */
 void *assoc_get_iterator(void);
-item *assoc_iterate(void *iterp);
+bool assoc_iterate(void *iterp, item **it);
 void assoc_iterate_final(void *iterp);
 
 extern unsigned int hashpower;

--- a/assoc.h
+++ b/assoc.h
@@ -7,5 +7,10 @@ void do_assoc_move_next_bucket(void);
 int start_assoc_maintenance_thread(void);
 void stop_assoc_maintenance_thread(void);
 void assoc_start_expand(uint64_t curr_items);
+/* walk functions */
+void *assoc_get_iterator(void);
+item *assoc_iterate(void *iterp);
+void assoc_iterate_final(void *iterp);
+
 extern unsigned int hashpower;
 extern unsigned int item_lock_hashpower;

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1071,12 +1071,17 @@ The response line could be one of:
 
 - "BADCLASS [message]" to indicate an invalid class was specified.
 
-lru_crawler metadump <classid,classid,classid|all>
+lru_crawler metadump <classid,classid,classid|all|hash>
 
 - Similar in function to the above "lru_crawler crawl" command, this function
   outputs one line for every valid item found in the matching slab classes.
   Similar to "cachedump", but does not lock the cache and can return all
   items, not just 1MB worth.
+
+  if "hash" is specified instead of a classid or "all", the crawler will dump
+  items by directly walking the hash table instead of the LRU's. This makes it
+  more likely all items will be visited once as LRU reordering and locking can
+  cause frequently accessed items to be missed.
 
   Lines are in "key=value key2=value2" format, with value being URI encoded
   (ie: %20 for a space).


### PR DESCRIPTION
code compiles but not tested/completed yet.

specifying 'hash' instead of 'all' will make the LRU crawler iterate
over every bucket in the hash table once, instead of what's in the LRU.
This also doesn't suffer from missing items because of LRU reordering
or high lock contention.