### PR TITLE
Expose memory_file path in stats settings

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1389,6 +1389,7 @@ other stats command.
 |                   | bool     | Does nothing as of 1.5.15                    |
 | drop_privileges   | bool     | If yes, and available, drop unused syscalls  |
 |                   |          | (see seccomp on Linux, pledge on OpenBSD)    |
+| memory_file       | char     | Warm restart memory file path, if enabled    |
 |-------------------+----------+----------------------------------------------|
 
 

--- a/memcached.h
+++ b/memcached.h
@@ -489,6 +489,7 @@ struct settings {
     bool ssl_session_cache; /* enable SSL server session caching */
 #endif
     int num_napi_ids;   /* maximum number of NAPI IDs */
+    char *memory_file;  /* warm restart memory file path */
 };
 
 extern struct stats stats;

--- a/t/restart.t
+++ b/t/restart.t
@@ -24,6 +24,12 @@ my $mem_path = "/tmp/mc_restart.$$";
 my $server = new_memcached("-m 128 -e $mem_path -I 2m");
 my $sock = $server->sock;
 
+diag "restart basic stats";
+{
+    my $stats = mem_stats($server->sock, ' settings');
+    is($stats->{memory_file}, $mem_path);
+}
+
 diag "Set some values, various sizes.";
 {
     my $cur = 2;


### PR DESCRIPTION
This change proposes the ability to read back the wam restart memory file path in a `stats settings` command, in similar spirit as some other options like `ssl_chain_cert`. We have found this useful when querying metrics targeting only clusters with warm restart enabled (since `stats settings` output is scraped into the metrics system).

With a memory file:

```bash
$ echo "stats settings" | nc -q0 localhost 11211 | grep memory_file
STAT memory_file /tmp/restart-test
```

Without:

```bash
$ echo "stats settings" | nc -q0 localhost 11211 | grep memory_file
STAT memory_file (null)
```