### PR TITLE
Graceful shutdown protocol command

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1689,9 +1689,11 @@ be released back to the OS asynchronously.
 The argument is in megabytes, not bytes. Input gets multiplied out into
 megabytes internally.
 
-"shutdown" and "shutdown_graceful" are commands with no arguments, and
-can be used to stop memcached with signals SIGINT and SIGUSR1, respectively.
-These commands are disabled by default, but can be enabled with the -A flag.
+"shutdown" is a command with an optional argument used to stop memcached with
+a kill signal. By default, "shutdown" alone raises SIGINT, though "graceful"
+may be specified as the single argument to instead trigger a graceful shutdown
+with SIGUSR1. The shutdown command is disabled by default, and can be enabled
+with the -A/--enable-shutdown flag.
 
 "version" is a command with no arguments:
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1689,6 +1689,10 @@ be released back to the OS asynchronously.
 The argument is in megabytes, not bytes. Input gets multiplied out into
 megabytes internally.
 
+"shutdown" and "shutdown_graceful" are commands with no arguments, and
+can be used to stop memcached with signals SIGINT and SIGUSR1, respectively.
+These commands are disabled by default, but can be enabled with the -A flag.
+
 "version" is a command with no arguments:
 
 version\r\n

--- a/proto_text.c
+++ b/proto_text.c
@@ -2348,10 +2348,10 @@ static void process_quit_command(conn *c) {
     c->close_after_write = true;
 }
 
-static void process_shutdown_command(conn *c) {
+static void process_shutdown_command(conn *c, int signal) {
     if (settings.shutdown_command) {
         conn_set_state(c, conn_closing);
-        raise(SIGINT);
+        raise(signal);
     } else {
         out_string(c, "ERROR: shutdown not enabled");
     }
@@ -2620,7 +2620,10 @@ static void process_command(conn *c, char *command) {
             process_stat(c, tokens, ntokens);
         } else if (strcmp(tokens[COMMAND_TOKEN].value, "shutdown") == 0) {
 
-            process_shutdown_command(c);
+            process_shutdown_command(c, SIGINT);
+        } else if (strcmp(tokens[COMMAND_TOKEN].value, "shutdown_graceful") == 0) {
+
+            process_shutdown_command(c, SIGUSR1);
         } else if (strcmp(tokens[COMMAND_TOKEN].value, "slabs") == 0) {
 
             process_slabs_command(c, tokens, ntokens);

--- a/t/shutdown.t
+++ b/t/shutdown.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $server;
+my $sock;
+
+# Disabled shutdown (default)
+$server = new_memcached();
+$sock = $server->sock;
+print $sock "shutdown\r\n";
+is(scalar <$sock>, "ERROR: shutdown not enabled\r\n",
+    "error when shutdown is not enabled");
+$server->DESTROY();
+
+# Normal shutdown
+$server = new_memcached("-A");
+$sock = $server->sock;
+print $sock "version\r\n";
+like(scalar <$sock>, qr/VERSION/, "server is alive");
+print $sock "shutdown\r\n";
+print $sock "version\r\n";
+is(scalar <$sock>, undef, "server has been shut down");
+
+# Graceful shutdown
+$server = new_memcached("-A");
+$sock = $server->sock;
+print $sock "version\r\n";
+like(scalar <$sock>, qr/VERSION/, "server is alive");
+print $sock "shutdown_graceful\r\n";
+print $sock "version\r\n";
+is(scalar <$sock>, undef, "server has been gracefully shut down");
+
+done_testing();

--- a/t/shutdown.t
+++ b/t/shutdown.t
@@ -18,21 +18,28 @@ is(scalar <$sock>, "ERROR: shutdown not enabled\r\n",
     "error when shutdown is not enabled");
 $server->DESTROY();
 
+# Shutdown command error
+$server = new_memcached("-A");
+$sock = $server->sock;
+print $sock "shutdown foo\r\n";
+like(scalar <$sock>, qr/CLIENT_ERROR/, "rejected invalid shutdown mode");
+$server->DESTROY();
+
 # Normal shutdown
 $server = new_memcached("-A");
 $sock = $server->sock;
 print $sock "version\r\n";
-like(scalar <$sock>, qr/VERSION/, "server is alive");
+like(scalar <$sock>, qr/VERSION/, "server is initially alive");
 print $sock "shutdown\r\n";
 print $sock "version\r\n";
-is(scalar <$sock>, undef, "server has been shut down");
+is(scalar <$sock>, undef, "server has been normally shut down");
 
 # Graceful shutdown
 $server = new_memcached("-A");
 $sock = $server->sock;
 print $sock "version\r\n";
-like(scalar <$sock>, qr/VERSION/, "server is alive");
-print $sock "shutdown_graceful\r\n";
+like(scalar <$sock>, qr/VERSION/, "server is initially alive");
+print $sock "shutdown graceful\r\n";
 print $sock "version\r\n";
 is(scalar <$sock>, undef, "server has been gracefully shut down");
 


### PR DESCRIPTION
- Add a new subcommand `shutdown graceful` that raises a `SIGUSR1` for graceful shutdown.
- Add some documentation on the shutdown command in `doc/protocol.txt`
- Also add a simple unit test for shutdown behavior. I realized that there's already a test defined in testapp, I can get rid of the Perl test added here in favor of updating that one if that is preferred.

Manual test:

Shutdown enabled:

```
$ echo "shutdown" | nc -q0 localhost 11211
...
Signal handled: Interrupt.
$ echo "shutdown graceful" | nc -q0 localhost 11211
...
Graceful shutdown signal handled: User defined signal 1.
Gracefully stopping
```

```
$ echo "shutdown asdfsad" | nc -q0 localhost 11211
CLIENT_ERROR invalid shutdown mode
```

Shutdown not enabled (default):

```
$ echo "shutdown" | nc -q0 localhost 11211
ERROR: shutdown not enabled
$ echo "shutdown graceful" | nc -q0 localhost 11211
ERROR: shutdown not enabled
$ echo "shutdown foo" | nc -q0 localhost 11211
ERROR: shutdown not enabled
```

Resolves #739.