### PR TITLE
core: support malloc'ed blobs for body read

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -728,6 +728,7 @@ struct conn {
     bool mset_res; /** uses mset format for return code */
     bool close_after_write; /** flush write then move to close connection */
     bool rbuf_malloced; /** read buffer was malloc'ed for ascii mget, needs free() */
+    bool item_malloced; /** item for conn_nread state is a temporary malloc */
 #ifdef TLS
     SSL    *ssl;
     char   *ssl_wbuf;


### PR DESCRIPTION
conn_nread state handles c->item like an item, but allow it to be a
temporary malloced blob via setting c->item_malloced = true.

to be used for buffering value reads in the proxy code.

----

just putting this up as a PR for visibility. took a while of thinking about it to simplify it to this level: it's not safe to examine c->item as an item when it's a malloced buffer, but it never will if we check `c->item_malloced` first :)

Seems a simple enough change otherwise. conn_nread has a few bail points that pass through closing, and `c->item` is handled via that path. I might go back to using the slabber for buffering SETs depending on how large they are or if they intend to be duped locally later.