### PR TITLE
Allow metadump to output keys without URI encoding them

### DIFF
--- a/crawler.h
+++ b/crawler.h
@@ -33,10 +33,10 @@ int start_item_crawler_thread(void);
 int stop_item_crawler_thread(bool wait);
 int init_lru_crawler(void *arg);
 enum crawler_result_type lru_crawler_crawl(char *slabs, enum crawler_run_type,
-        void *c, const int sfd, unsigned int remaining);
+        void *c, const int sfd, unsigned int remaining, bool noencode);
 int lru_crawler_start(uint8_t *ids, uint32_t remaining,
                              const enum crawler_run_type type, void *data,
-                             void *c, const int sfd);
+                             void *c, const int sfd, bool noencode);
 void lru_crawler_pause(void);
 void lru_crawler_resume(void);
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1071,7 +1071,7 @@ The response line could be one of:
 
 - "BADCLASS [message]" to indicate an invalid class was specified.
 
-lru_crawler metadump <classid,classid,classid|all|hash>
+lru_crawler metadump <classid,classid,classid|all|hash> [noencode]
 
 - Similar in function to the above "lru_crawler crawl" command, this function
   outputs one line for every valid item found in the matching slab classes.
@@ -1090,6 +1090,9 @@ lru_crawler metadump <classid,classid,classid|all|hash>
 
   "key", "exp" (expiration time), "la", (last access time), "cas",
   "fetch" (if item has been fetched before).
+
+  "noencode" optional parameter that instructs MC to output the key without
+  URL encoding it.
 
 The response line could be one of:
 

--- a/items.c
+++ b/items.c
@@ -1538,7 +1538,7 @@ static void lru_maintainer_crawler_check(struct crawler_expired_data *cdata, log
         if (settings.lru_crawler_tocrawl && settings.lru_crawler_tocrawl < tocrawl_limit) {
             tocrawl_limit = settings.lru_crawler_tocrawl;
         }
-        lru_crawler_start(todo, tocrawl_limit, CRAWLER_AUTOEXPIRE, cdata, NULL, 0);
+        lru_crawler_start(todo, tocrawl_limit, CRAWLER_AUTOEXPIRE, cdata, NULL, 0, false);
     }
 }
 

--- a/proto_text.c
+++ b/proto_text.c
@@ -2416,7 +2416,7 @@ static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t n
         }
 
         rv = lru_crawler_crawl(tokens[2].value, CRAWLER_EXPIRED, NULL, 0,
-                settings.lru_crawler_tocrawl);
+                settings.lru_crawler_tocrawl, false);
         switch(rv) {
         case CRAWLER_OK:
             out_string(c, "OK");
@@ -2435,7 +2435,8 @@ static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t n
             break;
         }
         return;
-    } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "metadump") == 0) {
+    } else if ((ntokens == 4 || ntokens == 5) &&
+            strcmp(tokens[COMMAND_TOKEN + 1].value, "metadump") == 0) {
         if (settings.lru_crawler == false) {
             out_string(c, "CLIENT_ERROR lru crawler disabled");
             return;
@@ -2449,8 +2450,16 @@ static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t n
             return;
         }
 
+        bool noencode = false;
+        if (ntokens == 5 && !strncmp(tokens[3].value, "noencode", 8)) {
+            noencode = true;
+        } else if (ntokens == 5) {
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+
         int rv = lru_crawler_crawl(tokens[2].value, CRAWLER_METADUMP,
-                c, c->sfd, LRU_CRAWLER_CAP_REMAINING);
+                c, c->sfd, LRU_CRAWLER_CAP_REMAINING, noencode);
         switch(rv) {
             case CRAWLER_OK:
                 // TODO: documentation says this string is returned, but


### PR DESCRIPTION
When "lru_crawler metadump all/<slabid>" is given the "noencode"
option, it outputs non-URL-encoded keys.

TODO: Add test