### PR TITLE
Allow metadump to output keys without URI encoding them (Method 2)

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1071,7 +1071,7 @@ The response line could be one of:
 
 - "BADCLASS [message]" to indicate an invalid class was specified.
 
-lru_crawler metadump <classid,classid,classid|all|hash>
+lru_crawler metadump <classid,classid,classid|all|hash> [noencode]
 
 - Similar in function to the above "lru_crawler crawl" command, this function
   outputs one line for every valid item found in the matching slab classes.
@@ -1090,6 +1090,9 @@ lru_crawler metadump <classid,classid,classid|all|hash>
 
   "key", "exp" (expiration time), "la", (last access time), "cas",
   "fetch" (if item has been fetched before).
+
+  "noencode" optional parameter that instructs MC to output the key without
+  URL encoding it.
 
 The response line could be one of:
 

--- a/memcached.h
+++ b/memcached.h
@@ -551,7 +551,7 @@ typedef struct _stritem {
 
 // TODO: If we eventually want user loaded modules, we can't use an enum :(
 enum crawler_run_type {
-    CRAWLER_AUTOEXPIRE=0, CRAWLER_EXPIRED, CRAWLER_METADUMP
+    CRAWLER_AUTOEXPIRE=0, CRAWLER_EXPIRED, CRAWLER_METADUMP, CRAWLER_METADUMP_NOENCODE
 };
 
 typedef struct {

--- a/proto_text.c
+++ b/proto_text.c
@@ -2435,7 +2435,8 @@ static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t n
             break;
         }
         return;
-    } else if (ntokens == 4 && strcmp(tokens[COMMAND_TOKEN + 1].value, "metadump") == 0) {
+    } else if ((ntokens == 4 || ntokens == 5) &&
+            strcmp(tokens[COMMAND_TOKEN + 1].value, "metadump") == 0) {
         if (settings.lru_crawler == false) {
             out_string(c, "CLIENT_ERROR lru crawler disabled");
             return;
@@ -2449,7 +2450,16 @@ static void process_lru_crawler_command(conn *c, token_t *tokens, const size_t n
             return;
         }
 
-        int rv = lru_crawler_crawl(tokens[2].value, CRAWLER_METADUMP,
+        bool noencode = false;
+        if (ntokens == 5 && !strncmp(tokens[3].value, "noencode", 8)) {
+            noencode = true;
+        } else if (ntokens == 5) {
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+
+        int rv = lru_crawler_crawl(tokens[2].value,
+                noencode ? CRAWLER_METADUMP_NOENCODE : CRAWLER_METADUMP,
                 c, c->sfd, LRU_CRAWLER_CAP_REMAINING);
         switch(rv) {
             case CRAWLER_OK:


### PR DESCRIPTION
This patch creates a new crawler module type called
CRAWLER_METADUMP_NOENCODE. When given the "noencode" option while
doing a metadump operation, this new module type will be evaluated
on every key which skips URI encoding them before outputting them.

TODO: Add test