### PR TITLE
Logger: customize max sleep

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -510,7 +510,6 @@ static void logger_thread_sum_stats(struct logger_stats *ls) {
     STATS_UNLOCK();
 }
 
-#define MAX_LOGGER_SLEEP 1000000
 #define MIN_LOGGER_SLEEP 1000
 
 /* Primary logger thread routine */
@@ -541,10 +540,10 @@ static void *logger_thread(void *arg) {
 
         /* TODO: abstract into a function and share with lru_crawler */
         if (!found_logs) {
-            if (to_sleep < MAX_LOGGER_SLEEP)
+            if (to_sleep < settings.logger_max_sleep)
                 to_sleep += to_sleep / 8;
-            if (to_sleep > MAX_LOGGER_SLEEP)
-                to_sleep = MAX_LOGGER_SLEEP;
+            if (to_sleep > settings.logger_max_sleep)
+                to_sleep = settings.logger_max_sleep;
         } else {
             to_sleep /= 2;
             if (to_sleep < MIN_LOGGER_SLEEP)

--- a/memcached.h
+++ b/memcached.h
@@ -455,6 +455,7 @@ struct settings {
     int idle_timeout;       /* Number of seconds to let connections idle */
     unsigned int logger_watcher_buf_size; /* size of logger's per-watcher buffer */
     unsigned int logger_buf_size; /* size of per-thread logger buffer */
+    unsigned int logger_max_sleep; /* max sleep time of logger */
     unsigned int read_buf_mem_limit; /* total megabytes allowable for net buffers */
     bool drop_privileges;   /* Whether or not to drop unnecessary process privileges */
     bool watch_enabled; /* allows watch commands to be dropped */


### PR DESCRIPTION
allow to change logger max sleep time. Usefull to increase on
mostly idle cases like docker on dev machine.