### PR TITLE
logger: Report item sizes for fetch, mutation, and eviction watchers

### DIFF
--- a/items.c
+++ b/items.c
@@ -1029,8 +1029,8 @@ item *do_item_get(const char *key, const size_t nkey, const uint32_t hv, conn *c
     if (settings.verbose > 2)
         fprintf(stderr, "\n");
     /* For now this is in addition to the above verbose logging. */
-    LOGGER_LOG(c->thread->l, LOG_FETCHERS, LOGGER_ITEM_GET, NULL, was_found, key, nkey,
-               (it) ? ITEM_clsid(it) : 0, c->sfd);
+    LOGGER_LOG(c->thread->l, LOG_FETCHERS, LOGGER_ITEM_GET, NULL, was_found, key,
+               nkey, (it) ? it->nbytes : 0, (it) ? ITEM_clsid(it) : 0, c->sfd);
 
     return it;
 }

--- a/logger.h
+++ b/logger.h
@@ -63,6 +63,7 @@ typedef const struct {
 /* log entry intermediary structures */
 struct logentry_eviction {
     long long int exptime;
+    int nbytes;
     uint32_t latime;
     uint16_t it_flags;
     uint8_t nkey;
@@ -84,6 +85,7 @@ struct logentry_item_get {
     uint8_t was_found;
     uint8_t nkey;
     uint8_t clsid;
+    int nbytes;
     int sfd;
     char key[];
 };
@@ -94,6 +96,7 @@ struct logentry_item_store {
     rel_time_t ttl;
     uint8_t nkey;
     uint8_t clsid;
+    int nbytes;
     int sfd;
     char key[];
 };

--- a/memcached.c
+++ b/memcached.c
@@ -1638,7 +1638,8 @@ enum store_item_type do_store_item(item *it, int comm, conn *c, const uint32_t h
         c->cas = ITEM_get_cas(it);
     }
     LOGGER_LOG(c->thread->l, LOG_MUTATIONS, LOGGER_ITEM_STORE, NULL,
-            stored, comm, ITEM_key(it), it->nkey, it->exptime, ITEM_clsid(it), c->sfd);
+            stored, comm, ITEM_key(it), it->nkey, it->nbytes, it->exptime,
+            ITEM_clsid(it), c->sfd);
 
     return stored;
 }


### PR DESCRIPTION
This change proposes the addition of a new tag `size` (int) for watchers on `fetchers`, `mutations`, and `evictions` that expresses the value size of the associated item in bytes.

This has been quite useful, for example, for building histograms of item value sizes partitioned by key prefix for traffic into a large shared-tenancy cluster.

If there's interest in this change, I'm also happy to add a test to `t/watcher.t` if desired.

Some sample representative output from `watch fetchers mutations`:

```
ts=1621616365.760769 gid=13491372 type=item_store key=<scrubbed> status=stored cmd=set ttl=360 clsid=8 cfd=134 size=350
ts=1621616365.763121 gid=13491375 type=item_get key=<scrubbed> status=not_found clsid=0 cfd=134 size=0
ts=1621616365.763121 gid=13491376 type=item_store key=<scrubbed> status=stored cmd=set ttl=360 clsid=8 cfd=134 size=350
ts=1621616365.766095 gid=13491377 type=item_get key=<scrubbed> status=found clsid=8 cfd=144 size=350
ts=1621616365.766215 gid=13491378 type=item_get key=<scrubbed> status=found clsid=8 cfd=99 size=350
ts=1621616365.770232 gid=13491379 type=item_get key=<scrubbed> status=not_found clsid=0 cfd=40 size=0
ts=1621616365.781125 gid=13491380 type=item_get key=<scrubbed> status=found clsid=8 cfd=111 size=350
ts=1621616365.781126 gid=13491381 type=item_store key=<scrubbed> status=stored cmd=set ttl=360 clsid=8 cfd=111 size=350
ts=1621616365.781809 gid=13491382 type=item_get key=<scrubbed> status=found clsid=8 cfd=99 size=350
ts=1621616365.781810 gid=13491383 type=item_store key=<scrubbed> status=stored cmd=set ttl=360 clsid=8 cfd=99 size=350
ts=1621616365.791614 gid=13491384 type=item_get key=<scrubbed> status=not_found clsid=0 cfd=78 size=0
```