### PR TITLE
logger: Implementation proposal for LOG_CONNEVENTS

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1125,7 +1125,7 @@ Watchers are a way to connect to memcached and inspect what's going on
 internally. This is an evolving feature so new endpoints should show up over
 time.
 
-watch <fetchers|mutations|evictions>
+watch <fetchers|mutations|evictions|connevents>
 
 - Turn connection into a watcher. Options can be stacked and are
   space-separated. Logs will be sent to the watcher until it disconnects.
@@ -1159,6 +1159,11 @@ The arguments are:
 - "evictions": Shows some information about items as they are evicted from the
   cache. Useful in seeing if items being evicted were actually used, and which
   keys are getting removed.
+
+- "connevents": Emits logs when connections are opened and closed, i.e. when
+  clients connect or disconnect. For TCP transports, logs indicate the remote
+  address IP and port. Connection close events additionally supply a reason for
+  closing the connection.
 
 Statistics
 ----------

--- a/logger.h
+++ b/logger.h
@@ -20,6 +20,8 @@ enum log_entry_type {
     LOGGER_ITEM_STORE,
     LOGGER_CRAWLER_STATUS,
     LOGGER_SLAB_MOVE,
+    LOGGER_CONNECTION_NEW,
+    LOGGER_CONNECTION_CLOSE,
 #ifdef EXTSTORE
     LOGGER_EXTSTORE_WRITE,
     LOGGER_COMPACT_START,
@@ -36,6 +38,8 @@ enum log_entry_subtype {
     LOGGER_EVICTION_ENTRY,
     LOGGER_ITEM_GET_ENTRY,
     LOGGER_ITEM_STORE_ENTRY,
+    LOGGER_CONNECTION_NEW_ENTRY,
+    LOGGER_CONNECTION_CLOSE_ENTRY,
 #ifdef EXTSTORE
     LOGGER_EXT_WRITE_ENTRY,
 #endif
@@ -99,6 +103,13 @@ struct logentry_item_store {
     int nbytes;
     int sfd;
     char key[];
+};
+
+struct logentry_conn_event {
+    int transport;
+    int reason;
+    int sfd;
+    struct sockaddr addr;
 };
 
 /* end intermediary structures */

--- a/memcached.h
+++ b/memcached.h
@@ -245,6 +245,13 @@ enum stop_reasons {
     EXIT_NORMALLY
 };
 
+enum close_reasons {
+    ERROR_CLOSE,
+    NORMAL_CLOSE,
+    IDLE_TIMEOUT_CLOSE,
+    SHUTDOWN_CLOSE,
+};
+
 #define IS_TCP(x) (x == tcp_transport)
 #define IS_UDP(x) (x == udp_transport)
 
@@ -773,6 +780,7 @@ struct conn {
 #endif
     enum protocol protocol;   /* which protocol this connection speaks */
     enum network_transport transport; /* what transport is used by this connection */
+    enum close_reasons close_reason; /* reason for transition into conn_closing */
 
     /* data for UDP clients */
     int    request_id; /* Incoming UDP request ID, if this is a UDP "connection" */

--- a/proto_bin.c
+++ b/proto_bin.c
@@ -1032,6 +1032,7 @@ static void dispatch_bin_command(conn *c, char *extbuf) {
                 write_bin_response(c, NULL, 0, 0, 0);
                 conn_set_state(c, conn_mwrite);
                 c->close_after_write = true;
+                c->close_reason = NORMAL_CLOSE;
             } else {
                 protocol_error = 1;
             }

--- a/proto_text.c
+++ b/proto_text.c
@@ -2269,6 +2269,8 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
                 f |= LOG_MUTATIONS;
             } else if ((strcmp(tokens[x].value, "sysevents") == 0)) {
                 f |= LOG_SYSEVENTS;
+            } else if ((strcmp(tokens[x].value, "connevents") == 0)) {
+                f |= LOG_CONNEVENTS;
             } else {
                 out_string(c, "ERROR");
                 return;
@@ -2485,6 +2487,7 @@ static void process_version_command(conn *c) {
 static void process_quit_command(conn *c) {
     conn_set_state(c, conn_mwrite);
     c->close_after_write = true;
+    c->close_reason = NORMAL_CLOSE;
 }
 
 static void process_shutdown_command(conn *c, token_t *tokens, const size_t ntokens) {
@@ -2494,9 +2497,11 @@ static void process_shutdown_command(conn *c, token_t *tokens, const size_t ntok
     }
 
     if (ntokens == 2) {
+        c->close_reason = SHUTDOWN_CLOSE;
         conn_set_state(c, conn_closing);
         raise(SIGINT);
     } else if (ntokens == 3 && strcmp(tokens[SUBCOMMAND_TOKEN].value, "graceful") == 0) {
+        c->close_reason = SHUTDOWN_CLOSE;
         conn_set_state(c, conn_closing);
         raise(SIGUSR1);
     } else {


### PR DESCRIPTION
This PR adds support for recognizing a new watcher command `connevents` which enables the existing but not yet implemented `LOG_CONNEVENTS` flag. It adds support for logging events on new connections and closed connections.

Consider this a draft implementation proposal. There's still some testing left to do (esp. with protocols other than TCP), and docs and tests need to be added as well. I'll work on those items if this change is in the general right direction, and something desirable to include upstream.

The current proposal shapes log lines something like this:

```
ts=1622360517.365343 gid=1 type=conn_new rip=::1 rport=56972 transport=tcp cfd=29
ts=1622360520.236421 gid=2 type=conn_close rip=::1 rport=56972 transport=tcp cfd=29
ts=1622360532.667576 gid=3 type=conn_new rip=127.0.0.1 rport=49332 transport=tcp cfd=29
ts=1622360534.714145 gid=4 type=conn_close rip=127.0.0.1 rport=49332 transport=tcp cfd=29
```