### PR TITLE
Expose shutdown_command state in `stats settings`

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1363,6 +1363,7 @@ other stats command.
 | evictions         | on/off   | When off, LRU evictions are disabled.        |
 | domain_socket     | string   | Path to the domain socket (if any).          |
 | umask             | 32 (oct) | umask for the creation of the domain socket. |
+| shutdown_command  | yes/no   | If shutdown admin command is enabled.        |
 | growth_factor     | float    | Chunk size growth factor.                    |
 | chunk_size        | 32       | Minimum space allocated for key+value+flags. |
 | num_threads       | 32       | Number of threads (including dispatch).      |

--- a/memcached.c
+++ b/memcached.c
@@ -1819,6 +1819,8 @@ void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("domain_socket", "%s",
                 settings.socketpath ? settings.socketpath : "NULL");
     APPEND_STAT("umask", "%o", settings.access);
+    APPEND_STAT("shutdown_command", "%s",
+                settings.shutdown_command ? "yes" : "no");
     APPEND_STAT("growth_factor", "%.2f", settings.factor);
     APPEND_STAT("chunk_size", "%d", settings.chunk_size);
     APPEND_STAT("num_threads", "%d", settings.num_threads);

--- a/t/stats.t
+++ b/t/stats.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 108;
+use Test::More tests => 109;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -147,6 +147,7 @@ if (enabled_tls_testing() || !supports_unix_socket()) {
 is('on', $settings->{'evictions'});
 is('yes', $settings->{'cas_enabled'});
 is('no', $settings->{'auth_enabled_sasl'});
+is('no', $settings->{'shutdown_command'});
 
 print $sock "stats reset\r\n";
 is(scalar <$sock>, "RESET\r\n", "good stats reset");


### PR DESCRIPTION
Loosely related follow-up to some earlier changes around the shutdown command. This change proposes exposing the value of `settings.shutdown_command` (set with `-A` or `--enable-shutdown`) in the output for `stats settings`.

```
$ echo "stats settings" | nc -q0 localhost 11211 | grep shutdown
STAT shutdown_command no
```

```
$ ./memcached -A
...
$ echo "stats settings" | nc -q0 localhost 11211 | grep shutdown
STAT shutdown_command yes
```