### PR TITLE
[docker] Add a new user to the docker images

### DIFF
--- a/devtools/Dockerfile.alpine
+++ b/devtools/Dockerfile.alpine
@@ -2,13 +2,16 @@ FROM alpine:latest
 
 ARG CONFIGURE_OPTS="--enable-seccomp"
 
-RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf perl-test-harness-utils
+RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf perl-test-harness-utils git
 
+RUN adduser -S memcached
 ADD . /src
 WORKDIR /src
 
 RUN ./autogen.sh
 RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
+
+USER memcached
 
 CMD make test

--- a/devtools/Dockerfile.arch
+++ b/devtools/Dockerfile.arch
@@ -5,6 +5,7 @@ ARG CONFIGURE_OPTS="--enable-seccomp"
 RUN pacman -Sy && pacman --noconfirm -S gcc automake autoconf libevent libseccomp git make perl
 RUN ln -s /usr/bin/core_perl/prove /usr/bin/prove
 
+RUN useradd -ms /bin/bash memcached
 ADD . /src
 WORKDIR /src
 
@@ -15,5 +16,7 @@ RUN autoconf
 
 RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
+
+USER memcached
 
 CMD make test

--- a/devtools/Dockerfile.fedora
+++ b/devtools/Dockerfile.fedora
@@ -4,11 +4,14 @@ ARG CONFIGURE_OPTS="--enable-seccomp"
 
 RUN dnf install -y perl automake autoconf libseccomp-devel libevent-devel gcc make git
 
+RUN useradd -ms /bin/bash memcached
 ADD . /src
 WORKDIR /src
 
 RUN aclocal && autoheader && automake --foreign --add-missing && autoconf
 RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
+
+USER memcached
 
 CMD make test

--- a/devtools/Dockerfile.ubuntu
+++ b/devtools/Dockerfile.ubuntu
@@ -4,11 +4,14 @@ ARG CONFIGURE_OPTS="--enable-seccomp"
 
 RUN apt-get update && apt-get install -y build-essential automake1.11 autoconf libevent-dev libseccomp-dev git
 
+RUN useradd -ms /bin/bash memcached
 ADD . /src
 WORKDIR /src
 
 RUN ./autogen.sh
 RUN ./configure ${CONFIGURE_OPTS}
 RUN make -j
+
+USER memcached
 
 CMD make test


### PR DESCRIPTION
These changes aim to improve our memcached devtools images to allow us to reuse them during development stages.

These changes create a memcached user for all the images, switch to this user by default once memcached have been configured for building.

That allow to run the memcached server directly when the containers are started, else, without the user the run will fail as we try to execute memcached as root user.

Also we should notice that the alpine image has been fixed by adding git to the list of the requirements to install. Else the build will fails.