### PR TITLE
Fix minor severity heap buffer overflow reading `--auth-file`

### DIFF
--- a/authfile.c
+++ b/authfile.c
@@ -41,23 +41,29 @@ enum authfile_ret authfile_load(const char *file) {
         return AUTHFILE_STATFAIL;
     }
 
-    auth_data = calloc(1, sb.st_size);
+    auth_data = calloc(1, sb.st_size + 1);
 
     char *auth_cur = auth_data;
+    char *auth_end = auth_data + sb.st_size;
     auth_t *entry_cur = auth_entries;
     int used = 0;
 
-    while ((fgets(auth_cur, MAX_ENTRY_LEN, pwfile)) != NULL) {
+    while ((fgets(auth_cur, auth_end - auth_cur < MAX_ENTRY_LEN ? auth_end - auth_cur : MAX_ENTRY_LEN, pwfile)) != NULL) {
         int x;
         int found = 0;
 
         for (x = 0; x < MAX_ENTRY_LEN; x++) {
-            if (!found && auth_cur[x] == ':') {
-                entry_cur->user = auth_cur;
-                entry_cur->ulen = x;
-                entry_cur->pass = &auth_cur[x+1];
-                found = 1;
-            } else if (found) {
+            if (!found) {
+                if (auth_cur[x] == '\0') {
+                    // The username is malformed - this is either the end of the file or a null byte.
+                    break;
+                } else if (auth_cur[x] == ':') {
+                    entry_cur->user = auth_cur;
+                    entry_cur->ulen = x;
+                    entry_cur->pass = &auth_cur[x+1];
+                    found = 1;
+                }
+            } else {
                 // Find end of password.
                 if (auth_cur[x] == '\n' ||
                     auth_cur[x] == '\r' ||


### PR DESCRIPTION
Fixes #805

Allocate an extra byte for reading the last entry when there is no `\n` at
the end of the file.

Also, check if the user contains null bytes when reading the last entry.

Unrelatedly, add handling in case the auth file size changes while it is being read.

----
Should this start forbidding control characters in usernames such as `\r` as well (clients probably can't send that)

