### PR TITLE
logger: Properly accommodate IPv6 addresses in LOG_CONNEVENTS logs

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -138,14 +138,15 @@ static void _logger_log_item_store(logentry *e, const entry_details *d, const vo
 }
 
 static void _logger_log_conn_event(logentry *e, const entry_details *d, const void *entry, va_list ap) {
-    struct sockaddr *addr = va_arg(ap, struct sockaddr *);
+    struct sockaddr_in6 *addr = va_arg(ap, struct sockaddr_in6 *);
+    socklen_t addrlen = va_arg(ap, socklen_t);
     enum network_transport transport = va_arg(ap, enum network_transport);
     enum close_reasons reason = va_arg(ap, enum close_reasons);
     int sfd = va_arg(ap, int);
 
     struct logentry_conn_event *le = (struct logentry_conn_event *) e->data;
 
-    memcpy(&le->addr, addr, sizeof(struct sockaddr));
+    memcpy(&le->addr, addr, addrlen);
     le->sfd = sfd;
     le->transport = transport;
     le->reason = reason;
@@ -156,11 +157,11 @@ static void _logger_log_conn_event(logentry *e, const entry_details *d, const vo
  * Util functions used by the logger background thread
  *************************/
 
-static int _logger_util_addr_endpoint(struct sockaddr *addr, char *rip,
+static int _logger_util_addr_endpoint(struct sockaddr_in6 *addr, char *rip,
         size_t riplen, unsigned short *rport) {
     memset(rip, 0, riplen);
 
-    switch (addr->sa_family) {
+    switch (addr->sin6_family) {
         case AF_INET:
             inet_ntop(AF_INET, &((struct sockaddr_in *) addr)->sin_addr,
                     rip, riplen - 1);

--- a/logger.h
+++ b/logger.h
@@ -104,7 +104,7 @@ struct logentry_conn_event {
     int transport;
     int reason;
     int sfd;
-    struct sockaddr addr;
+    struct sockaddr_in6 addr;
 };
 
 /* end intermediary structures */

--- a/memcached.c
+++ b/memcached.c
@@ -676,7 +676,7 @@ conn *conn_new(const int sfd, enum conn_states init_state,
 
     if (init_state == conn_new_cmd) {
         LOGGER_LOG(NULL, LOG_CONNEVENTS, LOGGER_CONNECTION_NEW, NULL,
-                (struct sockaddr *) &c->request_addr, c->transport, 0, sfd);
+                &c->request_addr, c->request_addr_size, c->transport, 0, sfd);
     }
 
     if (settings.verbose > 1) {
@@ -864,7 +864,7 @@ static void conn_close(conn *c) {
 
     if (c->thread) {
         LOGGER_LOG(c->thread->l, LOG_CONNEVENTS, LOGGER_CONNECTION_CLOSE, NULL,
-                (struct sockaddr *) &c->request_addr, c->transport,
+                &c->request_addr, c->request_addr_size, c->transport,
                 c->close_reason, c->sfd);
     }
 


### PR DESCRIPTION
Unfortunately, I introduced a bug in #790 that I didn't catch at the time since I was primarily testing with IPv4.

When the remote peer is connected over IPv6, the cast `(struct sockaddr *) &c->request_addr` truncates the struct which causes the `inet_ntop` output for `rip` to be incorrect. The proposed fix is to retain the `struct sockaddr_in6` type defined [here](https://github.com/memcached/memcached/blob/d0fe0d591b5e9265131ad7371c51dd9b27f634f5/memcached.h#L676). `c->request_addr_size` abstracts away the size already (presumably to take care of IPv4/IPv6 differences).

Before this change:

IPv4:

```
$ nc -4 10.5.0.1 11211
```

```
ts=1629305951.994024 gid=6 type=conn_new rip=10.5.0.1 rport=40534 transport=tcp cfd=29
ts=1629306074.986838 gid=7 type=conn_close rip=10.5.0.1 rport=40534 transport=tcp reason=normal cfd=29
```

IPv6:

```
# hello from san francisco
$ nc -6 2604:5500:c382:f300:5cf1:bb25:1001:5964 11211
```

```
# note the truncated address
ts=1629306088.631154 gid=8 type=conn_new rip=2604:5500:c382:f300:: rport=57106 transport=tcp cfd=29
ts=1629306091.873913 gid=9 type=conn_close rip=2604:5500:c382:f300:: rport=57106 transport=tcp reason=normal cfd=29
```

Unix:

```
$ nc -U /tmp/sock
```

```
ts=1629307760.919189 gid=2 type=conn_new rip=unix rport=0 transport=local cfd=28
ts=1629307761.993160 gid=3 type=conn_close rip=unix rport=0 transport=local reason=normal cfd=28
```

After this change:

IPv4:

```
$ nc -4 10.5.0.1 11211
```

```
ts=1629307902.903407 gid=2 type=conn_new rip=10.5.0.1 rport=40904 transport=tcp cfd=29
ts=1629307903.917884 gid=3 type=conn_close rip=10.5.0.1 rport=40904 transport=tcp reason=normal cfd=29
```

IPv6:

```
$ nc -6 2604:5500:c382:f300:5cf1:bb25:1001:5964 11211
```

```
ts=1629307917.645603 gid=4 type=conn_new rip=2604:5500:c382:f300:5cf1:bb25:1001:5964 rport=57448 transport=tcp cfd=29
ts=1629307919.58216 gid=5 type=conn_close rip=2604:5500:c382:f300:5cf1:bb25:1001:5964 rport=57448 transport=tcp reason=normal cfd=29
```

Unix:

```
ts=1629307944.742783 gid=2 type=conn_new rip=unix rport=0 transport=local cfd=28
ts=1629307945.634618 gid=3 type=conn_close rip=unix rport=0 transport=local reason=normal cfd=28
```