### PR TITLE
add queue.h in archive

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ memcached_SOURCES = memcached.c memcached.h \
                     hash.c hash.h \
                     jenkins_hash.c jenkins_hash.h \
                     murmur3_hash.c murmur3_hash.h \
+                    queue.h \
                     slabs.c slabs.h \
                     items.c items.h \
                     assoc.c assoc.h \


### PR DESCRIPTION
As missing in official archive, cannot build

```
gcc -DHAVE_CONFIG_H -I.  -DNDEBUG   -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redh
at-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -pthread -pthread -Wall  -pedantic -Wmissing-prototypes -Wmissing-de
clarations -Wredundant-decls -c -o memcached-util.o `test -f 'util.c' || echo './'`util.c
In file included from memcached.h:42,
                 from items.c:2:
cache.h:5:10: fatal error: queue.h: No such file or directory
 #include "queue.h"
          ^~~~~~~~~
compilation terminated.
In file included from memcached.h:42,
                 from thread.c:5:
cache.h:5:10: fatal error: queue.h: No such file or directory
 #include "queue.h"
          ^~~~~~~~~
compilation terminated.

```