### PR TITLE
Fix full test suite under TLS

### DIFF
--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -311,7 +311,13 @@ sub new_memcached {
             $args .= " -U $udpport";
         }
         if ($ssl_enabled) {
-            $args .= " -Z -o ssl_chain_cert=$server_crt -o ssl_key=$server_key";
+            $args .= " -Z";
+            if ($args !~ /-o ssl_chain_cert=(\S+)/) {
+                $args .= " -o ssl_chain_cert=$server_crt";
+            }
+            if ($args !~ /-o ssl_key=(\S+)/) {
+                $args .= " -o ssl_key=$server_key";
+            }
         }
     } elsif ($args !~ /-s (\S+)/) {
         my $num = @unixsockets;

--- a/t/maxconns.t
+++ b/t/maxconns.t
@@ -47,6 +47,8 @@ sub test_maxconns {
     for my $s (@sockets) {
         $s->close();
     }
+
+    $stats = mem_stats($stat_sock);
     cmp_ok($stats->{rejected_connections}, '>', '1', 'rejected connections recorded');
     $server->stop;
     $stat_sock->close();

--- a/t/watcher.t
+++ b/t/watcher.t
@@ -89,20 +89,20 @@ if ($res eq "STORED\r\n") {
     $res = <$conn_client>;
     print $conn_client "quit\r\n";
     $res = <$conn_watcher>;
-    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_new .+ transport=local/,
+    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_new .+ transport=(local|tcp)/,
         'logged new connection');
     $res = <$conn_watcher>;
-    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_close .+ transport=local reason=normal/,
+    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_close .+ transport=(local|tcp) reason=normal/,
         'logged closed connection due to client disconnect');
 
     # error close
     $conn_client = $conn_server->new_sock;
     print $conn_client "GET / HTTP/1.1\r\n";
     $res = <$conn_watcher>;
-    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_new .+ transport=local/,
+    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_new .+ transport=(local|tcp)/,
         'logged new connection');
     $res = <$conn_watcher>;
-    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_close .+ transport=local reason=error/,
+    like($res, qr/ts=\d+\.\d+\ gid=\d+ type=conn_close .+ transport=(local|tcp) reason=error/,
         'logged closed connection due to client protocol error');
 }
 

--- a/testapp.c
+++ b/testapp.c
@@ -621,7 +621,7 @@ static pid_t start_server(in_port_t *port_out, bool daemon, int timeout) {
 
 static enum test_return test_issue_44(void) {
     in_port_t port;
-    pid_t pid = start_server(&port, true, 15);
+    pid_t pid = start_server(&port, true, 600);
     assert(kill(pid, SIGHUP) == 0);
     sleep(1);
     assert(kill(pid, SIGTERM) == 0);


### PR DESCRIPTION
`make test_tls` has some errors:

```
t/maxconns.t ................ 1/? 
#   Failed test 'rejected connections recorded'
#   at t/maxconns.t line 38.
#     '0'
#         >
#     '1'
# Looks like you failed 1 test of 1.
t/maxconns.t ................ Dubious, test returned 1 (wstat 256, 0x100)

```

```
t/watcher.t ................. 3/30 
#   Failed test 'logged new connection'
#   at t/watcher.t line 92.
#                   'ts=1634230984.805284 gid=2 type=conn_new rip=127.0.0.1 rport=53462 transport=tcp cfd=34
# '
#     doesn't match '(?^:ts=\d+\.\d+\ gid=\d+ type=conn_new .+ transport=local)'

#   Failed test 'logged closed connection due to client disconnect'
#   at t/watcher.t line 95.
#                   'ts=1634230984.807135 gid=3 type=conn_close rip=127.0.0.1 rport=53462 transport=tcp reason=normal cfd=34
# '
#     doesn't match '(?^:ts=\d+\.\d+\ gid=\d+ type=conn_close .+ transport=local reason=normal)'

#   Failed test 'logged new connection'
#   at t/watcher.t line 102.
#                   'ts=1634230984.809056 gid=4 type=conn_new rip=127.0.0.1 rport=53464 transport=tcp cfd=34
# '
#     doesn't match '(?^:ts=\d+\.\d+\ gid=\d+ type=conn_new .+ transport=local)'

#   Failed test 'logged closed connection due to client protocol error'
#   at t/watcher.t line 105.
#                   'ts=1634230984.810899 gid=5 type=conn_close rip=127.0.0.1 rport=53464 transport=tcp reason=error cfd=34
# '
#     doesn't match '(?^:ts=\d+\.\d+\ gid=\d+ type=conn_close .+ transport=local reason=error)'
t/watcher.t ................. 29/30 # Looks like you failed 4 tests of 30.
t/watcher.t ................. Dubious, test returned 4 (wstat 1024, 0x400)
```

* `maxconns.t`: The connection rejection logic writes the rejection message directly to the client socket without wrapping with TLS. I suspect this caused some issues with the SSL socket client, because refreshing the stats right before the check lets the test pass since the server itself is doing the right thing.
* `watcher.t`: Over TLS, we use a TCP transport rather than a local (Unix) transport.

[CI currently only runs the basic TLS tests](https://github.com/memcached/memcached/blob/master/.github/workflows/ci.yml#L21) so I guess that's why these went unnoticed. Happy to add a `make test_tls` step there if that's desirable.