### PR TITLE
proxy: fixes for liburing support

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -3002,7 +3002,9 @@ static int mcplib_backend_connect_timeout(lua_State *L) {
 
     STAT_L(ctx);
     ctx->timeouts.connect.tv_sec = seconds;
+#ifdef HAVE_LIBURING
     ctx->timeouts.connect_ur.tv_sec = seconds;
+#endif
     STAT_UL(ctx);
 
     return 0;
@@ -3014,7 +3016,9 @@ static int mcplib_backend_retry_timeout(lua_State *L) {
 
     STAT_L(ctx);
     ctx->timeouts.retry.tv_sec = seconds;
+#ifdef HAVE_LIBURING
     ctx->timeouts.retry_ur.tv_sec = seconds;
+#endif
     STAT_UL(ctx);
 
     return 0;
@@ -3026,7 +3030,9 @@ static int mcplib_backend_read_timeout(lua_State *L) {
 
     STAT_L(ctx);
     ctx->timeouts.read.tv_sec = seconds;
+#ifdef HAVE_LIBURING
     ctx->timeouts.read_ur.tv_sec = seconds;
+#endif
     STAT_UL(ctx);
 
     return 0;


### PR DESCRIPTION
Starting out by linking liburing's timeouts, which are hrtimers and shouldn't be infinitely scalable. I did some quick tests and it doesn't seem to be impacting performance at ~300krps, which is fine for a first pass.

This PR will track a few more changes:

- [x] all timeouts for liburing mode (note: double check connect timeouts?)
- [x] periodic timeout updater in uring mode (sigh)
~~restructure uring mode to avoid sqe/cqe starvation at high loads~~ - making this a separate branch once I do more experiments/research.