### PR TITLE
meta: fix CAS ('c') return values

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -712,6 +712,7 @@ with CAS semantics did not exist.
 The flags used by the 'ms' command are:
 
 - b: interpret key as base64 encoded binary value (see metaget)
+- c: return CAS value if successfully stored.
 - C(token): compare CAS value when storing item
 - F(token): set client flags to token (32 bit unsigned numeric)
 - I: invalidate. set-to-invalid if supplied CAS is older than item's CAS
@@ -722,6 +723,10 @@ The flags used by the 'ms' command are:
 - M(token): mode switch to change behavior to add, replace, append, prepend
 
 The flags are now repeated with detailed information where useful:
+
+- c: returns the CAS value on successful storage. Will return 0 on error, but
+  clients must not depend on the return value being zero. In future versions
+this may return the current CAS value for "EX" return code conditions.
 
 - C(token): compare CAS value when storing item
 
@@ -873,7 +878,7 @@ The flags used by the 'ma' command are:
 - M(token): mode switch to change between incr and decr modes.
 - q: use noreply semantics for return codes (see details under mset)
 - t: return current TTL
-- c: return current CAS
+- c: return current CAS value if successful.
 - v: return new value
 
 The flags are now repeated with detailed information where useful:

--- a/proto_text.c
+++ b/proto_text.c
@@ -1551,7 +1551,6 @@ error:
 static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntokens) {
     char *key;
     size_t nkey;
-    uint64_t req_cas_id = 0;
     item *it = NULL;
     int i;
     uint32_t hv;
@@ -1611,7 +1610,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
         MEMCACHED_COMMAND_DELETE(c->sfd, ITEM_key(it), it->nkey);
 
         // allow only deleting/marking if a CAS value matches.
-        if (of.has_cas && ITEM_get_cas(it) != req_cas_id) {
+        if (of.has_cas && ITEM_get_cas(it) != of.req_cas_id) {
             pthread_mutex_lock(&c->thread->stats.mutex);
             c->thread->stats.delete_misses++;
             pthread_mutex_unlock(&c->thread->stats.mutex);

--- a/proto_text.c
+++ b/proto_text.c
@@ -107,7 +107,7 @@ static void _finalize_mset(conn *c, enum store_item_type ret) {
                 // We don't have the CAS until this point, which is why we
                 // generate this line so late.
                 META_CHAR(p, 'c');
-                p = itoa_u64(ITEM_get_cas(it), p);
+                p = itoa_u64(c->cas, p);
                 break;
             default:
                 break;
@@ -1408,6 +1408,8 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
 
     // Set noreply after tokens are understood.
     c->noreply = of.no_reply;
+    // Clear cas return value
+    c->cas = 0;
 
     bool has_error = false;
     for (i = KEY_TOKEN+1; i < ntokens-1; i++) {


### PR DESCRIPTION
Fixes #842 - meta will match binprot behavior.
Also fixes #844 

TODO:
- [x] tests
- [x] look at the delete bug.
- [x] decide if we want to try harder and return the underlying CAS instead of zero for some conditions.
- [x] ensure docs match