### PR TITLE
core: fix use-after-free for text multigets

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -440,8 +440,8 @@ bool rbuf_switch_to_malloc(conn *c) {
     if (!tmp)
         return false;
 
-    do_cache_free(c->thread->rbuf_cache, c->rbuf);
     memcpy(tmp, c->rcurr, c->rbytes);
+    do_cache_free(c->thread->rbuf_cache, c->rbuf);
 
     c->rcurr = c->rbuf = tmp;
     c->rsize = size;


### PR DESCRIPTION
Reported in #849 - this fixes copying a read buffer after freeing the
original read buffer.

This didn't matter for years since the cache code didn't touch the
buffer, but recently it can reuse the first 8 bytes as a pointer to the
internal freelist. Thus in some situations where large reads happen the
command can get corrupted, returning an unhelpful "ERROR" to the end
user.