### PR TITLE
proxy: audit TODO/FIXME lines. mark some for v2

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1815,6 +1815,7 @@ void server_stats(ADD_STAT add_stats, conn *c) {
     if (settings.proxy_enabled) {
         APPEND_STAT("proxy_conn_requests", "%llu", (unsigned long long)thread_stats.proxy_conn_requests);
         APPEND_STAT("proxy_conn_errors", "%llu", (unsigned long long)thread_stats.proxy_conn_errors);
+        APPEND_STAT("proxy_conn_oom", "%llu", (unsigned long long)thread_stats.proxy_conn_oom);
     }
 #endif
     APPEND_STAT("delete_misses", "%llu", (unsigned long long)thread_stats.delete_misses);

--- a/memcached.c
+++ b/memcached.c
@@ -869,7 +869,11 @@ static void conn_cleanup(conn *c) {
     assert(c != NULL);
 
     conn_release_items(c);
-
+#ifdef PROXY
+    if (c->proxy_coro_ref) {
+        proxy_cleanup_conn(c);
+    }
+#endif
     if (c->sasl_conn) {
         assert(settings.sasl);
         sasl_dispose(&c->sasl_conn);

--- a/memcached.h
+++ b/memcached.h
@@ -337,7 +337,8 @@ struct slab_stats {
 #ifdef PROXY
 #define PROXY_THREAD_STATS_FIELDS \
     X(proxy_conn_requests) \
-    X(proxy_conn_errors)
+    X(proxy_conn_errors) \
+    X(proxy_conn_oom)
 #endif
 
 /**

--- a/memcached.h
+++ b/memcached.h
@@ -819,6 +819,9 @@ struct conn {
 
     int io_queues_submitted; /* see notes on io_queue_t */
     io_queue_t io_queues[IO_QUEUE_COUNT]; /* set of deferred IO queues. */
+#ifdef PROXY
+    unsigned int proxy_coro_ref; /* lua reference for active coroutine */
+#endif
 #ifdef EXTSTORE
     unsigned int recache_counter;
 #endif

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -3211,15 +3211,22 @@ static int mcplib_backend_failure_limit(lua_State *L) {
     return 0;
 }
 
-// TODO: take fractional time and convert.
+// sad, I had to look this up...
+#define NANOSECONDS(x) ((x) * 1E9 + 0.5)
+#define MICROSECONDS(x) ((x) * 1E6 + 0.5)
+
 static int mcplib_backend_connect_timeout(lua_State *L) {
-    int seconds = luaL_checkinteger(L, -1);
+    lua_Number secondsf = luaL_checknumber(L, -1);
+    lua_Integer secondsi = (lua_Integer) secondsf;
+    lua_Number subseconds = secondsf - secondsi;
     proxy_ctx_t *ctx = settings.proxy_ctx; // FIXME (v2): get global ctx reference in thread/upvalue.
 
     STAT_L(ctx);
-    ctx->tunables.connect.tv_sec = seconds;
+    ctx->tunables.connect.tv_sec = secondsi;
+    ctx->tunables.connect.tv_usec = MICROSECONDS(subseconds);
 #ifdef HAVE_LIBURING
-    ctx->tunables.connect_ur.tv_sec = seconds;
+    ctx->tunables.connect_ur.tv_sec = secondsi;
+    ctx->tunables.connect_ur.tv_nsec = NANOSECONDS(subseconds);
 #endif
     STAT_UL(ctx);
 
@@ -3227,13 +3234,17 @@ static int mcplib_backend_connect_timeout(lua_State *L) {
 }
 
 static int mcplib_backend_retry_timeout(lua_State *L) {
-    int seconds = luaL_checkinteger(L, -1);
+    lua_Number secondsf = luaL_checknumber(L, -1);
+    lua_Integer secondsi = (lua_Integer) secondsf;
+    lua_Number subseconds = secondsf - secondsi;
     proxy_ctx_t *ctx = settings.proxy_ctx; // FIXME (v2): get global ctx reference in thread/upvalue.
 
     STAT_L(ctx);
-    ctx->tunables.retry.tv_sec = seconds;
+    ctx->tunables.retry.tv_sec = secondsi;
+    ctx->tunables.retry.tv_usec = MICROSECONDS(subseconds);
 #ifdef HAVE_LIBURING
-    ctx->tunables.retry_ur.tv_sec = seconds;
+    ctx->tunables.retry_ur.tv_sec = secondsi;
+    ctx->tunables.retry_ur.tv_nsec = NANOSECONDS(subseconds);
 #endif
     STAT_UL(ctx);
 
@@ -3241,13 +3252,17 @@ static int mcplib_backend_retry_timeout(lua_State *L) {
 }
 
 static int mcplib_backend_read_timeout(lua_State *L) {
-    int seconds = luaL_checkinteger(L, -1);
+    lua_Number secondsf = luaL_checknumber(L, -1);
+    lua_Integer secondsi = (lua_Integer) secondsf;
+    lua_Number subseconds = secondsf - secondsi;
     proxy_ctx_t *ctx = settings.proxy_ctx; // FIXME (v2): get global ctx reference in thread/upvalue.
 
     STAT_L(ctx);
-    ctx->tunables.read.tv_sec = seconds;
+    ctx->tunables.read.tv_sec = secondsi;
+    ctx->tunables.read.tv_usec = MICROSECONDS(subseconds);
 #ifdef HAVE_LIBURING
-    ctx->tunables.read_ur.tv_sec = seconds;
+    ctx->tunables.read_ur.tv_sec = secondsi;
+    ctx->tunables.read_ur.tv_nsec = NANOSECONDS(subseconds);
 #endif
     STAT_UL(ctx);
 

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -7,6 +7,7 @@ void process_proxy_stats(ADD_STAT add_stats, conn *c);
 /* proxy mode handlers */
 int try_read_command_proxy(conn *c);
 void complete_nread_proxy(conn *c);
+void proxy_cleanup_conn(conn *c);
 void proxy_thread_init(LIBEVENT_THREAD *thr);
 void proxy_init(bool proxy_uring);
 // TODO: need better names or a better interface for these. can be confusing

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -92,7 +92,7 @@ function mcp_config_pools(oldss)
     for _, subs in pairs(main_zones) do
         for k, v in pairs(subs) do
             -- use next line instead for a third party ketama hash
-            -- subs[k] = mcp.pool(v, { dist = ketama })
+            -- subs[k] = mcp.pool(v, { dist = ketama, hash = ketama.hash })
             -- this line overrides the default bucket size for ketama
             -- subs[k] = mcp.pool(v, { dist = ketama, obucket = 80 })
             -- this line uses the default murmur3 straight hash.
@@ -104,7 +104,9 @@ function mcp_config_pools(oldss)
             -- for each zone.
             -- NOTE: 'k' may not be the right seed here:
             -- instead stitch main_zone's key + the sub key?
-            -- subs[k] = mcp.pool(v, { dist = mcp.hash_jump, seed = k })
+            -- subs[k] = mcp.pool(v, { dist = mcp.dist_jump_hash, seed = k })
+            -- subs[k] = mcp.pool(v, { dist = mcp.dist_jump_hash, seed = k, filter = "stop", filter_conf = "|#|" })
+            -- subs[k] = mcp.pool(v, { dist = mcp.dist_jump_hash, seed = k, filter = "tags", filter_conf = "{}" })
         end
     end
 

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -13,7 +13,7 @@ local STAT_ANOTHER <const> = 2
 function mcp_config_pools(oldss)
     mcp.add_stat(STAT_EXAMPLE, "example")
     mcp.add_stat(STAT_ANOTHER, "another")
-    mcp.backend_connect_timeout(5) -- 5 second timeout.
+    mcp.backend_connect_timeout(5.5) -- 5 and a half second timeout.
     -- alias mcp.backend for convenience.
     -- important to alias global variables in routes where speed is concerned.
     local srv = mcp.backend

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -1,7 +1,6 @@
--- xTODO: sets of zones behind a prefix.
--- xTODO: zones with local vs other failover.
--- xTODO: failover on get
--- xTODO: all zone sync on set
+-- WARNING: if you cause errors during configuration reload by putting
+-- incompatible data into the table returned by mcp_config_pools, the daeomon
+-- will exit.
 -- TODO: fallback cache for broken/overloaded zones.
 
 -- local zone could/should be fetched from environment or local file.


### PR DESCRIPTION
Marks TODO/FIXME items that can be done after MVP/V1 status is achieved. This PR also attempts to address most of the non-v2 TODO/FIXME items.

"v2" just means "after v1". Not at all tied to a specific version or any
order.

This cuts us down from 170 items to... 80...

Most of what was marked v2 are optimizations or require some refactoring for future features. Most of what's left are missing error handling and obvious bugs/limitations. I'll fix all of these before doing more serious edge case testing, since after looking through them a lot of these are pretty obvious.