### PR TITLE
Extend extbuf in try_read_command_binary function

### DIFF
--- a/proto_bin.c
+++ b/proto_bin.c
@@ -110,7 +110,10 @@ int try_read_command_binary(conn *c) {
         // want to refactor a ton of code either. Header is only ever used out
         // of c->binary_header, but the extlen stuff is used for the latter
         // bytes. Just wastes 24 bytes on the stack this way.
-        char extbuf[sizeof(c->binary_header) + BIN_MAX_EXTLEN+1];
+
+        // +4 need to be here because extbuf is used for protocol_binary_request_incr
+        // and its member message is alligned to 48 bytes intead of 44
+        char extbuf[sizeof(c->binary_header) + BIN_MAX_EXTLEN+4];
         memcpy(extbuf + sizeof(c->binary_header), c->rcurr + sizeof(c->binary_header),
                 extlen > BIN_MAX_EXTLEN ? BIN_MAX_EXTLEN : extlen);
         c->rbytes -= sizeof(c->binary_header) + extlen + keylen;


### PR DESCRIPTION
Extbuf needs to have 48 bytes because it is used
for protocol_binary_request_incr union. Unions member
message is alligned to 48 bytes.
Fixes #863