### PR TITLE
Proxy observability improvements

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -54,7 +54,7 @@ static int logger_thread_poll_watchers(int force_poll, int watcher);
 static void _logger_log_text(logentry *e, const entry_details *d, const void *entry, va_list ap) {
     int reqlen = d->reqlen;
     int total = vsnprintf((char *) e->data, reqlen, d->format, ap);
-    if (total >= reqlen || total <= 0) {
+    if (total <= 0) {
         fprintf(stderr, "LOGGER: Failed to vsnprintf a text entry: (total) %d\n", total);
     }
     e->size = total + 1; // null byte
@@ -367,13 +367,17 @@ static const entry_details default_entries[] = {
     },
 #endif
 #ifdef PROXY
-    [LOGGER_PROXY_CONFIG] = {512, LOG_SYSEVENTS, _logger_log_text, _logger_parse_text,
+    [LOGGER_PROXY_CONFIG] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
         "type=proxy_conf status=%s"
     },
-    [LOGGER_PROXY_RAW] = {512, LOG_RAWCMDS, _logger_log_proxy_raw, _logger_parse_prx_raw, NULL},
-    [LOGGER_PROXY_ERROR] = {512, LOG_SYSEVENTS, _logger_log_text, _logger_parse_text,
+    [LOGGER_PROXY_RAW] = {512, LOG_PROXYCMDS, _logger_log_proxy_raw, _logger_parse_prx_raw, NULL},
+    [LOGGER_PROXY_ERROR] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
         "type=proxy_error msg=%s"
     },
+    [LOGGER_PROXY_USER] = {512, LOG_PROXYUSER, _logger_log_text, _logger_parse_text,
+        "type=proxy_user msg=%s"
+    },
+
 #endif
 };
 

--- a/logger.c
+++ b/logger.c
@@ -377,6 +377,9 @@ static const entry_details default_entries[] = {
     [LOGGER_PROXY_USER] = {512, LOG_PROXYUSER, _logger_log_text, _logger_parse_text,
         "type=proxy_user msg=%s"
     },
+    [LOGGER_PROXY_BE_ERROR] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
+        "type=proxy_backend error=%s ip=%s port=%s"
+    },
 
 #endif
 };

--- a/logger.h
+++ b/logger.h
@@ -36,6 +36,7 @@ enum log_entry_type {
     LOGGER_PROXY_RAW,
     LOGGER_PROXY_ERROR,
     LOGGER_PROXY_USER,
+    LOGGER_PROXY_BE_ERROR,
 #endif
 };
 

--- a/logger.h
+++ b/logger.h
@@ -35,6 +35,7 @@ enum log_entry_type {
     LOGGER_PROXY_CONFIG,
     LOGGER_PROXY_RAW,
     LOGGER_PROXY_ERROR,
+    LOGGER_PROXY_USER,
 #endif
 };
 
@@ -144,6 +145,9 @@ struct _logentry {
 #define LOG_EVICTIONS  (1<<6) /* details of evicted items */
 #define LOG_STRICT     (1<<7) /* block worker instead of drop */
 #define LOG_RAWCMDS    (1<<9) /* raw ascii commands */
+#define LOG_PROXYCMDS  (1<<10) /* command logs from proxy */
+#define LOG_PROXYEVENTS (1<<11) /* error log stream from proxy */
+#define LOG_PROXYUSER (1<<12) /* user generated logs from proxy */
 
 typedef struct _logger {
     struct _logger *prev;

--- a/memcached.c
+++ b/memcached.c
@@ -1816,6 +1816,7 @@ void server_stats(ADD_STAT add_stats, conn *c) {
         APPEND_STAT("proxy_conn_requests", "%llu", (unsigned long long)thread_stats.proxy_conn_requests);
         APPEND_STAT("proxy_conn_errors", "%llu", (unsigned long long)thread_stats.proxy_conn_errors);
         APPEND_STAT("proxy_conn_oom", "%llu", (unsigned long long)thread_stats.proxy_conn_oom);
+        APPEND_STAT("proxy_req_active", "%llu", (unsigned long long)thread_stats.proxy_req_active);
     }
 #endif
     APPEND_STAT("delete_misses", "%llu", (unsigned long long)thread_stats.delete_misses);

--- a/memcached.h
+++ b/memcached.h
@@ -338,7 +338,8 @@ struct slab_stats {
 #define PROXY_THREAD_STATS_FIELDS \
     X(proxy_conn_requests) \
     X(proxy_conn_errors) \
-    X(proxy_conn_oom)
+    X(proxy_conn_oom) \
+    X(proxy_req_active)
 #endif
 
 /**

--- a/memcached.h
+++ b/memcached.h
@@ -715,7 +715,8 @@ typedef struct {
 #ifdef PROXY
     void *L;
     void *proxy_hooks;
-    void *proxy_stats;
+    void *proxy_user_stats;
+    void *proxy_int_stats;
     // TODO: add ctx object so we can attach to queue.
 #endif
 } LIBEVENT_THREAD;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -2853,6 +2853,10 @@ static int mcplib_backend_gc(lua_State *L) {
     mcmc_disconnect(be->client);
     free(be->client);
 
+    // FIXME (v2): upvalue for global ctx.
+    proxy_ctx_t *ctx = settings.proxy_ctx;
+    STAT_DECR(ctx, backend_total, 1);
+
     return 0;
 }
 
@@ -2882,10 +2886,6 @@ static int mcplib_backend(lua_State *L) {
 
     // This might shift to internal objects?
     mcp_backend_t *be = lua_newuserdatauv(L, sizeof(mcp_backend_t), 0);
-    if (be == NULL) {
-        proxy_lua_error(L, "out of memory allocating backend");
-        return 0;
-    }
 
     // FIXME (v2): remove some of the excess zero'ing below?
     memset(be, 0, sizeof(mcp_backend_t));
@@ -2944,6 +2944,10 @@ static int mcplib_backend(lua_State *L) {
     // set our new backend object into the reference table.
     lua_settable(L, lua_upvalueindex(MCP_BACKEND_UPVALUE));
     // stack is back to having backend on the top.
+
+    // FIXME (v2): upvalue for global ctx.
+    proxy_ctx_t *ctx = settings.proxy_ctx;
+    STAT_INCR(ctx, backend_total, 1);
 
     return 1;
 }

--- a/proto_text.c
+++ b/proto_text.c
@@ -2291,6 +2291,12 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
                 f |= LOG_SYSEVENTS;
             } else if ((strcmp(tokens[x].value, "connevents") == 0)) {
                 f |= LOG_CONNEVENTS;
+            } else if ((strcmp(tokens[x].value, "proxycmds") == 0)) {
+                f |= LOG_PROXYCMDS;
+            } else if ((strcmp(tokens[x].value, "proxyevents") == 0)) {
+                f |= LOG_PROXYEVENTS;
+            } else if ((strcmp(tokens[x].value, "proxyuser") == 0)) {
+                f |= LOG_PROXYUSER;
             } else {
                 out_string(c, "ERROR");
                 return;

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -131,6 +131,8 @@ function failover_factory(zones, local_zone)
     return function(r)
         local res = near_zone(r)
         if res:hit() == false then
+            -- example for mcp.log... Don't do this though :)
+            mcp.log("failed to find " .. r:key() .. " in zone: " .. local_zone)
             for _, zone in pairs(far_zones) do
                 res = zone(r)
                 if res:hit() then


### PR DESCRIPTION
More MVP grind:

- adds a bunch more stats to `stats proxy` - tracking how many of each type of command was received.
```
stats proxy
STAT user_example 0
STAT user_another 0
STAT cmd_mg 0
STAT cmd_ms 0
STAT cmd_md 0
STAT cmd_mn 0
STAT cmd_ma 0
STAT cmd_me 0
STAT cmd_get 0
STAT cmd_gat 0
STAT cmd_set 0
STAT cmd_add 0
STAT cmd_cas 0
STAT cmd_gets 0
STAT cmd_gats 0
STAT cmd_incr 0
STAT cmd_decr 0
STAT cmd_touch 0
STAT cmd_append 0
STAT cmd_prepend 0
STAT cmd_delete 0
STAT cmd_replace 0
END
```
- adds `watch proxycmds|proxyevents|proxyuser` watcher endpoints.
- adds `mcp.log()` lua interface to logging (lands in proxyuser)
- adds some logs to backend errors, these look like:
```
ts=1644553677.231725 gid=5 type=proxy_backend error=connecting ip=127.2.1.3 port=11213
ts=1644553677.231738 gid=6 type=proxy_backend error=connecting ip=127.1.1.3 port=11212
ts=1644553677.231746 gid=7 type=proxy_backend error=connecting ip=127.3.1.3 port=11214
```

More specific errors are possible but will take more effort to get the interfaces to align. the errno should be added to the existing line at some point.

Before merging, also looking at:
- [ ] `mcp.slow_log_threshold(0.5)` - set a timing threshold for sending logs to `proxycmds` log stream.
- [ ] might be able to add the backend ip:port to the slow log stream
- [ ] also looking at a short string or number to "tag" a request with (which can be zone/route/anything), which would be sent in the slow/error log stream.
- don't think I can get detailed errors into the slow log stream (which we could also trigger on error) without significant work... but I tried.