### PR TITLE
proxy: 'stats proxy' crashes on invocation

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1103,7 +1103,7 @@ static int proxy_thread_loadconf(LIBEVENT_THREAD *thr) {
     STAT_L(ctx);
     struct proxy_user_stats *us = &ctx->user_stats;
     struct proxy_user_stats *tus = NULL;
-    if (us->num_stats != 0) {
+    if (us->num_stats == 0) {
         pthread_mutex_lock(&thr->stats.mutex);
         if (thr->proxy_user_stats == NULL) {
             tus = calloc(1, sizeof(struct proxy_user_stats));


### PR DESCRIPTION
I noticed running 'stats proxy' caused a crash. On observing it under
GDB, it crashed while attempting to access the worker thread level
proxy_user_stats in process_proxy_stats().
This showed that the thread level 'proxy_user_stats' wasnt properly
initialized. On checking it's initialization code in
proxy_worker_reload(), a typo was noticed that caused the bug.
This patch fixes it.