### PR TITLE
proxy: add ring_hash builtin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,8 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_await.c proxy_ustats.c \
 					 proxy_jump_hash.c proxy_request.c \
 					 proxy_network.c proxy_lua.c \
-					 proxy_config.c
+					 proxy_config.c proxy_ring_hash.c \
+					 md5.c
 endif
 
 if ENABLE_EXTSTORE

--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -3,7 +3,7 @@ use strict;
 use FindBin qw($Bin);
 chdir "$Bin/.." or die;
 
-my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md);
+my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md md5.c md5.h);
 push(@exempted, glob("doc/*.xml"));
 push(@exempted, glob("doc/*.full"));
 push(@exempted, glob("doc/xml2rfc/*.xsl"));

--- a/logger.c
+++ b/logger.c
@@ -379,7 +379,7 @@ static const entry_details default_entries[] = {
         "type=proxy_user msg=%s"
     },
     [LOGGER_PROXY_BE_ERROR] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
-        "type=proxy_backend error=%s ip=%s port=%s"
+        "type=proxy_backend error=%s name=%s port=%s"
     },
 
 #endif

--- a/md5.c
+++ b/md5.c
@@ -1,0 +1,381 @@
+/*
+  Copyright (C) 1999, 2000, 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5.c,v 1.6 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.c is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Clarified derivation from RFC 1321; now handles byte order
+	either statically or dynamically; added missing #include <string.h>
+	in library.
+  2002-03-11 lpd Corrected argument list for main(), and added int return
+	type, in test program and T value program.
+  2002-02-21 lpd Added missing #include <stdio.h> in test program.
+  2000-07-03 lpd Patched to eliminate warnings about "constant is
+	unsigned in ANSI C, signed in traditional"; made test program
+	self-checking.
+  1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
+  1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5).
+  1999-05-03 lpd Original version.
+ */
+
+#include "md5.h"
+#include <string.h>
+
+#undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
+#ifdef ARCH_IS_BIG_ENDIAN
+#  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
+#else
+#  define BYTE_ORDER 0
+#endif
+
+#define T_MASK ((md5_word_t)~0)
+#define T1 /* 0xd76aa478 */ (T_MASK ^ 0x28955b87)
+#define T2 /* 0xe8c7b756 */ (T_MASK ^ 0x173848a9)
+#define T3    0x242070db
+#define T4 /* 0xc1bdceee */ (T_MASK ^ 0x3e423111)
+#define T5 /* 0xf57c0faf */ (T_MASK ^ 0x0a83f050)
+#define T6    0x4787c62a
+#define T7 /* 0xa8304613 */ (T_MASK ^ 0x57cfb9ec)
+#define T8 /* 0xfd469501 */ (T_MASK ^ 0x02b96afe)
+#define T9    0x698098d8
+#define T10 /* 0x8b44f7af */ (T_MASK ^ 0x74bb0850)
+#define T11 /* 0xffff5bb1 */ (T_MASK ^ 0x0000a44e)
+#define T12 /* 0x895cd7be */ (T_MASK ^ 0x76a32841)
+#define T13    0x6b901122
+#define T14 /* 0xfd987193 */ (T_MASK ^ 0x02678e6c)
+#define T15 /* 0xa679438e */ (T_MASK ^ 0x5986bc71)
+#define T16    0x49b40821
+#define T17 /* 0xf61e2562 */ (T_MASK ^ 0x09e1da9d)
+#define T18 /* 0xc040b340 */ (T_MASK ^ 0x3fbf4cbf)
+#define T19    0x265e5a51
+#define T20 /* 0xe9b6c7aa */ (T_MASK ^ 0x16493855)
+#define T21 /* 0xd62f105d */ (T_MASK ^ 0x29d0efa2)
+#define T22    0x02441453
+#define T23 /* 0xd8a1e681 */ (T_MASK ^ 0x275e197e)
+#define T24 /* 0xe7d3fbc8 */ (T_MASK ^ 0x182c0437)
+#define T25    0x21e1cde6
+#define T26 /* 0xc33707d6 */ (T_MASK ^ 0x3cc8f829)
+#define T27 /* 0xf4d50d87 */ (T_MASK ^ 0x0b2af278)
+#define T28    0x455a14ed
+#define T29 /* 0xa9e3e905 */ (T_MASK ^ 0x561c16fa)
+#define T30 /* 0xfcefa3f8 */ (T_MASK ^ 0x03105c07)
+#define T31    0x676f02d9
+#define T32 /* 0x8d2a4c8a */ (T_MASK ^ 0x72d5b375)
+#define T33 /* 0xfffa3942 */ (T_MASK ^ 0x0005c6bd)
+#define T34 /* 0x8771f681 */ (T_MASK ^ 0x788e097e)
+#define T35    0x6d9d6122
+#define T36 /* 0xfde5380c */ (T_MASK ^ 0x021ac7f3)
+#define T37 /* 0xa4beea44 */ (T_MASK ^ 0x5b4115bb)
+#define T38    0x4bdecfa9
+#define T39 /* 0xf6bb4b60 */ (T_MASK ^ 0x0944b49f)
+#define T40 /* 0xbebfbc70 */ (T_MASK ^ 0x4140438f)
+#define T41    0x289b7ec6
+#define T42 /* 0xeaa127fa */ (T_MASK ^ 0x155ed805)
+#define T43 /* 0xd4ef3085 */ (T_MASK ^ 0x2b10cf7a)
+#define T44    0x04881d05
+#define T45 /* 0xd9d4d039 */ (T_MASK ^ 0x262b2fc6)
+#define T46 /* 0xe6db99e5 */ (T_MASK ^ 0x1924661a)
+#define T47    0x1fa27cf8
+#define T48 /* 0xc4ac5665 */ (T_MASK ^ 0x3b53a99a)
+#define T49 /* 0xf4292244 */ (T_MASK ^ 0x0bd6ddbb)
+#define T50    0x432aff97
+#define T51 /* 0xab9423a7 */ (T_MASK ^ 0x546bdc58)
+#define T52 /* 0xfc93a039 */ (T_MASK ^ 0x036c5fc6)
+#define T53    0x655b59c3
+#define T54 /* 0x8f0ccc92 */ (T_MASK ^ 0x70f3336d)
+#define T55 /* 0xffeff47d */ (T_MASK ^ 0x00100b82)
+#define T56 /* 0x85845dd1 */ (T_MASK ^ 0x7a7ba22e)
+#define T57    0x6fa87e4f
+#define T58 /* 0xfe2ce6e0 */ (T_MASK ^ 0x01d3191f)
+#define T59 /* 0xa3014314 */ (T_MASK ^ 0x5cfebceb)
+#define T60    0x4e0811a1
+#define T61 /* 0xf7537e82 */ (T_MASK ^ 0x08ac817d)
+#define T62 /* 0xbd3af235 */ (T_MASK ^ 0x42c50dca)
+#define T63    0x2ad7d2bb
+#define T64 /* 0xeb86d391 */ (T_MASK ^ 0x14792c6e)
+
+
+static void
+md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
+{
+    md5_word_t
+	a = pms->abcd[0], b = pms->abcd[1],
+	c = pms->abcd[2], d = pms->abcd[3];
+    md5_word_t t;
+#if BYTE_ORDER > 0
+    /* Define storage only for big-endian CPUs. */
+    md5_word_t X[16];
+#else
+    /* Define storage for little-endian or both types of CPUs. */
+    md5_word_t xbuf[16];
+    const md5_word_t *X;
+#endif
+
+    {
+#if BYTE_ORDER == 0
+	/*
+	 * Determine dynamically whether this is a big-endian or
+	 * little-endian machine, since we can use a more efficient
+	 * algorithm on the latter.
+	 */
+	static const int w = 1;
+
+	if (*((const md5_byte_t *)&w)) /* dynamic little-endian */
+#endif
+#if BYTE_ORDER <= 0		/* little-endian */
+	{
+	    /*
+	     * On little-endian machines, we can process properly aligned
+	     * data without copying it.
+	     */
+	    if (!((data - (const md5_byte_t *)0) & 3)) {
+		/* data are properly aligned */
+		X = (const md5_word_t *)data;
+	    } else {
+		/* not aligned */
+		memcpy(xbuf, data, 64);
+		X = xbuf;
+	    }
+	}
+#endif
+#if BYTE_ORDER == 0
+	else			/* dynamic big-endian */
+#endif
+#if BYTE_ORDER >= 0		/* big-endian */
+	{
+	    /*
+	     * On big-endian machines, we must arrange the bytes in the
+	     * right order.
+	     */
+	    const md5_byte_t *xp = data;
+	    int i;
+
+#  if BYTE_ORDER == 0
+	    X = xbuf;		/* (dynamic only) */
+#  else
+#    define xbuf X		/* (static only) */
+#  endif
+	    for (i = 0; i < 16; ++i, xp += 4)
+		xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
+	}
+#endif
+    }
+
+#define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+
+    /* Round 1. */
+    /* Let [abcd k s i] denote the operation
+       a = b + ((a + F(b,c,d) + X[k] + T[i]) <<< s). */
+#define F(x, y, z) (((x) & (y)) | (~(x) & (z)))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + F(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+    /* Do the following 16 operations. */
+    SET(a, b, c, d,  0,  7,  T1);
+    SET(d, a, b, c,  1, 12,  T2);
+    SET(c, d, a, b,  2, 17,  T3);
+    SET(b, c, d, a,  3, 22,  T4);
+    SET(a, b, c, d,  4,  7,  T5);
+    SET(d, a, b, c,  5, 12,  T6);
+    SET(c, d, a, b,  6, 17,  T7);
+    SET(b, c, d, a,  7, 22,  T8);
+    SET(a, b, c, d,  8,  7,  T9);
+    SET(d, a, b, c,  9, 12, T10);
+    SET(c, d, a, b, 10, 17, T11);
+    SET(b, c, d, a, 11, 22, T12);
+    SET(a, b, c, d, 12,  7, T13);
+    SET(d, a, b, c, 13, 12, T14);
+    SET(c, d, a, b, 14, 17, T15);
+    SET(b, c, d, a, 15, 22, T16);
+#undef SET
+
+     /* Round 2. */
+     /* Let [abcd k s i] denote the operation
+          a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
+#define G(x, y, z) (((x) & (z)) | ((y) & ~(z)))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + G(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+     /* Do the following 16 operations. */
+    SET(a, b, c, d,  1,  5, T17);
+    SET(d, a, b, c,  6,  9, T18);
+    SET(c, d, a, b, 11, 14, T19);
+    SET(b, c, d, a,  0, 20, T20);
+    SET(a, b, c, d,  5,  5, T21);
+    SET(d, a, b, c, 10,  9, T22);
+    SET(c, d, a, b, 15, 14, T23);
+    SET(b, c, d, a,  4, 20, T24);
+    SET(a, b, c, d,  9,  5, T25);
+    SET(d, a, b, c, 14,  9, T26);
+    SET(c, d, a, b,  3, 14, T27);
+    SET(b, c, d, a,  8, 20, T28);
+    SET(a, b, c, d, 13,  5, T29);
+    SET(d, a, b, c,  2,  9, T30);
+    SET(c, d, a, b,  7, 14, T31);
+    SET(b, c, d, a, 12, 20, T32);
+#undef SET
+
+     /* Round 3. */
+     /* Let [abcd k s t] denote the operation
+          a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
+#define H(x, y, z) ((x) ^ (y) ^ (z))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + H(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+     /* Do the following 16 operations. */
+    SET(a, b, c, d,  5,  4, T33);
+    SET(d, a, b, c,  8, 11, T34);
+    SET(c, d, a, b, 11, 16, T35);
+    SET(b, c, d, a, 14, 23, T36);
+    SET(a, b, c, d,  1,  4, T37);
+    SET(d, a, b, c,  4, 11, T38);
+    SET(c, d, a, b,  7, 16, T39);
+    SET(b, c, d, a, 10, 23, T40);
+    SET(a, b, c, d, 13,  4, T41);
+    SET(d, a, b, c,  0, 11, T42);
+    SET(c, d, a, b,  3, 16, T43);
+    SET(b, c, d, a,  6, 23, T44);
+    SET(a, b, c, d,  9,  4, T45);
+    SET(d, a, b, c, 12, 11, T46);
+    SET(c, d, a, b, 15, 16, T47);
+    SET(b, c, d, a,  2, 23, T48);
+#undef SET
+
+     /* Round 4. */
+     /* Let [abcd k s t] denote the operation
+          a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
+#define I(x, y, z) ((y) ^ ((x) | ~(z)))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + I(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+     /* Do the following 16 operations. */
+    SET(a, b, c, d,  0,  6, T49);
+    SET(d, a, b, c,  7, 10, T50);
+    SET(c, d, a, b, 14, 15, T51);
+    SET(b, c, d, a,  5, 21, T52);
+    SET(a, b, c, d, 12,  6, T53);
+    SET(d, a, b, c,  3, 10, T54);
+    SET(c, d, a, b, 10, 15, T55);
+    SET(b, c, d, a,  1, 21, T56);
+    SET(a, b, c, d,  8,  6, T57);
+    SET(d, a, b, c, 15, 10, T58);
+    SET(c, d, a, b,  6, 15, T59);
+    SET(b, c, d, a, 13, 21, T60);
+    SET(a, b, c, d,  4,  6, T61);
+    SET(d, a, b, c, 11, 10, T62);
+    SET(c, d, a, b,  2, 15, T63);
+    SET(b, c, d, a,  9, 21, T64);
+#undef SET
+
+     /* Then perform the following additions. (That is increment each
+        of the four registers by the value it had before this block
+        was started.) */
+    pms->abcd[0] += a;
+    pms->abcd[1] += b;
+    pms->abcd[2] += c;
+    pms->abcd[3] += d;
+}
+
+void
+md5_init(md5_state_t *pms)
+{
+    pms->count[0] = pms->count[1] = 0;
+    pms->abcd[0] = 0x67452301;
+    pms->abcd[1] = /*0xefcdab89*/ T_MASK ^ 0x10325476;
+    pms->abcd[2] = /*0x98badcfe*/ T_MASK ^ 0x67452301;
+    pms->abcd[3] = 0x10325476;
+}
+
+void
+md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
+{
+    const md5_byte_t *p = data;
+    int left = nbytes;
+    int offset = (pms->count[0] >> 3) & 63;
+    md5_word_t nbits = (md5_word_t)(nbytes << 3);
+
+    if (nbytes <= 0)
+	return;
+
+    /* Update the message length. */
+    pms->count[1] += nbytes >> 29;
+    pms->count[0] += nbits;
+    if (pms->count[0] < nbits)
+	pms->count[1]++;
+
+    /* Process an initial partial block. */
+    if (offset) {
+	int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
+
+	memcpy(pms->buf + offset, p, copy);
+	if (offset + copy < 64)
+	    return;
+	p += copy;
+	left -= copy;
+	md5_process(pms, pms->buf);
+    }
+
+    /* Process full blocks. */
+    for (; left >= 64; p += 64, left -= 64)
+	md5_process(pms, p);
+
+    /* Process a final partial block. */
+    if (left)
+	memcpy(pms->buf, p, left);
+}
+
+void
+md5_finish(md5_state_t *pms, md5_byte_t digest[16])
+{
+    static const md5_byte_t pad[64] = {
+	0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+    md5_byte_t data[8];
+    int i;
+
+    /* Save the length before padding. */
+    for (i = 0; i < 8; ++i)
+	data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
+    /* Pad to 56 bytes mod 64. */
+    md5_append(pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
+    /* Append the length. */
+    md5_append(pms, data, 8);
+    for (i = 0; i < 16; ++i)
+	digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
+}

--- a/md5.h
+++ b/md5.h
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 1999, 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5.h,v 1.4 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.h is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Removed support for non-ANSI compilers; removed
+	references to Ghostscript; clarified derivation from RFC 1321;
+	now handles byte order either statically or dynamically.
+  1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
+  1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5);
+	added conditionalization for C++ compilation from Martin
+	Purschke <purschke@bnl.gov>.
+  1999-05-03 lpd Original version.
+ */
+
+#ifndef md5_INCLUDED
+#  define md5_INCLUDED
+
+/*
+ * This package supports both compile-time and run-time determination of CPU
+ * byte order.  If ARCH_IS_BIG_ENDIAN is defined as 0, the code will be
+ * compiled to run only on little-endian CPUs; if ARCH_IS_BIG_ENDIAN is
+ * defined as non-zero, the code will be compiled to run only on big-endian
+ * CPUs; if ARCH_IS_BIG_ENDIAN is not defined, the code will be compiled to
+ * run on either big- or little-endian CPUs, but will run slightly less
+ * efficiently on either one than if ARCH_IS_BIG_ENDIAN is defined.
+ */
+
+typedef unsigned char md5_byte_t; /* 8-bit byte */
+typedef unsigned int md5_word_t; /* 32-bit word */
+
+/* Define the state of the MD5 Algorithm. */
+typedef struct md5_state_s {
+    md5_word_t count[2];	/* message length in bits, lsw first */
+    md5_word_t abcd[4];		/* digest buffer */
+    md5_byte_t buf[64];		/* accumulate block */
+} md5_state_t;
+
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
+/* Initialize the algorithm. */
+
+#ifdef WIN32
+_declspec(dllexport)
+#endif
+void md5_init(md5_state_t *pms);
+
+/* Append a string to the message. */
+#ifdef WIN32
+_declspec(dllexport)
+#endif
+void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
+
+/* Finish the message and return the digest. */
+#ifdef WIN32
+_declspec(dllexport)
+#endif
+void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
+
+#ifdef __cplusplus
+}  /* end extern "C" */
+#endif
+
+#endif /* md5_INCLUDED */

--- a/proxy.h
+++ b/proxy.h
@@ -292,7 +292,7 @@ struct mcp_request_s {
 };
 
 typedef STAILQ_HEAD(io_head_s, _io_pending_proxy_t) io_head_t;
-#define MAX_IPLEN 45
+#define MAX_NAMELEN 255
 #define MAX_PORTLEN 6
 // TODO (v2): IOV_MAX tends to be 1000+ which would allow for more batching but we
 // don't have a good temporary space and don't want to malloc/free on every
@@ -303,9 +303,6 @@ typedef STAILQ_HEAD(io_head_s, _io_pending_proxy_t) io_head_t;
 #define BE_IOV_MAX IOV_MAX
 #endif
 struct mcp_backend_s {
-    char ip[MAX_IPLEN+1];
-    char port[MAX_PORTLEN+1];
-    double weight;
     int depth;
     int failed_count; // number of fails (timeouts) in a row
     pthread_mutex_t mutex; // covers stack.
@@ -327,6 +324,8 @@ struct mcp_backend_s {
     bool stacked; // if backend already queued for syscalls.
     bool bad; // timed out, marked as bad.
     struct iovec write_iovs[BE_IOV_MAX]; // iovs to stage batched writes
+    char name[MAX_NAMELEN+1];
+    char port[MAX_PORTLEN+1];
 };
 typedef STAILQ_HEAD(be_head_s, mcp_backend_s) be_head_t;
 
@@ -455,6 +454,7 @@ int mcplib_request_ntokens(lua_State *L);
 int mcplib_request_gc(lua_State *L);
 
 int mcplib_open_dist_jump_hash(lua_State *L);
+int mcplib_open_dist_ring_hash(lua_State *L);
 
 int proxy_run_coroutine(lua_State *Lc, mc_resp *resp, io_pending_proxy_t *p, conn *c);
 mcp_backend_t *mcplib_pool_proxy_call_helper(lua_State *L, mcp_pool_t *p, const char *key, size_t len);

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -822,7 +822,7 @@ static int _reset_bad_backend(mcp_backend_t *be, enum proxy_be_failures err) {
     STAILQ_INIT(&be->io_head);
 
     mcmc_disconnect(be->client);
-    int status = mcmc_connect(be->client, be->ip, be->port, be->connect_flags);
+    int status = mcmc_connect(be->client, be->name, be->port, be->connect_flags);
     if (status == MCMC_CONNECTED) {
         // TODO (v2): unexpected but lets let it be here.
         be->connecting = false;
@@ -842,7 +842,7 @@ static int _reset_bad_backend(mcp_backend_t *be, enum proxy_be_failures err) {
         be->can_write = true;
     }
 
-    LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, proxy_be_failure_text[err], be->ip, be->port);
+    LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, proxy_be_failure_text[err], be->name, be->port);
 
     return 0;
 }

--- a/proxy_ring_hash.c
+++ b/proxy_ring_hash.c
@@ -1,0 +1,366 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+* Copyright (c) 2022, Cache Forge LLC, All rights reserved.
+* Alan Kasindorf <alan@cacheforge.com>
+* Copyright (c) 2007, Last.fm, All rights reserved.
+* Richard Jones <rj@last.fm>
+* Christian Muehlhaeuser <muesli@gmail.com>
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the Last.fm Limited nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY Last.fm ``AS IS'' AND ANY
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Last.fm BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "proxy.h"
+#include "md5.h"
+
+#define DEFAULT_BUCKET_SIZE 160
+
+typedef struct {
+    unsigned int point; // continuum point.
+    unsigned int id; // server id.
+} cpoint;
+
+typedef struct {
+    struct proxy_hash_caller phc; // passed back to the proxy API.
+    unsigned int total_buckets;
+    cpoint continuum[]; // points to server ids.
+} ketama_t;
+
+static uint64_t ketama_key_hasher(const void *key, size_t len, uint64_t seed);
+static struct proxy_hash_func ketama_key_hash = {
+    ketama_key_hasher,
+};
+
+/* FROM ketama.c */
+static void ketama_md5_digest( char* inString, unsigned char md5pword[16] )
+{
+    md5_state_t md5state;
+
+    md5_init( &md5state );
+    md5_append( &md5state, (unsigned char *)inString, strlen( inString ) );
+    md5_finish( &md5state, md5pword );
+}
+
+static int ketama_compare(const void *p1, const void *p2) {
+    const cpoint *a = p1;
+    const cpoint *b = p2;
+
+    return (a->point < b->point) ? -1 : ((a->point > b->point) ? 1 : 0);
+}
+
+static uint64_t ketama_key_hasher(const void *key, size_t len, uint64_t seed) {
+    // NOTE: seed is ignored!
+    // embedding the md5 bits since key is specified with a length here.
+    md5_state_t md5state;
+    unsigned char digest[16];
+
+    md5_init(&md5state);
+    md5_append(&md5state, (unsigned char *)key, len);
+    md5_finish(&md5state, digest);
+
+    // mix the hash down (from ketama_hashi)
+    unsigned int h = (unsigned int)(( digest[3] << 24 )
+                        | ( digest[2] << 16 )
+                        | ( digest[1] <<  8 )
+                        |   digest[0] );
+    return h;
+}
+
+// Note: must return lookupas as zero-indexed.
+static uint32_t ketama_get_server(uint64_t hash, void *ctx) {
+    ketama_t *kt = (ketama_t *)ctx;
+    unsigned int h = hash;
+    int highp = kt->total_buckets;
+    int lowp = 0, midp;
+    unsigned int midval, midval1;
+
+    // divide and conquer array search to find server with next biggest
+    // point after what this key hashes to
+    while ( 1 )
+    {
+        midp = (int)( ( lowp+highp ) / 2 );
+
+        if ( midp == kt->total_buckets )
+            return kt->continuum[0].id-1; // if at the end, roll back to zeroth
+
+        midval = kt->continuum[midp].point;
+        midval1 = midp == 0 ? 0 : kt->continuum[midp-1].point;
+
+        if ( h <= midval && h > midval1 )
+            return kt->continuum[midp].id-1;
+
+        if ( midval < h )
+            lowp = midp + 1;
+        else
+            highp = midp - 1;
+
+        if ( lowp > highp )
+            return kt->continuum[0].id-1;
+    }
+}
+/* END FROM ketama.c */
+
+// not much to be done about this without making the interface unusable.
+#define MODE_DEFAULT 0 // uses xxhash
+#define MODE_KETAMA 1 // uses md5
+#define MODE_TWEMPROXY 2 // technically "libmemcached" ?
+#define MODE_EVCACHE 3 // not sure why this has a funny string init.
+
+// Not sure the hash algo used here matters all that much given the low number
+// of points... but it might be better to let it be overrideable.
+static void _add_server_default(ketama_t *kt, size_t hashstring_size, const char **parts,
+        lua_Integer bucket_size, lua_Integer id, unsigned int *cont) {
+    char *hashstring = malloc(hashstring_size);
+
+    for (int k = 0; k < bucket_size; k++) {
+        size_t len = snprintf(hashstring, hashstring_size, "%s:%s-%d", parts[0], parts[1], k);
+        kt->continuum[*cont].point = (unsigned int) XXH3_64bits(hashstring, len);
+        kt->continuum[*cont].id = id;
+    }
+
+    free(hashstring);
+}
+
+static void _add_server_ketama(ketama_t *kt, size_t hashstring_size, const char **parts,
+        lua_Integer bucket_size, lua_Integer id, unsigned int *cont) {
+    char *hashstring = malloc(hashstring_size);
+
+    for (int k = 0; k < bucket_size / 4; k++) {
+        unsigned char digest[16];
+
+        // - create hashing string for ketama
+        snprintf(hashstring, hashstring_size, "%s:%s-%d", parts[0], parts[1], k);
+
+        // - md5() hash it
+        // mostly from ketama.c
+        ketama_md5_digest(hashstring, digest);
+
+        /* Use successive 4-bytes from hash as numbers
+         * for the points on the circle: */
+        for(int h = 0; h < 4; h++ )
+        {
+            kt->continuum[*cont].point = ( digest[3+h*4] << 24 )
+                                  | ( digest[2+h*4] << 16 )
+                                  | ( digest[1+h*4] <<  8 )
+                                  |   digest[h*4];
+            kt->continuum[*cont].id = id;
+            (*cont)++;
+        }
+
+    }
+
+    free(hashstring);
+}
+
+static void _add_server_twemproxy(ketama_t *kt, size_t hashstring_size, const char **parts,
+        lua_Integer bucket_size, lua_Integer id, unsigned int *cont) {
+    char *hashstring = malloc(hashstring_size);
+
+    for (int k = 0; k < bucket_size / 4; k++) {
+        unsigned char digest[16];
+
+        // - create hashing string for ketama
+        if (strcmp(parts[1], "11211") == 0) {
+            // twemproxy sources libmemcached as removing the default port
+            // from the string if found.
+            snprintf(hashstring, hashstring_size, "%s-%d", parts[0], k);
+        } else {
+            snprintf(hashstring, hashstring_size, "%s:%s-%d", parts[0], parts[1], k);
+        }
+
+        // - md5() hash it
+        // mostly from ketama.c
+        ketama_md5_digest(hashstring, digest);
+
+        /* Use successive 4-bytes from hash as numbers
+         * for the points on the circle: */
+        for(int h = 0; h < 4; h++ )
+        {
+            kt->continuum[*cont].point = ( digest[3+h*4] << 24 )
+                                  | ( digest[2+h*4] << 16 )
+                                  | ( digest[1+h*4] <<  8 )
+                                  |   digest[h*4];
+            kt->continuum[*cont].id = id;
+            (*cont)++;
+        }
+
+    }
+
+    free(hashstring);
+}
+
+static void _add_server_evcache(ketama_t *kt, size_t hashstring_size, const char **parts,
+        lua_Integer bucket_size, lua_Integer id, unsigned int *cont) {
+    char *hashstring = malloc(hashstring_size);
+
+    for (int k = 0; k < bucket_size / 4; k++) {
+        unsigned char digest[16];
+
+        // - create hashing string for ketama
+        snprintf(hashstring, hashstring_size, "%s/%s:%s-%d", parts[0], parts[0], parts[1], k);
+        // - md5() hash it
+        // mostly from ketama.c
+        ketama_md5_digest(hashstring, digest);
+
+        /* Use successive 4-bytes from hash as numbers
+         * for the points on the circle: */
+        for(int h = 0; h < 4; h++ )
+        {
+            kt->continuum[*cont].point = ( digest[3+h*4] << 24 )
+                                  | ( digest[2+h*4] << 16 )
+                                  | ( digest[1+h*4] <<  8 )
+                                  |   digest[h*4];
+            kt->continuum[*cont].id = id;
+            (*cont)++;
+        }
+
+    }
+
+    free(hashstring);
+}
+
+#define PARTS 2
+// stack = [pool, option]
+static int ketama_new(lua_State *L) {
+    lua_Integer bucket_size = DEFAULT_BUCKET_SIZE;
+    const char *parts[PARTS];
+    size_t partlens[PARTS];
+    int makemode = 0;
+
+    // check for UA_TTABLE at 1
+    luaL_checktype(L, 1, LUA_TTABLE);
+    // get number of servers in pool.
+    // NOTE: rawlen skips metatable redirection. if we care; lua_len instead.
+    lua_Unsigned total = lua_rawlen(L, 1);
+
+    // check for optional input
+    int argc = lua_gettop(L);
+    if (argc > 1) {
+        luaL_checktype(L, 2, LUA_TTABLE);
+        if (lua_getfield(L, 2, "omode") != LUA_TNIL) {
+            luaL_checktype(L, -1, LUA_TSTRING);
+            const char *mode = lua_tostring(L, -1);
+            if (strcmp(mode, "default") == 0) {
+                makemode = MODE_DEFAULT;
+            } else if (strcmp(mode, "ketama") == 0) {
+                makemode = MODE_KETAMA;
+            } else if (strcmp(mode, "twemproxy") == 0) {
+                makemode = MODE_TWEMPROXY;
+            } else if (strcmp(mode, "evcache") == 0) {
+                makemode = MODE_EVCACHE;
+            } else {
+                lua_pushstring(L, "ring_hash: bad omode argument");
+                lua_error(L);
+            }
+        }
+        lua_pop(L, 1); // pops the nil or mode
+
+        if (lua_getfield(L, 2, "obuckets") != LUA_TNIL) {
+          int success = 0;
+          bucket_size = lua_tointegerx(L, -1, &success);
+          if (!success || bucket_size < 1) {
+              lua_pushstring(L, "ring_hash: option argument must be a positive integer");
+              lua_error(L);
+          }
+        }
+        lua_pop(L, 1);
+    }
+
+    // newuserdatauv() sized for pool*
+    size_t size = sizeof(ketama_t) + sizeof(cpoint) * (total * bucket_size);
+    ketama_t *kt = lua_newuserdatauv(L, size, 0);
+    // TODO: check *kt.
+    kt->total_buckets = bucket_size * total;
+
+    // loop over pool
+    unsigned int cont = 0;
+    lua_pushnil(L); // start the pool iterator
+    while (lua_next(L, 1) != 0) {
+        // key is -2, value is -1.
+        // value is another table. need to query it to get what we need for
+        // the hash.
+        // hash string is: hostname/ipaddr:port-repitition
+        // TODO: bother doing error checking?
+        lua_getfield(L, -1, "id");
+        lua_Integer id = lua_tointeger(L, -1);
+        lua_pop(L, 1);
+
+        // FIXME: we need to do the lua_pop after string assembly to be safe.
+        lua_getfield(L, -1, "addr");
+        parts[0] = lua_tolstring(L, -1, &partlens[0]);
+        lua_pop(L, 1);
+        lua_getfield(L, -1, "port");
+        parts[1] = lua_tolstring(L, -1, &partlens[1]);
+        lua_pop(L, 1);
+
+        size_t hashstring_size = 0;
+        for (int x = 0; x < PARTS; x++) {
+            hashstring_size += partlens[x];
+        }
+
+        // We have up to 3 delimiters in the final hashstring and an index
+        // 16 bytes is plenty to accomodate this requirement.
+        hashstring_size += 16;
+
+        switch (makemode) {
+            case MODE_DEFAULT:
+                _add_server_default(kt, hashstring_size, parts, bucket_size, id, &cont);
+                break;
+            case MODE_KETAMA:
+                _add_server_ketama(kt, hashstring_size, parts, bucket_size, id, &cont);
+                break;
+            case MODE_TWEMPROXY:
+                _add_server_twemproxy(kt, hashstring_size, parts, bucket_size, id, &cont);
+                break;
+            case MODE_EVCACHE:
+                _add_server_evcache(kt, hashstring_size, parts, bucket_size, id, &cont);
+                break;
+        }
+
+        lua_pop(L, 1); // remove value, leave key for next iteration.
+    }
+
+    // - qsort the points
+    qsort( &kt->continuum, cont, sizeof(cpoint), ketama_compare);
+
+    // set the hash/fetch function and the context ptr.
+    kt->phc.ctx = kt;
+    kt->phc.selector_func = ketama_get_server;
+
+    // - add a pushlightuserdata for the sub-struct with func/ctx.
+    lua_pushlightuserdata(L, &kt->phc);
+    // - return [UD, lightuserdata]
+    return 2;
+}
+
+int mcplib_open_dist_ring_hash(lua_State *L) {
+    const struct luaL_Reg ketama_f[] = {
+        {"new", ketama_new},
+        {NULL, NULL},
+    };
+
+    luaL_newlib(L, ketama_f);
+    lua_pushlightuserdata(L, &ketama_key_hash);
+    lua_setfield(L, -2, "hash");
+
+    return 1;
+}

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -23,56 +23,56 @@ function mcp_config_pools(oldss)
     -- IPs are "127" . "zone" . "pool" . "srv"
     local pfx = 'fooz1'
     local fooz1 = {
-        srv(pfx .. 'srv1', '127.1.1.1', 11212, 1),
-        srv(pfx .. 'srv2', '127.1.1.2', 11212, 1),
-        srv(pfx .. 'srv3', '127.1.1.3', 11212, 1),
+        srv(pfx .. 'srv1', '127.1.1.1', 11212),
+        srv(pfx .. 'srv2', '127.1.1.2', 11212),
+        srv(pfx .. 'srv3', '127.1.1.3', 11212),
     }
     pfx = 'fooz2'
     local fooz2 = {
-        srv(pfx .. 'srv1', '127.2.1.1', 11213, 1),
-        srv(pfx .. 'srv2', '127.2.1.2', 11213, 1),
-        srv(pfx .. 'srv3', '127.2.1.3', 11213, 1),
+        srv(pfx .. 'srv1', '127.2.1.1', 11213),
+        srv(pfx .. 'srv2', '127.2.1.2', 11213),
+        srv(pfx .. 'srv3', '127.2.1.3', 11213),
     }
     pfx = 'fooz3'
     local fooz3 = {
-        srv(pfx .. 'srv1', '127.3.1.1', 11214, 1),
-        srv(pfx .. 'srv2', '127.3.1.2', 11214, 1),
-        srv(pfx .. 'srv3', '127.3.1.3', 11214, 1),
+        srv(pfx .. 'srv1', '127.3.1.1', 11214),
+        srv(pfx .. 'srv2', '127.3.1.2', 11214),
+        srv(pfx .. 'srv3', '127.3.1.3', 11214),
     }
 
     pfx = 'barz1'
     -- zone "/bar/"-s primary zone should fail; all down.
     local barz1 = {
-        srv(pfx .. 'srv1', '127.1.2.1', 11210, 1),
-        srv(pfx .. 'srv2', '127.1.2.1', 11210, 1),
-        srv(pfx .. 'srv3', '127.1.2.1', 11210, 1),
+        srv(pfx .. 'srv1', '127.1.2.1', 11210),
+        srv(pfx .. 'srv2', '127.1.2.2', 11210),
+        srv(pfx .. 'srv3', '127.1.2.3', 11210),
     }
     pfx = 'barz2'
     local barz2 = {
-        srv(pfx .. 'srv1', '127.2.2.2', 11215, 1),
-        srv(pfx .. 'srv2', '127.2.2.2', 11215, 1),
-        srv(pfx .. 'srv3', '127.2.2.2', 11215, 1),
+        srv(pfx .. 'srv1', '127.2.2.1', 11215),
+        srv(pfx .. 'srv2', '127.2.2.2', 11215),
+        srv(pfx .. 'srv3', '127.2.2.3', 11215),
     }
     pfx = 'barz3'
     local barz3 = {
-        srv(pfx .. 'srv1', '127.3.2.3', 11216, 1),
-        srv(pfx .. 'srv2', '127.3.2.3', 11216, 1),
-        srv(pfx .. 'srv3', '127.3.2.3', 11216, 1),
+        srv(pfx .. 'srv1', '127.3.2.1', 11216),
+        srv(pfx .. 'srv2', '127.3.2.2', 11216),
+        srv(pfx .. 'srv3', '127.3.2.3', 11216),
     }
 
     -- fallback cache for any zone
     -- NOT USED YET
     pfx = 'fallz1'
     local fallz1 = {
-        srv(pfx .. 'srv1', '127.0.2.1', 11212, 1),
+        srv(pfx .. 'srv1', '127.0.2.1', 11212),
     }
     pfx = 'fallz2'
     local fallz2 = {
-        srv(pfx .. 'srv1', '127.0.2.2', 11212, 1),
+        srv(pfx .. 'srv1', '127.0.2.2', 11212),
     }
     pfx = 'fallz3'
     local fallz3 = {
-        srv(pfx .. 'srv1', '127.0.2.3', 11212, 1),
+        srv(pfx .. 'srv1', '127.0.2.3', 11212),
     }
 
     local main_zones = {
@@ -84,19 +84,16 @@ function mcp_config_pools(oldss)
     -- FIXME: should we copy the table to keep the pool tables around?
     -- does the hash selector hold a reference to the pool (but only available in main config?)
 
-    -- uncomment to use the ketama loadable module.
-    -- FIXME: passing an argument to the ketama module doesn't work yet.
-    -- local ketama = require("ketama")
-
     -- convert the pools into hash selectors.
     -- TODO: is this a good place to add prefixing/hash editing?
     for _, subs in pairs(main_zones) do
         for k, v in pairs(subs) do
-            -- use next line instead for a third party ketama hash
-            -- subs[k] = mcp.pool(v, { dist = ketama, hash = ketama.hash })
-            -- this line overrides the default bucket size for ketama
-            -- subs[k] = mcp.pool(v, { dist = ketama, obucket = 80 })
-            -- this line uses the default murmur3 straight hash.
+            -- next line uses a ring hash in "evcache compat" mode. note the
+            -- hash= override to use MD5 key hashing from ketama.
+            -- subs[k] = mcp.pool(v, { dist = mcp.dist_ring_hash, omode = "evcache", hash = mcp.dist_ring_hash.hash })
+            -- override the number of buckets per server.
+            -- subs[k] = mcp.pool(v, { dist = mcp.dist_ring_hash, omode = "evcache", hash = mcp.dist_ring_hash.hash, obuckets = 240 })
+            -- this line uses the default (currently xxhash + jump hash)
             subs[k] = mcp.pool(v)
 
             -- use this next line instead for jump hash.

--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -11,7 +11,7 @@ BEGIN {
         exit 0;
     }
 
-    my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md compile_commands.json);
+    my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md compile_commands.json md5.c md5.h);
     push(@exempted, glob("doc/*.xml"));
     push(@exempted, glob("doc/*.full"));
     push(@exempted, glob("doc/xml2rfc/*.xsl"));


### PR DESCRIPTION
this is ketama-based, with options for minor compat changes with major
libraries.

does _not_ support weights. The weights bits in the original ketama
broke the algorithm, as changing the number of points would shift
unrelated servers when the list changes.

this also changes backends to take a "name" specifically, instead of an
"ip address". Though note if supplying a hostname instead of an IP there
might be inline DNS lookups on reconnects.