### PR TITLE
Proxy feature roundup

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -131,7 +131,6 @@ enum proxy_defines {
 enum proxy_cmd_types {
     CMD_TYPE_GENERIC = 0,
     CMD_TYPE_GET, // get/gets/gat/gats
-    CMD_TYPE_UPDATE, // add/set/cas/prepend/append/replace
     CMD_TYPE_META, // m*'s.
 };
 
@@ -273,6 +272,7 @@ struct mcp_parser_s {
     uint32_t klen; // length of key.
     uint16_t tokens[PARSER_MAX_TOKENS]; // offsets for start of each token
     bool has_space; // a space was found after the last byte parsed.
+    bool noreply; // if quiet/noreply mode is set.
     union {
         struct mcp_parser_meta_s meta;
     } t;
@@ -355,15 +355,22 @@ struct proxy_event_thread_s {
     struct proxy_tunables tunables; // periodically copied from main ctx
 };
 
+enum mcp_resp_mode {
+    RESP_MODE_NORMAL = 0,
+    RESP_MODE_NOREPLY,
+    RESP_MODE_METAQUIET
+};
+
 #define RESP_CMD_MAX 8
 typedef struct {
     mcmc_resp_t resp;
     struct timeval start; // start time inherited from paired request
-    char cmd[RESP_CMD_MAX+1]; // until we can reverse CMD_*'s to strings directly.
-    int status; // status code from mcmc_read()
     char *buf; // response line + potentially value.
     size_t blen; // total size of the value to read.
+    int status; // status code from mcmc_read()
     int bread; // amount of bytes read into value so far.
+    char cmd[RESP_CMD_MAX+1]; // until we can reverse CMD_*'s to strings directly.
+    enum mcp_resp_mode mode; // reply mode (for noreply fixing)
 } mcp_resp_t;
 
 // re-cast an io_pending_t into this more descriptive structure.

--- a/proxy.h
+++ b/proxy.h
@@ -440,7 +440,7 @@ enum mcp_await_e {
     AWAIT_FIRST, // return the result from the first pool
 };
 int mcplib_await(lua_State *L);
-int mcplib_await_run(conn *c, lua_State *L, int coro_ref);
+int mcplib_await_run(conn *c, mc_resp *resp, lua_State *L, int coro_ref);
 int mcplib_await_return(io_pending_proxy_t *p);
 
 // user stats interface

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -525,7 +525,19 @@ int mcplib_request(lua_State *L) {
     size_t vlen = 0;
     mcp_parser_t pr = {0};
     const char *cmd = luaL_checklstring(L, 1, &len);
-    const char *val = luaL_optlstring(L, 2, NULL, &vlen);
+    const char *val = NULL;
+    int type = lua_type(L, 2);
+    if (type == LUA_TSTRING) {
+        val = luaL_optlstring(L, 2, NULL, &vlen);
+    } else if (type == LUA_TUSERDATA) {
+        mcp_resp_t *r = luaL_checkudata(L, 2, "mcp.response");
+        if (r->buf) {
+            val = r->buf;
+            vlen = r->blen;
+        } else {
+            // TODO (v2): other response modes unhandled.
+        }
+    }
 
     // FIXME (v2): if we inline the userdata we can avoid memcpy'ing the parser
     // structure from the stack? but causes some code duplication.

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -131,12 +131,16 @@ function failover_factory(zones, local_zone)
         if res:hit() == false then
             -- example for mcp.log... Don't do this though :)
             mcp.log("failed to find " .. r:key() .. " in zone: " .. local_zone)
-            for _, zone in pairs(far_zones) do
-                res = zone(r)
+            --for _, zone in pairs(far_zones) do
+            --    res = zone(r)
+            local restable = mcp.await(r, far_zones, 1)
+            for _, res in pairs(restable) do
                 if res:hit() then
-                    break
+                    --break
+                    return res
                 end
             end
+            return restable[1]
         end
         return res -- send result back to client
     end


### PR DESCRIPTION
There're a few usability features that bother me too much to go without in "v1"

- a hacky method of supporting noreply/quiet commands; I can see what would be bullet proof but will take time to get there.
- allow creating set requests from get responses. this is at least partly in now.
- _maybe_: get meta binary keys to work. Unfortunately this requires some fiddling as the key needs to be unpacked/repacked. The parser operates on const strings (as it must) so we would have to deal with binary keys from a layer higher.
- _maybe_: some extra functions for finding/editing meta tokens/flags

The meta routing tokens means we wouldn't necessarily have to examine binary keys at all, so for people trying to get every ounce of performance they can still avoid the transforms easily.

Everything past these should be stability fixes instead of feature updates until v1 is out.