### PR TITLE
Improve Slab Automove behavior

### DIFF
--- a/items.c
+++ b/items.c
@@ -660,10 +660,17 @@ void fill_item_stats_automove(item_stats_automove *am) {
         i = n | COLD_LRU;
         pthread_mutex_lock(&lru_locks[i]);
         cur->evicted = itemstats[i].evicted;
-        if (tails[i]) {
-            cur->age = current_time - tails[i]->time;
-        } else {
+        if (!tails[i]) {
             cur->age = 0;
+        } else if (tails[i]->nbytes == 0 && tails[i]->nkey == 0 && tails[i]->it_flags == 1) {
+            /* it's a crawler, check previous entry */
+            if (tails[i]->prev) {
+               cur->age = current_time - tails[i]->prev->time;
+            } else {
+               cur->age = 0;
+            }
+        } else {
+            cur->age = current_time - tails[i]->time;
         }
         pthread_mutex_unlock(&lru_locks[i]);
      }

--- a/slab_automove.c
+++ b/slab_automove.c
@@ -98,9 +98,6 @@ void slab_automove_run(void *arg, int *src, int *dst) {
         int w_offset = n * a->window_size;
         struct window_data *wd = &a->window_data[w_offset + (a->window_cur % a->window_size)];
         memset(wd, 0, sizeof(struct window_data));
-        // summarize the window-up-to-now.
-        memset(&w_sum, 0, sizeof(struct window_data));
-        window_sum(&a->window_data[w_offset], &w_sum, a->window_size);
 
         // if page delta, or evicted delta, mark window dirty
         // (or outofmemory)
@@ -122,6 +119,10 @@ void slab_automove_run(void *arg, int *src, int *dst) {
         // set age into window
         wd->age = a->iam_after[n].age;
 
+        // summarize the window-up-to-now.
+        memset(&w_sum, 0, sizeof(struct window_data));
+        window_sum(&a->window_data[w_offset], &w_sum, a->window_size);
+
         // grab age as average of window total
         uint64_t age = w_sum.age / a->window_size;
 
@@ -130,6 +131,7 @@ void slab_automove_run(void *arg, int *src, int *dst) {
             if (w_sum.dirty == 0) {
                 *src = n;
                 *dst = 0;
+                youngest = oldest = -1;
                 break;
             }
         }


### PR DESCRIPTION
- Skip using crawler items when calculating the automover age stats as
they can severely skew the ages in the stats to the point of completely
starving particular slabs
- Include the current window data in the window sum so we don't free
pages that are actually needed - this also matches the python script
behavior
- Reset young / old when interrupting the automove decision loop so we
don't accidentally move things which we didn't mean to