### PR TITLE
proxy: mcp.log_req* API interface

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1177,7 +1177,7 @@ The arguments are:
   address IP and port. Connection close events additionally supply a reason for
   closing the connection.
 
-- "proxycmds": Emits detailed timing logs about requests/responses being
+- "proxyreqs": Emits detailed timing logs about requests/responses being
   returned to a client while in proxy mode. The conditions which logs are
   written here may be influenced by configuration.
 

--- a/logger.c
+++ b/logger.c
@@ -304,33 +304,6 @@ static int _logger_parse_cce(logentry *e, char *scratch) {
 }
 
 #ifdef PROXY
-static void _logger_log_proxy_raw(logentry *e, const entry_details *d, const void *entry, va_list ap) {
-    struct timeval start = va_arg(ap, struct timeval);
-    char *cmd = va_arg(ap, char *);
-    unsigned short type = va_arg(ap, int);
-    unsigned short code = va_arg(ap, int);
-
-    struct logentry_proxy_raw *le = (void *)e->data;
-    struct timeval end;
-    gettimeofday(&end, NULL);
-    le->type = type;
-    le->code = code;
-    le->elapsed = (end.tv_sec - start.tv_sec) * 1000000 + (end.tv_usec - start.tv_usec);
-    memcpy(le->cmd, cmd, 9);
-    e->size = sizeof(struct logentry_proxy_raw);
-}
-
-static int _logger_parse_prx_raw(logentry *e, char *scratch) {
-    int total;
-    struct logentry_proxy_raw *le = (void *)e->data;
-
-    total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
-            "ts=%d.%d gid=%llu type=proxy_raw elapsed=%lu cmd=%s type=%d code=%d\n",
-            (int) e->tv.tv_sec, (int) e->tv.tv_usec, (unsigned long long) e->gid,
-            le->elapsed, le->cmd, le->type, le->code);
-    return total;
-}
-
 // TODO (v2): the length caps here are all magic numbers. Haven't thought of
 // something yet that I like better.
 // Should at least make a define to the max log len (1024) and do some math
@@ -383,7 +356,6 @@ static int _logger_parse_prx_req(logentry *e, char *scratch) {
     int total;
     struct logentry_proxy_req *le = (void *)e->data;
 
-    // TODO: encode detail / req
     total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
             "ts=%d.%d gid=%llu type=proxy_req elapsed=%lu type=%d code=%d status=%d be=%.*s:%.*s detail=%.*s req=%.*s\n",
             (int) e->tv.tv_sec, (int) e->tv.tv_usec, (unsigned long long) e->gid,
@@ -435,8 +407,7 @@ static const entry_details default_entries[] = {
     [LOGGER_PROXY_CONFIG] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
         "type=proxy_conf status=%s"
     },
-    [LOGGER_PROXY_RAW] = {512, LOG_PROXYCMDS, _logger_log_proxy_raw, _logger_parse_prx_raw, NULL},
-    [LOGGER_PROXY_REQ] = {1024, LOG_PROXYUSER, _logger_log_proxy_req, _logger_parse_prx_req, NULL},
+    [LOGGER_PROXY_REQ] = {1024, LOG_PROXYREQS, _logger_log_proxy_req, _logger_parse_prx_req, NULL},
     [LOGGER_PROXY_ERROR] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
         "type=proxy_error msg=%s"
     },

--- a/logger.c
+++ b/logger.c
@@ -330,6 +330,70 @@ static int _logger_parse_prx_raw(logentry *e, char *scratch) {
             le->elapsed, le->cmd, le->type, le->code);
     return total;
 }
+
+// TODO (v2): the length caps here are all magic numbers. Haven't thought of
+// something yet that I like better.
+// Should at least make a define to the max log len (1024) and do some math
+// here.
+static void _logger_log_proxy_req(logentry *e, const entry_details *d, const void *entry, va_list ap) {
+    char *req = va_arg(ap, char *);
+    int reqlen = va_arg(ap, uint32_t);
+    long elapsed = va_arg(ap, long);
+    unsigned short type = va_arg(ap, int);
+    unsigned short code = va_arg(ap, int);
+    int status = va_arg(ap, int);
+    char *detail = va_arg(ap, char *);
+    size_t dlen = va_arg(ap, size_t);
+    char *be_name = va_arg(ap, char *);
+    char *be_port = va_arg(ap, char *);
+
+    struct logentry_proxy_req *le = (void *)e->data;
+    le->type = type;
+    le->code = code;
+    le->status = status;
+    le->dlen = dlen;
+    le->elapsed = elapsed;
+    le->be_namelen = strlen(be_name);
+    le->be_portlen = strlen(be_port);
+    char *data = le->data;
+    if (req[reqlen-2] == '\r') {
+        reqlen -= 2;
+    } else {
+        reqlen--;
+    }
+    if (reqlen > 300) {
+        reqlen = 300;
+    }
+    if (dlen > 150) {
+        dlen = 150;
+    }
+    // be_namelen and be_portlen can't be longer than 255+6
+    le->reqlen = reqlen;
+    memcpy(data, req, reqlen);
+    data += reqlen;
+    memcpy(data, detail, dlen);
+    data += dlen;
+    memcpy(data, be_name, le->be_namelen);
+    data += le->be_namelen;
+    memcpy(data, be_port, le->be_portlen);
+    e->size = sizeof(struct logentry_proxy_req) + reqlen + dlen + le->be_namelen + le->be_portlen;
+}
+
+static int _logger_parse_prx_req(logentry *e, char *scratch) {
+    int total;
+    struct logentry_proxy_req *le = (void *)e->data;
+
+    // TODO: encode detail / req
+    total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
+            "ts=%d.%d gid=%llu type=proxy_req elapsed=%lu type=%d code=%d status=%d be=%.*s:%.*s detail=%.*s req=%.*s\n",
+            (int) e->tv.tv_sec, (int) e->tv.tv_usec, (unsigned long long) e->gid,
+            le->elapsed, le->type, le->code, le->status,
+            (int)le->be_namelen, le->data+le->reqlen+le->dlen,
+            (int)le->be_portlen, le->data+le->reqlen+le->dlen+le->be_namelen, // fml.
+            (int)le->dlen, le->data+le->reqlen, (int)le->reqlen, le->data
+            );
+    return total;
+}
 #endif
 
 /* Should this go somewhere else? */
@@ -372,6 +436,7 @@ static const entry_details default_entries[] = {
         "type=proxy_conf status=%s"
     },
     [LOGGER_PROXY_RAW] = {512, LOG_PROXYCMDS, _logger_log_proxy_raw, _logger_parse_prx_raw, NULL},
+    [LOGGER_PROXY_REQ] = {1024, LOG_PROXYUSER, _logger_log_proxy_req, _logger_parse_prx_req, NULL},
     [LOGGER_PROXY_ERROR] = {512, LOG_PROXYEVENTS, _logger_log_text, _logger_parse_text,
         "type=proxy_error msg=%s"
     },

--- a/logger.h
+++ b/logger.h
@@ -115,13 +115,6 @@ struct logentry_conn_event {
     struct sockaddr_in6 addr;
 };
 #ifdef PROXY
-struct logentry_proxy_raw {
-    unsigned short type;
-    unsigned short code;
-    long elapsed; // elapsed time in usec
-    char cmd[8];
-};
-
 struct logentry_proxy_req {
     unsigned short type;
     unsigned short code;
@@ -159,7 +152,7 @@ struct _logentry {
 #define LOG_EVICTIONS  (1<<6) /* details of evicted items */
 #define LOG_STRICT     (1<<7) /* block worker instead of drop */
 #define LOG_RAWCMDS    (1<<9) /* raw ascii commands */
-#define LOG_PROXYCMDS  (1<<10) /* command logs from proxy */
+#define LOG_PROXYREQS  (1<<10) /* command logs from proxy */
 #define LOG_PROXYEVENTS (1<<11) /* error log stream from proxy */
 #define LOG_PROXYUSER (1<<12) /* user generated logs from proxy */
 

--- a/logger.h
+++ b/logger.h
@@ -36,6 +36,7 @@ enum log_entry_type {
     LOGGER_PROXY_RAW,
     LOGGER_PROXY_ERROR,
     LOGGER_PROXY_USER,
+    LOGGER_PROXY_REQ,
     LOGGER_PROXY_BE_ERROR,
 #endif
 };
@@ -119,6 +120,18 @@ struct logentry_proxy_raw {
     unsigned short code;
     long elapsed; // elapsed time in usec
     char cmd[8];
+};
+
+struct logentry_proxy_req {
+    unsigned short type;
+    unsigned short code;
+    int status;
+    uint32_t reqlen;
+    size_t dlen;
+    size_t be_namelen;
+    size_t be_portlen;
+    long elapsed;
+    char data[];
 };
 #endif
 /* end intermediary structures */

--- a/memcached.h
+++ b/memcached.h
@@ -719,6 +719,7 @@ typedef struct {
     void *proxy_hooks;
     void *proxy_user_stats;
     void *proxy_int_stats;
+    uint32_t proxy_rng[4]; // fast per-thread rng for lua.
     // TODO: add ctx object so we can attach to queue.
 #endif
 } LIBEVENT_THREAD;

--- a/proto_text.c
+++ b/proto_text.c
@@ -2291,8 +2291,8 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
                 f |= LOG_SYSEVENTS;
             } else if ((strcmp(tokens[x].value, "connevents") == 0)) {
                 f |= LOG_CONNEVENTS;
-            } else if ((strcmp(tokens[x].value, "proxycmds") == 0)) {
-                f |= LOG_PROXYCMDS;
+            } else if ((strcmp(tokens[x].value, "proxyreqs") == 0)) {
+                f |= LOG_PROXYREQS;
             } else if ((strcmp(tokens[x].value, "proxyevents") == 0)) {
                 f |= LOG_PROXYEVENTS;
             } else if ((strcmp(tokens[x].value, "proxyuser") == 0)) {

--- a/proxy.h
+++ b/proxy.h
@@ -371,6 +371,8 @@ typedef struct {
     int bread; // amount of bytes read into value so far.
     char cmd[RESP_CMD_MAX+1]; // until we can reverse CMD_*'s to strings directly.
     enum mcp_resp_mode mode; // reply mode (for noreply fixing)
+    char be_name[MAX_NAMELEN+1];
+    char be_port[MAX_PORTLEN+1];
 } mcp_resp_t;
 
 // re-cast an io_pending_t into this more descriptive structure.

--- a/proxy.h
+++ b/proxy.h
@@ -364,12 +364,11 @@ enum mcp_resp_mode {
 #define RESP_CMD_MAX 8
 typedef struct {
     mcmc_resp_t resp;
-    struct timeval start; // start time inherited from paired request
     char *buf; // response line + potentially value.
     size_t blen; // total size of the value to read.
     int status; // status code from mcmc_read()
     int bread; // amount of bytes read into value so far.
-    char cmd[RESP_CMD_MAX+1]; // until we can reverse CMD_*'s to strings directly.
+    uint8_t cmd; // from parser (pr.command)
     enum mcp_resp_mode mode; // reply mode (for noreply fixing)
     char be_name[MAX_NAMELEN+1];
     char be_port[MAX_PORTLEN+1];

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -167,6 +167,10 @@ static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int aw
 
     // The direct backend object. await object is holding reference
     p->backend = be;
+    // See #887 for notes.
+    // TODO (v2): hopefully this can be optimized out.
+    strncpy(r->be_name, be->name, MAX_NAMELEN+1);
+    strncpy(r->be_port, be->port, MAX_PORTLEN+1);
 
     mcp_request_attach(Lc, rq, p);
 

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -97,7 +97,6 @@ static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int aw
     // reserve one uservalue for a lua-supplied response.
     mcp_resp_t *r = lua_newuserdatauv(Lc, sizeof(mcp_resp_t), 1);
     memset(r, 0, sizeof(mcp_resp_t));
-    r->start = rq->start;
     // Set noreply mode.
     // TODO (v2): the response "inherits" the request's noreply mode, which isn't
     // strictly correct; we should inherit based on the request that spawned
@@ -120,15 +119,7 @@ static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int aw
         r->mode = RESP_MODE_NORMAL;
     }
 
-    int x;
-    int end = rq->pr.reqlen-2 > RESP_CMD_MAX ? RESP_CMD_MAX : rq->pr.reqlen-2;
-    for (x = 0; x < end; x++) {
-        if (rq->pr.request[x] == ' ') {
-            break;
-        }
-        r->cmd[x] = rq->pr.request[x];
-    }
-    r->cmd[x] = '\0';
+    r->cmd = rq->pr.command;
 
     luaL_getmetatable(Lc, "mcp.response");
     lua_setmetatable(Lc, -2);


### PR DESCRIPTION
Been experimenting with different logging interfaces. The `watch proxycmds` logger has a very limited view into the request context (mainly, it only has the response object and not the original request to compare to), but adds some other hard to get information (total length of a request cycle, etc). To get better logging with full context and some control lets hoist this into lua. It's also a crazy firehose so lets add some conditionals/sampling.

This adds `mcp.log_req(request, response, "detail")` and `mcp_log_reqsample(milliseconds, rate, allerrors, rq, rs, "detail")`. The idea is to add context from passing through a route function. See `t/startfile.lua`'s usage. Note that in startfile the reqlog is buried pretty low, but it could be the top level route as well. This means you can change logging granularity (or if it should log at all) per route if desired.

TODO:
- [x] Still figuring the interface I prefer: lots of funcs or funcs with options. Don't want to create/dump an options table so we're stuck with arguments. (done: went with two functions)
- [x] This adds a way to only log if it took over some elapsed time, or a sample rate (ie; one in 1000 reqs on average). Also want to add a way of saying "if we're sampling or checking elapsed, also log 100% of request errors (ie; not `MCMC_OK`) (done)
- [x] Needs to encode request and detail for the log output (yes yes yes, it's fine! you can't parse the log lines unless this happens!) (snipping newline from the request so we can just drop the whole line in as the final argument here... will make parsing log lines a bit harder but not sure it matters). if people put spaces in the detail section that's their own fault)
- [x] Not convinced I need the random generator vs a modulo. Modulo isn't exactly fast but it'll still beat this random generator by a bit. (meh, fine.)
- [x] rewire t/startfile.lua to add log detail from the zone functions. (got one example up)
- [x] Need to extend these a bit so the "response" can be a string, so we can log plain responses created by lua. Currently `watch proxycmds` will only fire log lines that create full response objects.
- [x] Need to get backend host/port info into the string. Sadly doesn't look like any better options other than copying the whole strings into the response object on every request :(
- [x] Update logger to reserve a min 1k space for these potentially huge lines :(
- [x] Maybe: delete proxycmds entirely. it's half useless and can minus out a decent chunk of code. Could reuse the proxycmds flag as proxyreqs specific to `log_req`
- [ ] Maybe: Store the length of the backend host strings in `mcp_backend_s` so we can remove all of the strncpy's.