### PR TITLE
Disable TLS re-negotiation via SSL_OP_NO_RENEGOTIATION option

### DIFF
--- a/tls.c
+++ b/tls.c
@@ -212,17 +212,23 @@ int ssl_init(void) {
         SSL_CTX_set_session_cache_mode(settings.ssl_ctx, SSL_SESS_CACHE_OFF);
     }
 
+#ifdef SSL_OP_NO_RENEGOTIATION
+    // Disable TLS re-negotiation if SSL_OP_NO_RENEGOTIATION is defined for
+    // openssl 1.1.0h or above
+    SSL_CTX_set_options(settings.ssl_ctx, SSL_OP_NO_RENEGOTIATION);
+#endif
+
     return 0;
 }
 
 /*
  * This method is registered with each SSL connection and abort the SSL session
- * if a client initiates a renegotiation.
- * TODO : Proper way to do this is to set SSL_OP_NO_RENEGOTIATION
- *       using the SSL_CTX_set_options but that option only available in
- *       openssl 1.1.0h or above.
+ * if a client initiates a renegotiation for openssl versions before 1.1.0h.
+ * For openssl 1.1.0h and above, TLS re-negotiation is disabled by setting the
+ * SSL_OP_NO_RENEGOTIATION option in SSL_CTX_set_options.
  */
 void ssl_callback(const SSL *s, int where, int ret) {
+#ifndef SSL_OP_NO_RENEGOTIATION
     SSL* ssl = (SSL*)s;
     if (SSL_in_before(ssl)) {
         fprintf(stderr, "%d: SSL renegotiation is not supported, "
@@ -230,6 +236,7 @@ void ssl_callback(const SSL *s, int where, int ret) {
         SSL_set_shutdown(ssl, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
         return;
     }
+#endif
 }
 
 /*


### PR DESCRIPTION
Properly disable TLS re-negotiation by setting the `SSL_OP_NO_RENEGOTIATION` option via `SSL_CTX_set_options()`. This applies when the OpenSSL version is 1.1.0h and above when the `SSL_OP_NO_RENEGOTIATION` macro is defined.

Before the fix, I was able to do TLS re-negotiation from client side on an open session.

> /usr/bin/openssl s_client -connect localhost:11211
> ---
> New, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES256-GCM-SHA384
> Server public key is 2048 bit
> Secure Renegotiation IS supported
> SSL-Session:
>    Protocol  : TLSv1.2
> ....
> R
> RENEGOTIATING
> depth=0 C = US, ST = CA, O = Test, OU = Subunit of Test Organization, CN = test.com, emailAddress = root@test.com
> verify error:num=20:unable to get local issuer certificate
> verify return:1
> depth=0 C = US, ST = CA, O = Test, OU = Subunit of Test Organization, CN = test.com, emailAddress = root@test.com
> verify error:num=21:unable to verify the first certificate
> verify return:1

After the fix, client can no longer re-negotiate.

> /usr/bin/openssl s_client -connect localhost:11211
> ---
> New, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES256-GCM-SHA384
> Server public key is 2048 bit
> Secure Renegotiation IS supported
> SSL-Session:
>    Protocol  : TLSv1.2
> ....
> R
> RENEGOTIATING
> 140151971125152:error:14094153:SSL routines:ssl3_read_bytes:no renegotiation:s3_pkt.c:1481: