### PR TITLE
Proxy parser rework

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include <lua.h>
 #include <lualib.h>

--- a/proxy.h
+++ b/proxy.h
@@ -310,7 +310,8 @@ struct mcp_backend_s {
     void *client; // mcmc client
     STAILQ_ENTRY(mcp_backend_s) be_next; // stack for backends
     io_head_t io_head; // stack of requests.
-    char *rbuf; // static allocated read buffer.
+    char *rbuf; // statically allocated read buffer.
+    size_t rbufused; // currently active bytes in the buffer
     struct event event; // libevent
 #ifdef HAVE_LIBURING
     proxy_event_t ur_rd_ev; // liburing.

--- a/proxy.h
+++ b/proxy.h
@@ -154,11 +154,7 @@ typedef struct {
     bool set; // NOTE: not sure if necessary if code structured properly
 } proxy_event_t;
 
-static struct __kernel_timespec updater_ts = {.tv_sec = 3, .tv_nsec = 0};
-static void _proxy_evthr_evset_notifier(proxy_event_thread_t *t);
-static void _proxy_evthr_evset_clock(proxy_event_thread_t *t);
-static void *proxy_event_thread_ur(void *arg);
-static void proxy_event_updater_ur(void *udata, struct io_uring_cqe *cqe);
+void *proxy_event_thread_ur(void *arg);
 #endif
 
 // Note: This ends up wasting a few counters, but simplifies the rest of the

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -104,7 +104,7 @@ static int mcplib_backend(lua_State *L) {
     strncpy(be->name, name, MAX_NAMELEN);
     strncpy(be->port, port, MAX_PORTLEN);
     be->depth = 0;
-    be->rbuf = NULL;
+    be->rbufused = 0;
     be->failed_count = 0;
     STAILQ_INIT(&be->io_head);
     be->state = mcp_backend_read;

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -885,6 +885,7 @@ static int _flush_pending_write(mcp_backend_t *be) {
                 // short circuit for common case.
                 sent -= io->iovbytes;
             } else {
+                io->iovbytes -= sent;
                 for (int x = 0; x < io->iovcnt; x++) {
                     struct iovec *iov = &io->iov[x];
                     if (sent >= iov->iov_len) {

--- a/vendor/mcmc/mcmc.h
+++ b/vendor/mcmc/mcmc.h
@@ -76,16 +76,13 @@ typedef struct {
 int mcmc_fd(void *c);
 size_t mcmc_size(int options);
 size_t mcmc_min_buffer_size(int options);
-char *mcmc_read_prep(void *c, char *buf, size_t bufsize, size_t *bufremain);
 int mcmc_parse_buf(void *c, char *buf, size_t read, mcmc_resp_t *r);
 int mcmc_connect(void *c, char *host, char *port, int options);
 int mcmc_check_nonblock_connect(void *c, int *err);
 int mcmc_send_request(void *c, const char *request, int len, int count);
 int mcmc_request_writev(void *c, const struct iovec *iov, int iovcnt, ssize_t *sent, int count);
-int mcmc_read(void *c, char *buf, size_t bufsize, mcmc_resp_t *r);
-int mcmc_read_value(void *c, char *val, const size_t vsize, int *read);
-int mcmc_read_value_buf(void *c, char *val, const size_t vsize, int *read);
-char *mcmc_buffer_consume(void *c, int *remain);
+//int mcmc_read(void *c, char *buf, size_t bufsize, mcmc_resp_t *r);
+//int mcmc_read_value(void *c, char *val, mcmc_resp_t *r, int *read);
 int mcmc_disconnect(void *c);
 void mcmc_get_error(void *c, char *code, size_t clen, char *msg, size_t mlen);
 


### PR DESCRIPTION
There are some potential protocol desync bugs due to mcmc handling its
own buffers and the newer event handler handling its own syscalls.

this change should have better separation of code for the buffer
tracking. if this change works I will add some optimizations to reduce
memmove's.

this also needs an extension to allow reading large values directly into the value buffer again. right now it'll double copy large values and run excessive recv calls. I've not made this too hard but I want to validate correctness before optimizations.