### PR TITLE
Fix FTBFS with GCC 12 on ppc64el

### DIFF
--- a/testapp.c
+++ b/testapp.c
@@ -2011,7 +2011,7 @@ static void *binary_hickup_recv_verification_thread(void *arg) {
 
 static enum test_return test_binary_pipeline_hickup_chunk(void *buffer, size_t buffersize) {
     off_t offset = 0;
-    char *key[256];
+    char *key[256] = { NULL };
     uint64_t value = 0xfeedfacedeadbeef;
 
     while (hickup_thread_running &&


### PR DESCRIPTION
GCC 12 on ppc64el complains about "key" being undefined on testapp.c.
This commit silences the error.

This was detected during the mass archive rebuild on Ubuntu:

https://launchpadlibrarian.net/607764095/buildlog_ubuntu-kinetic-ppc64el.memcached_1.6.15-1_BUILDING.txt.gz