### PR TITLE
proxy: mcp.request improvements

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -457,6 +457,7 @@ int mcplib_request_ltrimkey(lua_State *L);
 int mcplib_request_rtrimkey(lua_State *L);
 int mcplib_request_token(lua_State *L);
 int mcplib_request_ntokens(lua_State *L);
+int mcplib_request_has_flag(lua_State *L);
 int mcplib_request_gc(lua_State *L);
 
 int mcplib_open_dist_jump_hash(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -458,6 +458,7 @@ int mcplib_request_rtrimkey(lua_State *L);
 int mcplib_request_token(lua_State *L);
 int mcplib_request_ntokens(lua_State *L);
 int mcplib_request_has_flag(lua_State *L);
+int mcplib_request_flag_token(lua_State *L);
 int mcplib_request_gc(lua_State *L);
 
 int mcplib_open_dist_jump_hash(lua_State *L);

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -32,6 +32,23 @@ static int mcplib_response_hit(lua_State *L) {
     return 1;
 }
 
+// Caller needs to discern if a vlen is 0 because of a failed response or an
+// OK response that was actually zero. So we always return an integer value
+// here.
+static int mcplib_response_vlen(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    // We do remove the "\r\n" from the value length, so if you're actually
+    // processing the value nothing breaks.
+    if (r->resp.vlen >= 2) {
+        lua_pushinteger(L, r->resp.vlen-2);
+    } else {
+        lua_pushinteger(L, 0);
+    }
+
+    return 1;
+}
+
 static int mcplib_response_gc(lua_State *L) {
     mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
 
@@ -773,6 +790,7 @@ int proxy_register_libs(LIBEVENT_THREAD *t, void *ctx) {
     const struct luaL_Reg mcplib_response_m[] = {
         {"ok", mcplib_response_ok},
         {"hit", mcplib_response_hit},
+        {"vlen", mcplib_response_vlen},
         {"__gc", mcplib_response_gc},
         {NULL, NULL}
     };

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -782,6 +782,7 @@ int proxy_register_libs(LIBEVENT_THREAD *t, void *ctx) {
         {"rtrimkey", mcplib_request_rtrimkey},
         {"token", mcplib_request_token},
         {"ntokens", mcplib_request_ntokens},
+        {"has_flag", mcplib_request_has_flag},
         {"__tostring", NULL},
         {"__gc", mcplib_request_gc},
         {NULL, NULL}

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -815,6 +815,7 @@ int proxy_register_libs(LIBEVENT_THREAD *t, void *ctx) {
         {"token", mcplib_request_token},
         {"ntokens", mcplib_request_ntokens},
         {"has_flag", mcplib_request_has_flag},
+        {"flag_token", mcplib_request_flag_token},
         {"__tostring", NULL},
         {"__gc", mcplib_request_gc},
         {NULL, NULL}

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -49,6 +49,28 @@ static int mcplib_response_vlen(lua_State *L) {
     return 1;
 }
 
+// Refer to MCMC_CODE_* defines.
+static int mcplib_response_code(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    lua_pushinteger(L, r->resp.code);
+
+    return 1;
+}
+
+// Get the unparsed response line for handling in lua.
+static int mcplib_response_line(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    if (r->resp.rline != NULL) {
+        lua_pushlstring(L, r->resp.rline, r->resp.rlen);
+    } else {
+        lua_pushnil(L);
+    }
+
+    return 1;
+}
+
 static int mcplib_response_gc(lua_State *L) {
     mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
 
@@ -754,6 +776,16 @@ static void proxy_register_defines(lua_State *L) {
     lua_pushinteger(L, x); \
     lua_setfield(L, -2, #x);
 
+    X(MCMC_CODE_STORED);
+    X(MCMC_CODE_EXISTS);
+    X(MCMC_CODE_DELETED);
+    X(MCMC_CODE_TOUCHED);
+    X(MCMC_CODE_VERSION);
+    X(MCMC_CODE_NOT_FOUND);
+    X(MCMC_CODE_NOT_STORED);
+    X(MCMC_CODE_OK);
+    X(MCMC_CODE_NOP);
+    X(MCMC_CODE_MISS);
     X(P_OK);
     X(CMD_ANY);
     X(CMD_ANY_STORAGE);
@@ -792,6 +824,8 @@ int proxy_register_libs(LIBEVENT_THREAD *t, void *ctx) {
         {"ok", mcplib_response_ok},
         {"hit", mcplib_response_hit},
         {"vlen", mcplib_response_vlen},
+        {"code", mcplib_response_code},
+        {"line", mcplib_response_line},
         {"__gc", mcplib_response_gc},
         {NULL, NULL}
     };

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -23,21 +23,33 @@ static int _process_tokenize(mcp_parser_t *pr, const size_t max) {
     while (s != end) {
         switch (state) {
             case 0:
+                // scanning for first non-space to find a token.
                 if (*s != ' ') {
                     pr->tokens[curtoken] = s - pr->request;
                     if (++curtoken == max) {
-                        goto endloop;
+                        s++;
+                        state = 2;
+                        break;
                     }
                     state = 1;
                 }
                 s++;
                 break;
             case 1:
+                // advance over a token
                 if (*s != ' ') {
                     s++;
                 } else {
                     state = 0;
                 }
+                break;
+            case 2:
+                // hit max tokens before end of the line.
+                // keep advancing so we can place endcap token.
+                if (*s == ' ') {
+                    goto endloop;
+                }
+                s++;
                 break;
         }
     }
@@ -45,7 +57,7 @@ endloop:
 
     // endcap token so we can quickly find the length of any token by looking
     // at the next one.
-    pr->tokens[curtoken] = len;
+    pr->tokens[curtoken] = s - pr->request;
     pr->ntokens = curtoken;
     P_DEBUG("%s: cur_tokens: %d\n", __func__, curtoken);
 

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -151,6 +151,10 @@ function failover_factory(zones, local_zone)
             end
             return restable[1], "failover_backup_miss"
         end
+        -- example of making a new set request on the side.
+        -- local nr = mcp.request("set /foo/asdf 0 0 " .. res:vlen() .. "\r\n", res)
+        -- local nr = mcp.request("set /foo/asdf 0 0 2\r\n", "mo\r\n")
+        -- near_zone(nr)
         return res, "failover_hit" -- send result back to client
     end
 end
@@ -172,6 +176,9 @@ function setinvalidate_factory(zones, local_zone)
         if res:ok() == true then
             -- create a new delete request
             local dr = new_req("delete /testing/" .. r:key() .. "\r\n")
+            -- example of new request from existing request
+            -- note this isn't trimming the key so it'll make a weird one.
+            -- local dr = new_req("set /bar/" .. r:key() .. " 0 0 " .. r:token(5) .. "\r\n", r)
             for _, zone in pairs(far_zones) do
                 -- NOTE: can check/do things on the specific response here.
                 zone(dr)

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -166,6 +166,10 @@ function meta_get_factory(zones, local_zone)
         if r:has_flag("l") == true then
             print("client asking for last access time")
         end
+        local texists, token = r:flag_token("O")
+        if token ~= nil then
+            print("meta opaque flag token: " .. token)
+        end
         local res = near_zone(r)
 
         return res

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -159,6 +159,19 @@ function failover_factory(zones, local_zone)
     end
 end
 
+function meta_get_factory(zones, local_zone)
+    local near_zone = zones[local_zone]
+    -- in this test function we only fetch from the local zone.
+    return function(r)
+        if r:has_flag("l") == true then
+            print("client asking for last access time")
+        end
+        local res = near_zone(r)
+
+        return res
+    end
+end
+
 -- SET's to main zone, issues deletes to far zones.
 function setinvalidate_factory(zones, local_zone)
     local near_zone = zones[local_zone]
@@ -288,6 +301,7 @@ function mcp_config_routes(main_zones)
         -- need better routes designed for the test suite (edit the key
         -- prefix or something)
         map[mcp.CMD_ADD] = failover_factory(z, my_zone)
+        map[mcp.CMD_MG] = meta_get_factory(z, my_zone)
         prefixes[pfx] = command_factory(map, failover)
     end
 

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -172,6 +172,20 @@ function meta_get_factory(zones, local_zone)
     end
 end
 
+function meta_set_factory(zones, local_zone)
+    local near_zone = zones[local_zone]
+    -- in this test function we only talk to the local zone.
+    return function(r)
+        local res = near_zone(r)
+        if res:code() == mcp.MCMC_CODE_NOT_FOUND then
+            print("got meta NF response")
+        end
+        print("meta response line: " .. res:line())
+
+        return res
+    end
+end
+
 -- SET's to main zone, issues deletes to far zones.
 function setinvalidate_factory(zones, local_zone)
     local near_zone = zones[local_zone]
@@ -302,6 +316,7 @@ function mcp_config_routes(main_zones)
         -- prefix or something)
         map[mcp.CMD_ADD] = failover_factory(z, my_zone)
         map[mcp.CMD_MG] = meta_get_factory(z, my_zone)
+        map[mcp.CMD_MS] = meta_set_factory(z, my_zone)
         prefixes[pfx] = command_factory(map, failover)
     end
 


### PR DESCRIPTION
- errors if a string value is missing the "\r\n" terminator
- properly uses a value from a response object
- allows passing in a request object for the value as well

- also adds r:vlen() for recovering the value length of a response

think this still needs r:flags() or similar?

TODO: a few more functions for this particular PR:
- [x] `r:has_flag("C")`
- [x] `r:flag_token("C")` find and returns the flag token if exists. bonus: replace if second arg
- [x] `resp:code()` for retrieving meta status code (HD vs EX vs etc)
- [x] `resp:line()` for getting the raw response meta line, which can be inspected in lua while the lower level API is missing.

edit: note to self the characters are flags, arguments tokens, lol.