### PR TITLE
proxy: allow selecting top level routes based on listener tag

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -852,6 +852,7 @@ struct conn {
     /* This is where the binary header goes */
     protocol_binary_request_header binary_header;
     uint64_t cas; /* the cas to return */
+    uint64_t tag; /* listener stocket tag */
     short cmd; /* current command being processed */
     int opaque;
     int keylen;
@@ -914,7 +915,7 @@ io_queue_t *conn_io_queue_get(conn *c, int type);
 io_queue_cb_t *thread_io_queue_get(LIBEVENT_THREAD *t, int type);
 void conn_io_queue_return(io_pending_t *io);
 conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size,
-    enum network_transport transport, struct event_base *base, void *ssl);
+    enum network_transport transport, struct event_base *base, void *ssl, uint64_t conntag);
 
 void conn_worker_readd(conn *c);
 extern int daemonize(int nochdir, int noclose);
@@ -945,7 +946,7 @@ void proxy_reload_notify(LIBEVENT_THREAD *t);
 #endif
 void return_io_pending(io_pending_t *io);
 void dispatch_conn_new(int sfd, enum conn_states init_state, int event_flags, int read_buffer_size,
-    enum network_transport transport, void *ssl);
+    enum network_transport transport, void *ssl, uint64_t conntag);
 void sidethread_conn_close(conn *c);
 
 /* Lock wrappers for cache functions that are called from main loop. */

--- a/memcached.h
+++ b/memcached.h
@@ -915,7 +915,7 @@ io_queue_t *conn_io_queue_get(conn *c, int type);
 io_queue_cb_t *thread_io_queue_get(LIBEVENT_THREAD *t, int type);
 void conn_io_queue_return(io_pending_t *io);
 conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size,
-    enum network_transport transport, struct event_base *base, void *ssl, uint64_t conntag);
+    enum network_transport transport, struct event_base *base, void *ssl, uint64_t conntag, enum protocol bproto);
 
 void conn_worker_readd(conn *c);
 extern int daemonize(int nochdir, int noclose);
@@ -946,7 +946,7 @@ void proxy_reload_notify(LIBEVENT_THREAD *t);
 #endif
 void return_io_pending(io_pending_t *io);
 void dispatch_conn_new(int sfd, enum conn_states init_state, int event_flags, int read_buffer_size,
-    enum network_transport transport, void *ssl, uint64_t conntag);
+    enum network_transport transport, void *ssl, uint64_t conntag, enum protocol bproto);
 void sidethread_conn_close(conn *c);
 
 /* Lock wrappers for cache functions that are called from main loop. */

--- a/proxy.h
+++ b/proxy.h
@@ -218,9 +218,15 @@ typedef struct {
     pthread_mutex_t stats_lock; // used for rare global counters
 } proxy_ctx_t;
 
+struct proxy_hook_tagged {
+    uint64_t tag;
+    int lua_ref;
+};
+
 struct proxy_hook {
     int lua_ref;
-    bool is_lua; // pull the lua reference and call it as a lua function.
+    int tagcount;
+    struct proxy_hook_tagged *tagged; // array of possible tagged hooks.
 };
 
 // TODO (v2): some hash functions (crc?) might require initializers. If we run into

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -333,4 +333,7 @@ function mcp_config_routes(main_zones)
     -- are attached to the internal parser.
     --mcp.attach(mcp.CMD_ANY, function (r) return routetop(r) end)
     mcp.attach(mcp.CMD_ANY_STORAGE, routetop)
+    -- tagged top level attachments. ex: memcached -l tag[tagtest]:127.0.0.1:11212
+    -- mcp.attach(mcp.CMD_ANY_STORAGE, function (r) return "SERVER_ERROR no route\r\n" end, "tagtest")
+    -- mcp.attach(mcp.CMD_ANY_STORAGE, function (r) return "SERVER_ERROR my route\r\n" end, "newtag")
 end


### PR DESCRIPTION
`-l tag[asdfasdf]:0.0.0.0:11211`

in proxy:

`mcp.attach(mcp.CMD_ANY_STORAGE, routetop, "asdfasdf")`

If a third argument is given to mcp.attach, it will only route there if the client socket came from the matching listener socket's tag.

TODO
- [x] in this same PR I want to add core: `-l noproxy:etc` for skipping the proxy.
- [ ] `req:listener_tag()` if a request was created directly by a tagged client, this should also return the string tag. in cases where you don't want to use the attach method or have many tags and with use a lua table.

I _think_ I want a `noproxy` tag, but `mcp.attach(mcp.CMD_ANY, nil, "tag")` might be cleaner to implement so I'll have to check how hard it is first.

@smukil 