### PR TITLE
proxy: req:flag_token("F", "Freplacement")

### DIFF
--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -167,6 +167,8 @@ function meta_get_factory(zones, local_zone)
             print("client asking for last access time")
         end
         local texists, token = r:flag_token("O")
+        -- next example returns the previous token and replaces it.
+        -- local texists, token = r:flag_token("O", "Odoot")
         if token ~= nil then
             print("meta opaque flag token: " .. token)
         end


### PR DESCRIPTION
returns (exists, previous_token)
optional second argument will replace the flag/token with supplied
flag/token, or nothing if "" is passed.

Done some limited testing and seems to work right. Apologies for not doing this in the original PR :)

@smukil 