### PR TITLE
proxy: update mcmc and calling conventions

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -494,7 +494,7 @@ static void _set_noreply_mode(mc_resp *resp, mcp_resp_t *r) {
             }
             break;
         case RESP_MODE_METAQUIET:
-            if (r->resp.code == MCMC_CODE_MISS) {
+            if (r->resp.code == MCMC_CODE_END) {
                 resp->skip = true;
             } else if (r->cmd != CMD_MG && r->resp.code == MCMC_CODE_OK) {
                 // FIXME (v2): mcmc's parser needs to help us out a bit more

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -266,7 +266,7 @@ int mcplib_await_return(io_pending_proxy_t *p) {
             bool is_good = false;
             switch (aw->type) {
                 case AWAIT_GOOD:
-                    if (p->client_resp->status == MCMC_OK && p->client_resp->resp.code != MCMC_CODE_MISS) {
+                    if (p->client_resp->status == MCMC_OK && p->client_resp->resp.code != MCMC_CODE_END) {
                         is_good = true;
                     }
                     break;

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -23,7 +23,7 @@ static int mcplib_response_ok(lua_State *L) {
 static int mcplib_response_hit(lua_State *L) {
     mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
 
-    if (r->status == MCMC_OK && r->resp.code != MCMC_CODE_MISS) {
+    if (r->status == MCMC_OK && r->resp.code != MCMC_CODE_END) {
         lua_pushboolean(L, 1);
     } else {
         lua_pushboolean(L, 0);
@@ -853,7 +853,7 @@ static void proxy_register_defines(lua_State *L) {
     X(MCMC_CODE_NOT_STORED);
     X(MCMC_CODE_OK);
     X(MCMC_CODE_NOP);
-    X(MCMC_CODE_MISS);
+    X(MCMC_CODE_END);
     X(P_OK);
     X(CMD_ANY);
     X(CMD_ANY_STORAGE);

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -533,15 +533,15 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
         case mcp_backend_parse:
             r = p->client_resp;
             r->status = mcmc_parse_buf(be->client, be->rbuf, be->rbufused, &r->resp);
-            if (r->status != MCMC_OK) {
+
+            if (r->status == MCMC_ERR) {
                 P_DEBUG("%s: mcmc_read failed [%d]\n", __func__, r->status);
-                if (r->status == MCMC_WANT_READ) {
+                if (r->resp.code == MCMC_WANT_READ) {
                     return EV_READ;
-                } else {
-                    flags = -1;
-                    stop = true;
-                    break;
                 }
+                flags = -1;
+                stop = true;
+                break;
             }
 
             // we actually don't care about anything but the value length

--- a/vendor/mcmc/example.c
+++ b/vendor/mcmc/example.c
@@ -24,9 +24,9 @@ static void show_response_buffer(void *c, char *rbuf, size_t bufsize) {
         // need to know how far to advance the buffer.
         // resp->reslen + resp->vlen_read works, but feels awkward.
         status = mcmc_parse_buf(c, rbuf, bread, &resp);
-    } while (status == MCMC_WANT_READ);
+    } while (resp.code == MCMC_WANT_READ);
 
-    if (status != MCMC_OK) {
+    if (status == MCMC_ERR) {
         printf("bad response\n");
     }
 

--- a/vendor/mcmc/mcmc.h
+++ b/vendor/mcmc/mcmc.h
@@ -1,6 +1,9 @@
 #ifndef MCMC_HEADER
 #define MCMC_HEADER
 
+#include <sys/uio.h>
+#include <stdint.h>
+
 #define MCMC_OK 0
 #define MCMC_ERR -1
 #define MCMC_NOT_CONNECTED 1
@@ -8,7 +11,6 @@
 #define MCMC_CONNECTING 3 // nonblock mode.
 #define MCMC_WANT_WRITE 4
 #define MCMC_WANT_READ 5
-#define MCMC_HAS_RESULT 7
 // TODO: either internally set a flag for "ok" or "not ok" and use a func,
 // or use a bitflag here (1<<6) for "OK", (1<<5) for "FAIL", etc.
 // or, we directly return "OK" or "FAIL" and you can ask for specific error.
@@ -21,10 +23,10 @@
 #define MCMC_CODE_NOT_STORED 14
 #define MCMC_CODE_OK 15
 #define MCMC_CODE_NOP 16
-#define MCMC_PARSE_ERROR_SHORT 17
-#define MCMC_PARSE_ERROR 18
-#define MCMC_CODE_MISS 19 // FIXME
-
+#define MCMC_CODE_END 17
+#define MCMC_ERR_SHORT 18
+#define MCMC_ERR_PARSE 19
+#define MCMC_ERR_VALUE 20
 
 // response types
 #define MCMC_RESP_GET 100
@@ -45,8 +47,8 @@
 #define MCMC_ERROR_MSG_MAX 512
 
 typedef struct {
-    unsigned short type;
-    unsigned short code;
+    short type;
+    short code;
     char *value; // pointer to start of value in buffer.
     size_t reslen; // full length of the response line
     size_t vlen_read; // amount of value that was in supplied buffer.


### PR DESCRIPTION
upstream fixes: mcmc would return OK to garbage responses, which was
probably causing issues in the past.

This does remove the MCMC_CODE_MISS and replace it with MCMC_CODE_END.

Updated the commit a bit more: status is now either `MCMC_OK` or `MCMC_ERR` and resp.code always has the detail. I feel this is slightly cleaner overall.

I also didn't pull in the tests/* dir from mcmc since that's not really necessary yet.

@smukil - tagging for interest