### PR TITLE
proxy: addressing source TODO/FIXME's

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1887,7 +1887,7 @@ void server_stats(ADD_STAT add_stats, conn *c) {
     storage_stats(add_stats, c);
 #endif
 #ifdef PROXY
-    proxy_stats(add_stats, c);
+    proxy_stats(settings.proxy_ctx, add_stats, c);
 #endif
 #ifdef TLS
     if (settings.ssl_enabled) {
@@ -6093,7 +6093,7 @@ int main (int argc, char **argv) {
     /* start up worker threads if MT mode */
 #ifdef PROXY
     if (settings.proxy_enabled) {
-        proxy_init(settings.proxy_uring);
+        settings.proxy_ctx = proxy_init(settings.proxy_uring);
         if (proxy_load_config(settings.proxy_ctx) != 0) {
             exit(EXIT_FAILURE);
         }

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -1,15 +1,15 @@
 #ifndef PROTO_PROXY_H
 #define PROTO_PROXY_H
 
-void proxy_stats(ADD_STAT add_stats, conn *c);
-void process_proxy_stats(ADD_STAT add_stats, conn *c);
+void proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
+void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
 
 /* proxy mode handlers */
 int try_read_command_proxy(conn *c);
 void complete_nread_proxy(conn *c);
 void proxy_cleanup_conn(conn *c);
-void proxy_thread_init(LIBEVENT_THREAD *thr);
-void proxy_init(bool proxy_uring);
+void proxy_thread_init(void *ctx, LIBEVENT_THREAD *thr);
+void *proxy_init(bool proxy_uring);
 // TODO: need better names or a better interface for these. can be confusing
 // to reason about the order.
 void proxy_start_reload(void *arg);
@@ -22,6 +22,6 @@ void proxy_return_cb(io_pending_t *pending);
 void proxy_finalize_cb(io_pending_t *pending);
 
 /* lua */
-int proxy_register_libs(LIBEVENT_THREAD *t, void *ctx);
+int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state);
 
 #endif

--- a/proto_text.c
+++ b/proto_text.c
@@ -795,7 +795,7 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
 #endif
 #ifdef PROXY
     } else if (strcmp(subcommand, "proxy") == 0) {
-        process_proxy_stats(&append_stats, c);
+        process_proxy_stats(settings.proxy_ctx, &append_stats, c);
 #endif
     } else {
         /* getting here means that the subcommand is either engine specific or

--- a/proxy.h
+++ b/proxy.h
@@ -78,6 +78,7 @@
 #define MCP_THREAD_UPVALUE 1
 #define MCP_ATTACH_UPVALUE 2
 #define MCP_BACKEND_UPVALUE 3
+#define MCP_CONTEXT_UPVALUE 4
 
 // all possible commands.
 #define CMD_FIELDS \
@@ -476,7 +477,7 @@ void mcp_request_attach(lua_State *L, mcp_request_t *rq, io_pending_proxy_t *p);
 void proxy_lua_error(lua_State *L, const char *s);
 void proxy_lua_ferror(lua_State *L, const char *fmt, ...);
 int _start_proxy_config_threads(proxy_ctx_t *ctx);
-int proxy_thread_loadconf(LIBEVENT_THREAD *thr);
+int proxy_thread_loadconf(proxy_ctx_t *ctx, LIBEVENT_THREAD *thr);
 
 // TODO (v2): more .h files, perhaps?
 int mcplib_open_hash_xxhash(lua_State *L);

--- a/proxy_config.c
+++ b/proxy_config.c
@@ -333,7 +333,7 @@ static void _copy_config_table(lua_State *from, lua_State *to) {
 void proxy_worker_reload(void *arg, LIBEVENT_THREAD *thr) {
     proxy_ctx_t *ctx = arg;
     pthread_mutex_lock(&ctx->worker_lock);
-    if (proxy_thread_loadconf(thr) != 0) {
+    if (proxy_thread_loadconf(ctx, thr) != 0) {
         ctx->worker_failed = true;
     }
     ctx->worker_done = true;
@@ -343,10 +343,9 @@ void proxy_worker_reload(void *arg, LIBEVENT_THREAD *thr) {
 
 // FIXME (v2): need to test how to recover from an actual error here. error message
 // needs to go somewhere useful, counters added, etc.
-int proxy_thread_loadconf(LIBEVENT_THREAD *thr) {
+int proxy_thread_loadconf(proxy_ctx_t *ctx, LIBEVENT_THREAD *thr) {
     lua_State *L = thr->L;
     // load the precompiled config function.
-    proxy_ctx_t *ctx = settings.proxy_ctx;
     struct _dumpbuf *db = ctx->proxy_code;
     struct _dumpbuf db2; // copy because the helper modifies it.
     memcpy(&db2, db, sizeof(struct _dumpbuf));

--- a/proxy_ustats.c
+++ b/proxy_ustats.c
@@ -36,7 +36,7 @@ int mcplib_add_stat(lua_State *L) {
         }
     }
 
-    proxy_ctx_t *ctx = settings.proxy_ctx; // TODO (v2): store ctx in upvalue.
+    proxy_ctx_t *ctx = lua_touserdata(L, lua_upvalueindex(MCP_CONTEXT_UPVALUE));
 
     STAT_L(ctx);
     struct proxy_user_stats *us = &ctx->user_stats;

--- a/thread.c
+++ b/thread.c
@@ -490,7 +490,7 @@ static void setup_thread(LIBEVENT_THREAD *me) {
     // TODO: maybe register hooks to be called here from sub-packages? ie;
     // extstore, TLS, proxy.
     if (settings.proxy_enabled) {
-        proxy_thread_init(me);
+        proxy_thread_init(settings.proxy_ctx, me);
     }
 #endif
     thread_io_queue_add(me, IO_QUEUE_NONE, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Doing another pass against all of the TODO/FIXME's in the source files. They should either be addressed now or renamed as "v3". Note that there is no v3, this is just how I'm making the work more greppable.

Not doing these in any _particular_ order. Focus is on making code more testable and potential bugs/crashes instead of optimizations/features.

Might also rename or change the tag for "feature-y" todo/fixme's vs bug/flaw.