### PR TITLE
hacks to help figure out extstore bug

### DIFF
--- a/extstore.c
+++ b/extstore.c
@@ -664,6 +664,7 @@ int extstore_delete(void *ptr, unsigned int page_id, uint64_t page_version,
         if (p->obj_count >= count) {
             p->obj_count -= count;
         } else {
+            fprintf(stderr, "EXTSTORE: OVER DECREMENTING\n");
             p->obj_count = 0; // caller has bad accounting?
         }
         STAT_L(e);

--- a/storage.c
+++ b/storage.c
@@ -808,7 +808,7 @@ static void storage_compact_readback(void *storage, logger *l,
                 hdr = (item_hdr *)ITEM_data(hdr_it);
                 if (hdr->page_id == page_id && hdr->page_version == page_version) {
                     // Item header is still completely valid.
-                    extstore_delete(storage, page_id, page_version, 1, ntotal);
+                    int eret = extstore_delete(storage, page_id, page_version, 1, ntotal);
                     // drop inactive items.
                     if (drop_unread && GET_LRU(hdr_it->slabs_clsid) == COLD_LRU) {
                         do_write = false;
@@ -816,6 +816,7 @@ static void storage_compact_readback(void *storage, logger *l,
                     } else {
                         do_write = true;
                     }
+                    fprintf(stderr, "deleting (do_write: %d, eret: %d) item: %*.*s\n", eret, do_write, it->nkey, it->nkey, ITEM_key(it));
                 }
             }
 


### PR DESCRIPTION
if a key gets overwritten many times in a row while constantly flushing to extstore, and then stops being written, the compactor can possibly over-delete from a page and cause a page to be reclaimed in the middle of compaction. This is because the header in memory still matches the page-id and page of the now dead entries.

need to come back to resolve this bug sharing the debugging I did.