### PR TITLE
proxy: add mcp.await FASTGOOD flag

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -444,6 +444,7 @@ enum mcp_await_e {
     AWAIT_ANY, // any response, including errors,
     AWAIT_OK, // any non-error response
     AWAIT_FIRST, // return the result from the first pool
+    AWAIT_FASTGOOD, // returns on first hit or majority non-error
 };
 int mcplib_await(lua_State *L);
 int mcplib_await_run(conn *c, mc_resp *resp, lua_State *L, int coro_ref);

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -49,6 +49,7 @@ int mcplib_await(lua_State *L) {
             case AWAIT_ANY:
             case AWAIT_OK:
             case AWAIT_FIRST:
+            case AWAIT_FASTGOOD:
                 break;
             default:
                 proxy_lua_error(L, "invalid type argument tp mcp.await");
@@ -284,6 +285,16 @@ int mcplib_await_return(io_pending_proxy_t *p) {
                     } else {
                         // user only wants the first pool's result.
                         valid = false;
+                    }
+                    break;
+                case AWAIT_FASTGOOD:
+                    if (p->client_resp->status == MCMC_OK) {
+                        // End early on a hit.
+                        if (p->client_resp->resp.code != MCMC_CODE_END) {
+                            aw->wait_for = 0;
+                        } else {
+                            is_good = true;
+                        }
                     }
                     break;
             }

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -859,6 +859,7 @@ static void proxy_register_defines(lua_State *L) {
     X(AWAIT_ANY);
     X(AWAIT_OK);
     X(AWAIT_FIRST);
+    X(AWAIT_FASTGOOD);
     CMD_FIELDS
 #undef X
 }


### PR DESCRIPTION
returns early on a hit, else waits for N non-error responses.