### PR TITLE
proxy: backend connection improvement

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -5675,7 +5675,9 @@ int main (int argc, char **argv) {
                 protocol_specified = true;
                 break;
             case PROXY_URING:
-                settings.proxy_uring = true;
+                fprintf(stderr, "Proxy io-uring mode is not presently supported\n");
+                return 1;
+                //settings.proxy_uring = true;
                 break;
 #endif
 #ifdef MEMCACHED_DEBUG


### PR DESCRIPTION
Improvements to handling of new and failed backend socket connections.

Previously connections were initiated immediately, and initially from the config thread, yet completion of opening sockets wouldn't happen until a request tried to use that backend.

Now we open connections via the IO thread, as well as validate new connections with a "version\r\n" command.

Also fixes a couple of error conditions (parsing, backend disconnect) where clients could hang waiting for a retry time in certain conditions. Now connections should re-establish immediately and dead backends should flip into a bad fast-fail state quicker.

NOTES:

- There is some duplicated code now, which I am okay with. I want a third use case or some more time to pass. I looked at de-duplicating but after adding some required structures the code was roughly the same length. As is it should let me move faster while the backend conn code is tuned.
- A big goal here is to avoid adding a ton more tunables (how many times to retry, timeout lengths, etc) so where possible any algorithms should have reasonable defaults or be dynamically scaled.

TODO:

- [x] Should validation step be optional? I was about to do this but not sure if it's necessary. No, not right now.
- [x] Need to update the "bad backend" algorithm to hold them as bad for longer under more conditions. IE; the number of timeouts over time affects when something goes into fast fail state and for how long. Diff PR.
- [x] Should we run multiple probes before marking a backend as okay? I was planning on doing this but I'm not sure what scenarios this would capture. No, skipping this.
- [x] Probably not now, but in the future, we need a way of distinguishing which connections do connect-ahead. This is a decent default now, but not for sidecar use cases where you want to load the full configuration but clients tend only use a subset of pools. Yes, later.
- [x] For io_uring; leave the compile option in but gate the start option. Leave it disabled until I can make it production worthy.
- [x] Any cases where we can ship errno into the error log? Later: need to translate errno to internal errors to avoid long strings.
- [x] remove PROXY_DEBUG flag I left in.

I want to make the validator have a lua override but there's no clean way of doing this yet. The lua request API only works under workers, so I can't simply ship requests to the config thread or similar. I may try again before merging this. For example, it might make sense for some folks to request a specific key or do a set/get combo and check the timing.

@smukil 