### PR TITLE
Meta protocol cleanup adjustments

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4830,7 +4830,6 @@ int main (int argc, char **argv) {
         DROP_PRIVILEGES,
         RESP_OBJ_MEM_LIMIT,
         READ_BUF_MEM_LIMIT,
-        META_RESPONSE_OLD,
 #ifdef TLS
         SSL_CERT,
         SSL_KEY,
@@ -4893,7 +4892,6 @@ int main (int argc, char **argv) {
         [DROP_PRIVILEGES] = "drop_privileges",
         [RESP_OBJ_MEM_LIMIT] = "resp_obj_mem_limit",
         [READ_BUF_MEM_LIMIT] = "read_buf_mem_limit",
-        [META_RESPONSE_OLD] = "meta_response_old",
 #ifdef TLS
         [SSL_CERT] = "ssl_chain_cert",
         [SSL_KEY] = "ssl_key",
@@ -5498,9 +5496,6 @@ int main (int argc, char **argv) {
             case NO_LRU_MAINTAINER:
                 start_lru_maintainer = false;
                 settings.lru_segmented = false;
-                break;
-            case META_RESPONSE_OLD:
-                settings.meta_response_old = true;
                 break;
 #ifdef TLS
             case SSL_CERT:

--- a/memcached.h
+++ b/memcached.h
@@ -492,7 +492,6 @@ struct settings {
     bool drop_privileges;   /* Whether or not to drop unnecessary process privileges */
     bool watch_enabled; /* allows watch commands to be dropped */
     bool relaxed_privileges;   /* Relax process restrictions when running testapp */
-    bool meta_response_old; /* use "OK" instead of "HD". for response code TEMPORARY! */
 #ifdef EXTSTORE
     unsigned int ext_io_threadcount; /* number of IO threads to run. */
     unsigned int ext_page_size; /* size in megabytes of storage pages. */

--- a/proto_text.c
+++ b/proto_text.c
@@ -1758,11 +1758,7 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
     case OK:
         if (c->noreply)
             resp->skip = true;
-        if (settings.meta_response_old) {
-            memcpy(resp->wbuf, "OK ", 3);
-        } else {
-            memcpy(resp->wbuf, "HD ", 3);
-        }
+        // *it was filled, set the status below.
         break;
     case NON_NUMERIC:
         errstr = "CLIENT_ERROR cannot increment or decrement non-numeric value";
@@ -1785,7 +1781,7 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
                     item_created = true;
                 } else {
                     // Not sure how we can get here if we're holding the lock.
-                    memcpy(resp->wbuf, "NS ", 3);
+                    memcpy(resp->wbuf, "NS", 2);
                 }
             } else {
                 errstr = "SERVER_ERROR Out of memory allocating new item";
@@ -1800,14 +1796,14 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
             }
             pthread_mutex_unlock(&c->thread->stats.mutex);
             // won't have a valid it here.
-            memcpy(p, "NF ", 3);
-            p += 3;
+            memcpy(p, "NF", 2);
+            p += 2;
         }
         break;
     case DELTA_ITEM_CAS_MISMATCH:
         // also returns without a valid it.
-        memcpy(p, "EX ", 3);
-        p += 3;
+        memcpy(p, "EX", 2);
+        p += 2;
         break;
     }
 

--- a/proto_text.c
+++ b/proto_text.c
@@ -62,11 +62,7 @@ static void _finalize_mset(conn *c, enum store_item_type ret) {
 
     switch (ret) {
     case STORED:
-      if (settings.meta_response_old) {
-          memcpy(p, "OK", 2);
-      } else {
-          memcpy(p, "HD", 2);
-      }
+      memcpy(p, "HD", 2);
       // Only place noreply is used for meta cmds is a nominal response.
       if (c->noreply) {
           resp->skip = true;
@@ -1136,11 +1132,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
             memcpy(p, "VA ", 3);
             p = itoa_u32(it->nbytes-2, p+3);
         } else {
-            if (settings.meta_response_old) {
-                memcpy(p, "OK", 2);
-            } else {
-                memcpy(p, "HD", 2);
-            }
+            memcpy(p, "HD", 2);
             p += 2;
         }
 
@@ -1658,11 +1650,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
             // Clients can noreply nominal responses.
             if (c->noreply)
                 resp->skip = true;
-            if (settings.meta_response_old) {
-                memcpy(resp->wbuf, "OK", 2);
-            } else {
-                memcpy(resp->wbuf, "HD", 2);
-            }
+            memcpy(resp->wbuf, "HD", 2);
         } else {
             pthread_mutex_lock(&c->thread->stats.mutex);
             c->thread->stats.slab_stats[ITEM_clsid(it)].delete_hits++;
@@ -1672,11 +1660,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
             STORAGE_delete(c->thread->storage, it);
             if (c->noreply)
                 resp->skip = true;
-            if (settings.meta_response_old) {
-                memcpy(resp->wbuf, "OK", 2);
-            } else {
-                memcpy(resp->wbuf, "HD", 2);
-            }
+            memcpy(resp->wbuf, "HD", 2);
         }
         goto cleanup;
     } else {
@@ -1837,11 +1821,7 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
             memcpy(p, "VA ", 3);
             p = itoa_u32(vlen, p+3);
         } else {
-            if (settings.meta_response_old) {
-                memcpy(p, "OK", 2);
-            } else {
-                memcpy(p, "HD", 2);
-            }
+            memcpy(p, "HD", 2);
             p += 2;
         }
 

--- a/proto_text.c
+++ b/proto_text.c
@@ -1560,8 +1560,8 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
     char *errstr = "CLIENT_ERROR bad command line format";
     assert(c != NULL);
     mc_resp *resp = c->resp;
-    // reserve 3 bytes for status code
-    char *p = resp->wbuf + 3;
+    // reserve bytes for status code
+    char *p = resp->wbuf + 2;
 
     WANT_TOKENS_MIN(ntokens, 3);
 
@@ -1617,7 +1617,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
             c->thread->stats.delete_misses++;
             pthread_mutex_unlock(&c->thread->stats.mutex);
 
-            memcpy(resp->wbuf, "EX ", 3);
+            memcpy(resp->wbuf, "EX", 2);
             goto cleanup;
         }
 
@@ -1638,9 +1638,9 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
             if (c->noreply)
                 resp->skip = true;
             if (settings.meta_response_old) {
-                memcpy(resp->wbuf, "OK ", 3);
+                memcpy(resp->wbuf, "OK", 2);
             } else {
-                memcpy(resp->wbuf, "HD ", 3);
+                memcpy(resp->wbuf, "HD", 2);
             }
         } else {
             pthread_mutex_lock(&c->thread->stats.mutex);
@@ -1652,9 +1652,9 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
             if (c->noreply)
                 resp->skip = true;
             if (settings.meta_response_old) {
-                memcpy(resp->wbuf, "OK ", 3);
+                memcpy(resp->wbuf, "OK", 2);
             } else {
-                memcpy(resp->wbuf, "HD ", 3);
+                memcpy(resp->wbuf, "HD", 2);
             }
         }
         goto cleanup;
@@ -1663,7 +1663,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
         c->thread->stats.delete_misses++;
         pthread_mutex_unlock(&c->thread->stats.mutex);
 
-        memcpy(resp->wbuf, "NF ", 3);
+        memcpy(resp->wbuf, "NF", 2);
         goto cleanup;
     }
 cleanup:

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -210,16 +210,16 @@ my $sock = $server->sock;
 {
     diag "marithmetic tests";
     print $sock "ma mo\r\n";
-    like(scalar <$sock>, qr/^NF/, "incr miss");
+    like(scalar <$sock>, qr/^NF\r/, "incr miss");
 
     print $sock "ma mo D1\r\n";
-    like(scalar <$sock>, qr/^NF/, "incr miss with argument");
+    like(scalar <$sock>, qr/^NF\r/, "incr miss with argument");
 
     print $sock "set mo 0 0 1\r\n1\r\n";
     like(scalar <$sock>, qr/^STORED/, "stored with set");
 
     print $sock "ma mo\r\n";
-    like(scalar <$sock>, qr/^HD/, "incr'd a set value");
+    like(scalar <$sock>, qr/^HD\r/, "incr'd a set value");
 
     print $sock "set mo 0 0 1\r\nq\r\n";
     like(scalar <$sock>, qr/^STORED/, "stored with set");
@@ -228,7 +228,7 @@ my $sock = $server->sock;
     like(scalar <$sock>, qr/^CLIENT_ERROR /, "cannot incr non-numeric value");
 
     print $sock "ma mu N90\r\n";
-    like(scalar <$sock>, qr/^HD/, "incr with seed");
+    like(scalar <$sock>, qr/^HD\r/, "incr with seed");
     my $res = mget($sock, 'mu', 's t v Ofoo k');
     ok(keys %$res, "not a miss");
     ok(find_flags($res, 'st'), "got main flags back");
@@ -258,7 +258,7 @@ my $sock = $server->sock;
     is($res->{val}, '0', 'land at 0 for over-decrement');
 
     print $sock "ma mi q D1\r\nmn\r\n";
-    like(scalar <$sock>, qr/^MN/, "quiet increment");
+    like(scalar <$sock>, qr/^MN\r/, "quiet increment");
 
     # CAS routines.
     $res = marith($sock, 'mc', 'N0 c v');

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -768,7 +768,7 @@ sub mget_res {
         $r{size} = $1;
         $r{flags} = $2;
         $r{val} = $3;
-    } elsif ($resp =~ m/^HD ([^\r]+)\r\n/gm) {
+    } elsif ($resp =~ m/^HD\s*([^\r]+)\r\n/gm) {
         $r{flags} = $1;
         $r{hd} = 1;
     }

--- a/t/metaget.t
+++ b/t/metaget.t
@@ -129,6 +129,14 @@ my $sock = $server->sock;
     like(scalar <$sock>, qr/^ME foo /, "raw mget result");
 }
 
+# mdelete had excess space before newline.
+{
+    print $sock "md deltest\r\n";
+    is(scalar <$sock>, "NF\r\n", "delete status is correct");
+    print $sock "md foo\r\n";
+    is(scalar <$sock>, "HD\r\n", "delete status is correct");
+}
+
 # mget with arguments
 # - set some specific TTL and get it back (within reason)
 # - get cas
@@ -499,7 +507,7 @@ my $sock = $server->sock;
     # Lets mark the sucker as invalid, and drop its TTL to 30s
     diag "running mdelete";
     print $sock "md toinv I T30\r\n";
-    like(scalar <$sock>, qr/^HD /, "mdelete'd key");
+    like(scalar <$sock>, qr/^HD/, "mdelete'd key");
 
     # TODO: decide on if we need an explicit flag for "if I fetched a stale
     # value, does winning matter?


### PR DESCRIPTION
Cleanup fixes for meta protocol:

- Removes some excess spaces for md, ma commands.
- Allows bare "mg key" requests to work
- Reflects O and k flags for mg on miss (EN)
- Removes old `meta_response_old` start flag that was only supposed to be there for 3 months anyway.

Need to double check that I didn't miss any other report that's come up since. There're still some 'things to think about' with meta but I think as separate changes (ie; a "truly quiet" flag)

@smukil - tagging you since you folks are using meta and I'm paranoid of this change breaking something. All of the parsers I've written ignore N spaces before/after things and the protocol is supposed to allow for that. So it should be fine...

I'm going to have to just take an assumption/hope that nobody's coded super specifically to it and take the pain here. I was using regex prefex tests exclusively in the unit tests so I never noticed the bugs (and I don't think anyone ever reviewed meta deeply while it was under development)