### PR TITLE
Fixes to build with clang-15

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -80,14 +80,18 @@ item *assoc_find(const char *key, const size_t nkey, const uint32_t hv) {
     }
 
     item *ret = NULL;
+#ifdef ENABLE_DTRACE
     int depth = 0;
+#endif
     while (it) {
         if ((nkey == it->nkey) && (memcmp(key, ITEM_key(it), nkey) == 0)) {
             ret = it;
             break;
         }
         it = it->h_next;
+#ifdef ENABLE_DTRACE
         ++depth;
+#endif
     }
     MEMCACHED_ASSOC_FIND(key, nkey, depth);
     return ret;

--- a/darwin_priv.c
+++ b/darwin_priv.c
@@ -10,7 +10,7 @@
  * the sandbox api is marked deprecated, however still used
  * by couple of major softwares/libraries like openssh
  */
-void drop_privileges() {
+void drop_privileges(void) {
     extern char *__progname;
     char *error = NULL;
 


### PR DESCRIPTION
Fix unused variable error when dtrace is not enabled.

Add void parameter declaration for drop_privileges() in darwin_priv.c.