### PR TITLE
core: give threads unique names

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -280,6 +280,7 @@ int start_assoc_maintenance_thread(void) {
         fprintf(stderr, "Can't create thread: %s\n", strerror(ret));
         return -1;
     }
+    thread_setname(maintenance_tid, "mc-assocmaint");
     return 0;
 }
 

--- a/crawler.c
+++ b/crawler.c
@@ -569,6 +569,7 @@ int start_item_crawler_thread(void) {
         pthread_mutex_unlock(&lru_crawler_lock);
         return -1;
     }
+    thread_setname(item_crawler_tid, "mc-itemcrawler");
     /* Avoid returning until the crawler has actually started */
     pthread_cond_wait(&lru_crawler_cond, &lru_crawler_lock);
     pthread_mutex_unlock(&lru_crawler_lock);

--- a/items.c
+++ b/items.c
@@ -1730,6 +1730,7 @@ int start_lru_maintainer_thread(void *arg) {
         pthread_mutex_unlock(&lru_maintainer_lock);
         return -1;
     }
+    thread_setname(lru_maintainer_tid, "mc-lrumaint");
     pthread_mutex_unlock(&lru_maintainer_lock);
 
     return 0;

--- a/logger.c
+++ b/logger.c
@@ -822,6 +822,7 @@ static int start_logger_thread(void) {
         fprintf(stderr, "Can't start logger thread: %s\n", strerror(ret));
         return -1;
     }
+    thread_setname(logger_tid, "mc-log");
     return 0;
 }
 

--- a/memcached.c
+++ b/memcached.c
@@ -387,6 +387,7 @@ static int start_conn_timeout_thread(void) {
             strerror(ret));
         return -1;
     }
+    thread_setname(conn_timeout_tid, "mc-idletimeout");
 
     return 0;
 }

--- a/memcached.h
+++ b/memcached.h
@@ -994,6 +994,7 @@ void STATS_UNLOCK(void);
 void threadlocal_stats_reset(void);
 void threadlocal_stats_aggregate(struct thread_stats *stats);
 void slab_stats_aggregate(struct thread_stats *stats, struct slab_stats *out);
+void thread_setname(pthread_t thread, const char *name);
 LIBEVENT_THREAD *get_worker_thread(int id);
 
 /* Stat processing functions */

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -187,6 +187,7 @@ void *proxy_init(bool use_uring) {
 #else
         pthread_create(&t->thread_id, NULL, proxy_event_thread, t);
 #endif // HAVE_LIBURING
+        thread_setname(t->thread_id, "mc-prx-io");
     }
 
     _start_proxy_config_threads(ctx);

--- a/proxy_config.c
+++ b/proxy_config.c
@@ -167,16 +167,18 @@ int _start_proxy_config_threads(proxy_ctx_t *ctx) {
         pthread_mutex_unlock(&ctx->config_lock);
         return -1;
     }
+    thread_setname(ctx->config_tid, "mc-prx-config");
     pthread_mutex_unlock(&ctx->config_lock);
 
     pthread_mutex_lock(&ctx->manager_lock);
     if ((ret = pthread_create(&ctx->manager_tid, NULL,
                     _proxy_manager_thread, ctx)) != 0) {
-        fprintf(stderr, "Failed to start proxy configuration thread: %s\n",
+        fprintf(stderr, "Failed to start proxy manager thread: %s\n",
                 strerror(ret));
         pthread_mutex_unlock(&ctx->manager_lock);
         return -1;
     }
+    thread_setname(ctx->manager_tid, "mc-prx-manager");
     pthread_mutex_unlock(&ctx->manager_lock);
 
     return 0;

--- a/slabs.c
+++ b/slabs.c
@@ -1326,6 +1326,7 @@ int start_slab_maintenance_thread(void) {
         fprintf(stderr, "Can't create rebal thread: %s\n", strerror(ret));
         return -1;
     }
+    thread_setname(rebalance_tid, "mc-slabmaint");
     return 0;
 }
 

--- a/storage.c
+++ b/storage.c
@@ -686,6 +686,7 @@ int start_storage_write_thread(void *arg) {
             strerror(ret));
         return -1;
     }
+    thread_setname(storage_write_tid, "mc-ext-write");
 
     return 0;
 }
@@ -1019,6 +1020,7 @@ int start_storage_compact_thread(void *arg) {
             strerror(ret));
         return -1;
     }
+    thread_setname(storage_compact_tid, "mc-ext-compact");
 
     return 0;
 }

--- a/thread.c
+++ b/thread.c
@@ -387,6 +387,8 @@ static void create_worker(void *(*func)(void *), void *arg) {
                 strerror(ret));
         exit(1);
     }
+
+    thread_setname(((LIBEVENT_THREAD*)arg)->thread_id, "mc-worker");
 }
 
 /*
@@ -628,6 +630,17 @@ static void thread_libevent_process(evutil_socket_t fd, short which, void *arg) 
         cqi_free(me->ev_queue, item);
     }
 }
+
+// Interface is slightly different on various platforms.
+// On linux, at least, the len limit is 16 bytes.
+#define THR_NAME_MAXLEN 16
+void thread_setname(pthread_t thread, const char *name) {
+assert(strlen(name) < THR_NAME_MAXLEN);
+#if defined(__linux__)
+pthread_setname_np(thread, name);
+#endif
+}
+#undef THR_NAME_MAXLEN
 
 // NOTE: need better encapsulation.
 // used by the proxy module to iterate the worker threads.


### PR DESCRIPTION
allow users to differentiate thread functions externally to memcached. Useful for setting priorities or pinning threads to CPU's.

Pretty trivial outside of needing to duplicate the function for extstore. I don't have instances handy to test BSD/OBSD/etc so I've left those forms out for now so I don't accidentally break builds. Any user with such a platform should feel free to submit a tested patch too.

I may or may not move the function to a new header file before merging. I might wait because I've been doing some slow audits and might want to structure it differently if I can find more common code to pull out.