### PR TITLE
Add opaque data for KEY_TOKEN token

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -536,6 +536,7 @@ struct settings {
 #ifdef SOCK_COOKIE_ID
     uint32_t sock_cookie_id;
 #endif
+    bool opaque_ipv6_ns;
 };
 
 extern struct stats stats;
@@ -1036,6 +1037,7 @@ bool get_stats(const char *stat_type, int nkey, ADD_STAT add_stats, void *c);
 void stats_reset(void);
 void process_stat_settings(ADD_STAT add_stats, void *c);
 void process_stats_conns(ADD_STAT add_stats, void *c);
+uint64_t get_opaque_ipv6_namespace(const conn *c);
 
 #if HAVE_DROP_PRIVILEGES
 extern void setup_privilege_violations_handler(void);


### PR DESCRIPTION
It can be used to implement pseudo-namespacing using IPv6 the last 8-bytes (64-bits) as the client id (opaque data).

For example:

```
$ ip6tables -t nat -A POSTROUTING -p tcp --dport 11211 -j SNAT --to-source 2a02:4780:1000::ffff:ffff
```

The request comes from this source IP, with key `key1`. Then the key will be rewritten to `4294967295_key1`. Where 4294967295 is basically ffff:ffff from IPv6.

This case mostly usable in shared-hosting environments where you need memcached , but also namespace isolation is a MUST.

Each website has its own dedicated IPv6 address, hence this is easy to distinguish the client and rewrite key on request.

Run:

```
./memcached -vvv -o opaque_ipv6_ns
```

Debug:

first source IPv6:
```
<24 new auto-negotiating client connection
24: going from conn_new_cmd to conn_waiting
24: going from conn_waiting to conn_read
24: going from conn_read to conn_parse_cmd
24: Client using the ascii protocol
<24 set key1 0 0 10 noreply
24: going from conn_parse_cmd to conn_nread
> NOT FOUND 4294967295_key1
>24 NOREPLY STORED
24: going from conn_nread to conn_new_cmd
24: going from conn_new_cmd to conn_parse_cmd
<24 get key1
> FOUND KEY 4294967295_key1
>24 sending key 4294967295_key1
>24 END
```

second source IPv6:
```
<24 new auto-negotiating client connection
24: going from conn_new_cmd to conn_waiting
24: going from conn_waiting to conn_read
24: going from conn_read to conn_parse_cmd
24: Client using the ascii protocol
<24 set key1 0 0 10 noreply
24: going from conn_parse_cmd to conn_nread
> NOT FOUND 4043374591_key1
>24 NOREPLY STORED
24: going from conn_nread to conn_new_cmd
24: going from conn_new_cmd to conn_parse_cmd
<24 get key1
> FOUND KEY 4043374591_key1
>24 sending key 4043374591_key1
>24 END
```

Implemented only for ASCII mode.

Signed-off-by: Donatas Abraitis <donatas@hostinger.com>
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>