### PR TITLE
adding an independant portability layer, starting with the debug feature

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,8 @@ memcached_SOURCES = memcached.c memcached.h \
                     authfile.c authfile.h \
                     restart.c restart.h \
                     proto_text.c proto_text.h \
-                    proto_bin.c proto_bin.h
+                    proto_bin.c proto_bin.h \
+                    portability.h
 
 if BUILD_SOLARIS_PRIVS
 memcached_SOURCES += solaris_priv.c

--- a/daemon.c
+++ b/daemon.c
@@ -34,6 +34,8 @@
 # pragma ident "$NetBSD: daemon.c,v 1.9 2003/08/07 16:42:46 agc Exp $"
 #endif
 
+#include "config.h"
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/extstore.c
+++ b/extstore.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 #include "config.h"
+#include "portability.h"
 // FIXME: config.h?
 #include <stdint.h>
 #include <stdbool.h>
@@ -111,19 +112,6 @@ struct store_engine {
     pthread_mutex_t stats_mutex;
     struct extstore_stats stats;
 };
-
-// FIXME: code is duplicated from thread.c since extstore.c doesn't pull in
-// the memcached ecosystem. worth starting a cross-utility header with static
-// definitions/macros?
-// keeping a minimal func here for now.
-#define THR_NAME_MAXLEN 16
-static void thread_setname(pthread_t thread, const char *name) {
-assert(strlen(name) < THR_NAME_MAXLEN);
-#if defined(__linux__)
-pthread_setname_np(thread, name);
-#endif
-}
-#undef THR_NAME_MAXLEN
 
 static _store_wbuf *wbuf_new(size_t size) {
     _store_wbuf *b = calloc(1, sizeof(_store_wbuf));

--- a/logger.c
+++ b/logger.c
@@ -1,5 +1,7 @@
 /* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
+#include "config.h"
+
 #include <arpa/inet.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/memcached.h
+++ b/memcached.h
@@ -49,6 +49,7 @@
 #include "protocol_binary.h"
 #include "cache.h"
 #include "logger.h"
+#include "portability.h"
 
 #ifdef EXTSTORE
 #include "crc32c.h"
@@ -994,7 +995,6 @@ void STATS_UNLOCK(void);
 void threadlocal_stats_reset(void);
 void threadlocal_stats_aggregate(struct thread_stats *stats);
 void slab_stats_aggregate(struct thread_stats *stats, struct slab_stats *out);
-void thread_setname(pthread_t thread, const char *name);
 LIBEVENT_THREAD *get_worker_thread(int id);
 
 /* Stat processing functions */

--- a/portability.h
+++ b/portability.h
@@ -1,0 +1,29 @@
+#ifndef PORTABILITY_H
+#define PORTABILITY_H
+#include "config.h"
+#include <assert.h>
+#include <string.h>
+#include <pthread.h>
+
+#if defined(__FreeBSD__)
+#include <pthread_np.h>
+#endif
+
+// Interface is slightly different on various platforms.
+// On linux, at least, the len limit is 16 bytes.
+// TODO We can fairly add in macOs but it sets only for the current thread
+#define THR_NAME_MAXLEN 16
+
+__attribute__((unused)) static void thread_setname(pthread_t thread, const char *name) {
+assert(strlen(name) < THR_NAME_MAXLEN);
+#if defined(__linux__)
+    pthread_setname_np(thread, name);
+#elif defined(__FreeBSD__)
+    // TODO once 13.x release becomes the minimum
+    // linux and freebsd can be merged in one.
+    pthread_set_name_np(thread, name);
+#endif
+}
+#undef THR_NAME_MAXLEN
+
+#endif

--- a/sizes.c
+++ b/sizes.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <stdio.h>
 
 #include "memcached.h"

--- a/thread.c
+++ b/thread.c
@@ -631,17 +631,6 @@ static void thread_libevent_process(evutil_socket_t fd, short which, void *arg) 
     }
 }
 
-// Interface is slightly different on various platforms.
-// On linux, at least, the len limit is 16 bytes.
-#define THR_NAME_MAXLEN 16
-void thread_setname(pthread_t thread, const char *name) {
-assert(strlen(name) < THR_NAME_MAXLEN);
-#if defined(__linux__)
-pthread_setname_np(thread, name);
-#endif
-}
-#undef THR_NAME_MAXLEN
-
 // NOTE: need better encapsulation.
 // used by the proxy module to iterate the worker threads.
 LIBEVENT_THREAD *get_worker_thread(int id) {

--- a/util.c
+++ b/util.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <stdio.h>
 #include <assert.h>
 #include <ctype.h>


### PR DESCRIPTION
 as naming threads and two platforms.