### PR TITLE
remove useless function declaration do_assoc_move_next_bucket()

### DIFF
--- a/assoc.h
+++ b/assoc.h
@@ -1,12 +1,14 @@
 /* associative array */
 void assoc_init(const int hashpower_init);
+
 item *assoc_find(const char *key, const size_t nkey, const uint32_t hv);
 int assoc_insert(item *item, const uint32_t hv);
 void assoc_delete(const char *key, const size_t nkey, const uint32_t hv);
-void do_assoc_move_next_bucket(void);
+
 int start_assoc_maintenance_thread(void);
 void stop_assoc_maintenance_thread(void);
 void assoc_start_expand(uint64_t curr_items);
+
 /* walk functions */
 void *assoc_get_iterator(void);
 bool assoc_iterate(void *iterp, item **it);


### PR DESCRIPTION
do_assoc_move_next_bucket in assoc.h is useless, it should be removed. 