### PR TITLE
declare item_lock_hashpower as a static variable

### DIFF
--- a/assoc.h
+++ b/assoc.h
@@ -13,4 +13,3 @@ bool assoc_iterate(void *iterp, item **it);
 void assoc_iterate_final(void *iterp);
 
 extern unsigned int hashpower;
-extern unsigned int item_lock_hashpower;

--- a/thread.c
+++ b/thread.c
@@ -86,7 +86,7 @@ static pthread_mutex_t worker_hang_lock;
 static pthread_mutex_t *item_locks;
 /* size of the item lock hash table */
 static uint32_t item_lock_count;
-unsigned int item_lock_hashpower;
+static unsigned int item_lock_hashpower;
 #define hashsize(n) ((unsigned long int)1<<(n))
 #define hashmask(n) (hashsize(n)-1)
 


### PR DESCRIPTION
The only reference of extern `item_lock_hashpower` was removed by 
[commit 6af7aa0b1581b3b](https://github.com/memcached/memcached/commit/6af7aa0b1581b3bfac98e4fd7c67801cd1f8f1fb#diff-01a5f0312bb8368e0e99f956b269866fbeadfed74fb86597972be641c8fe637f), then it should be a static variable.