### PR TITLE
remove useless function item_link

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -974,7 +974,6 @@ item *item_alloc(char *key, size_t nkey, int flags, rel_time_t exptime, int nbyt
 item *item_get(const char *key, const size_t nkey, conn *c, const bool do_update);
 item *item_get_locked(const char *key, const size_t nkey, conn *c, const bool do_update, uint32_t *hv);
 item *item_touch(const char *key, const size_t nkey, uint32_t exptime, conn *c);
-int   item_link(item *it);
 void  item_remove(item *it);
 int   item_replace(item *it, item *new_it, const uint32_t hv);
 void  item_unlink(item *it);

--- a/thread.c
+++ b/thread.c
@@ -852,20 +852,6 @@ item *item_touch(const char *key, size_t nkey, uint32_t exptime, conn *c) {
 }
 
 /*
- * Links an item into the LRU and hashtable.
- */
-int item_link(item *item) {
-    int ret;
-    uint32_t hv;
-
-    hv = hash(ITEM_key(item), item->nkey);
-    item_lock(hv);
-    ret = do_item_link(item, hv);
-    item_unlock(hv);
-    return ret;
-}
-
-/*
  * Decrements the reference count on an item and adds it to the freelist if
  * needed.
  */


### PR DESCRIPTION
Function `mt_item_link ` was renamed to `item_link` in  [commit a9dcd9aceb17ed50](https://github.com/memcached/memcached/commit/a9dcd9aceb17ed502345742e77fd5d2cd89d9869#diff-161b2a279f4c67a1ab075a7890ecf6f3f1d483d910910fa52b3715e25cfdcbd7R430), and then it is never used.