### PR TITLE
bugfix: size.c: struct size error

### DIFF
--- a/sizes.c
+++ b/sizes.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     display("Slab Stats", sizeof(struct slab_stats));
     display("Thread stats",
             sizeof(struct thread_stats)
-            - (200 * sizeof(struct slab_stats)));
+            - (MAX_NUMBER_OF_SLAB_CLASSES * sizeof(struct slab_stats)));
     display("Global stats", sizeof(struct stats));
     display("Settings", sizeof(struct settings));
     display("Item (no cas)", sizeof(item));


### PR DESCRIPTION
The size of `Thread stats` is shown as a negative number,  because `MAX_NUMBER_OF_SLAB_CLASSES` was changed to 64.
```
$ ./sizes
Slab Stats	64
Thread stats	-6352
Global stats	208
...
```

after fix:
```
$ ./sizes
Slab Stats	64
Thread stats	2352
Global stats	208
...
```