### PR TITLE
rm_lru_maintainer_initialized

### DIFF
--- a/items.c
+++ b/items.c
@@ -63,7 +63,6 @@ static int stats_sizes_buckets = 0;
 static uint64_t cas_id = 0;
 
 static volatile int do_run_lru_maintainer_thread = 0;
-static int lru_maintainer_initialized = 0;
 static pthread_mutex_t lru_maintainer_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t cas_id_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t stats_sizes_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -1743,11 +1742,6 @@ void lru_maintainer_pause(void) {
 
 void lru_maintainer_resume(void) {
     pthread_mutex_unlock(&lru_maintainer_lock);
-}
-
-int init_lru_maintainer(void) {
-    lru_maintainer_initialized = 1;
-    return 0;
 }
 
 /* Tail linkers and crawler for the LRU crawler. */

--- a/items.h
+++ b/items.h
@@ -79,7 +79,6 @@ extern pthread_mutex_t lru_locks[POWER_LARGEST];
 
 int start_lru_maintainer_thread(void *arg);
 int stop_lru_maintainer_thread(void);
-int init_lru_maintainer(void);
 void lru_maintainer_pause(void);
 void lru_maintainer_resume(void);
 

--- a/memcached.c
+++ b/memcached.c
@@ -4910,9 +4910,6 @@ int main (int argc, char **argv) {
     }
 #endif
 
-    /* Run regardless of initializing it later */
-    init_lru_maintainer();
-
     /* set stderr non-buffering (for running under, say, daemontools) */
     setbuf(stderr, NULL);
 


### PR DESCRIPTION
The double-initializations of mutex `lru_maintainer_lock` was removed by [commit 90306c5393](https://github.com/memcached/memcached/commit/90306c539327f4e36b950c9f1a83e65d2ad44a4b). Then `lru_maintainer_initialized` is meaningless.

