### PR TITLE
Add time_fprintf to memcached log

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -684,6 +684,7 @@ AC_CHECK_FUNCS(pread)
 AC_CHECK_FUNCS(eventfd)
 AC_CHECK_FUNCS([accept4], [AC_DEFINE(HAVE_ACCEPT4, 1, [Define to 1 if support accept4])])
 AC_CHECK_FUNCS([getopt_long], [AC_DEFINE(HAVE_GETOPT_LONG, 1, [Define to 1 if support getopt_long])])
+AC_CHECK_FUNCS(localtime_r)
 
 dnl Need to disable opt for alignment check. GCC is too clever and turns this
 dnl into wide stores and no cmp under O2.

--- a/memcached.c
+++ b/memcached.c
@@ -725,23 +725,23 @@ conn *conn_new(const int sfd, enum conn_states init_state,
 
     if (settings.verbose > 1) {
         if (init_state == conn_listening) {
-            fprintf(stderr, "<%d server listening (%s)\n", sfd,
+            time_fprintf(stderr, "<%d server listening (%s)\n", sfd,
                 prot_text(c->protocol));
         } else if (IS_UDP(transport)) {
-            fprintf(stderr, "<%d server listening (udp)\n", sfd);
+            time_fprintf(stderr, "<%d server listening (udp)\n", sfd);
         } else if (c->protocol == negotiating_prot) {
-            fprintf(stderr, "<%d new auto-negotiating client connection\n",
+            time_fprintf(stderr, "<%d new auto-negotiating client connection\n",
                     sfd);
         } else if (c->protocol == ascii_prot) {
-            fprintf(stderr, "<%d new ascii client connection.\n", sfd);
+            time_fprintf(stderr, "<%d new ascii client connection.\n", sfd);
         } else if (c->protocol == binary_prot) {
-            fprintf(stderr, "<%d new binary client connection.\n", sfd);
+            time_fprintf(stderr, "<%d new binary client connection.\n", sfd);
 #ifdef PROXY
         } else if (c->protocol == proxy_prot) {
-            fprintf(stderr, "<%d new proxy client connection.\n", sfd);
+            time_fprintf(stderr, "<%d new proxy client connection.\n", sfd);
 #endif
         } else {
-            fprintf(stderr, "<%d new unknown (%d) client connection\n",
+            time_fprintf(stderr, "<%d new unknown (%d) client connection\n",
                 sfd, c->protocol);
             assert(false);
         }
@@ -930,7 +930,7 @@ static void conn_close(conn *c) {
     event_del(&c->event);
 
     if (settings.verbose > 1)
-        fprintf(stderr, "<%d connection closed.\n", c->sfd);
+        time_fprintf(stderr, "<%d connection closed.\n", c->sfd);
 
     conn_cleanup(c);
 

--- a/thread.c
+++ b/thread.c
@@ -213,10 +213,10 @@ void stop_threads(void) {
     // assoc can call pause_threads(), so we have to stop it first.
     stop_assoc_maintenance_thread();
     if (settings.verbose > 0)
-        fprintf(stderr, "stopped assoc\n");
+        time_fprintf(stderr, "stopped assoc\n");
 
     if (settings.verbose > 0)
-        fprintf(stderr, "asking workers to stop\n");
+        time_fprintf(stderr, "asking workers to stop\n");
 
     pthread_mutex_lock(&worker_hang_lock);
     pthread_mutex_lock(&init_lock);
@@ -230,43 +230,43 @@ void stop_threads(void) {
     // All of the workers are hung but haven't done cleanup yet.
 
     if (settings.verbose > 0)
-        fprintf(stderr, "asking background threads to stop\n");
+        time_fprintf(stderr, "asking background threads to stop\n");
 
     // stop each side thread.
     // TODO: Verify these all work if the threads are already stopped
     stop_item_crawler_thread(CRAWLER_WAIT);
     if (settings.verbose > 0)
-        fprintf(stderr, "stopped lru crawler\n");
+        time_fprintf(stderr, "stopped lru crawler\n");
     if (settings.lru_maintainer_thread) {
         stop_lru_maintainer_thread();
         if (settings.verbose > 0)
-            fprintf(stderr, "stopped maintainer\n");
+            time_fprintf(stderr, "stopped maintainer\n");
     }
     if (settings.slab_reassign) {
         stop_slab_maintenance_thread();
         if (settings.verbose > 0)
-            fprintf(stderr, "stopped slab mover\n");
+            time_fprintf(stderr, "stopped slab mover\n");
     }
     logger_stop();
     if (settings.verbose > 0)
-        fprintf(stderr, "stopped logger thread\n");
+        time_fprintf(stderr, "stopped logger thread\n");
     stop_conn_timeout_thread();
     if (settings.verbose > 0)
-        fprintf(stderr, "stopped idle timeout thread\n");
+        time_fprintf(stderr, "stopped idle timeout thread\n");
 
     // Close all connections then let the workers finally exit.
     if (settings.verbose > 0)
-        fprintf(stderr, "closing connections\n");
+        time_fprintf(stderr, "closing connections\n");
     conn_close_all();
     pthread_mutex_unlock(&worker_hang_lock);
     if (settings.verbose > 0)
-        fprintf(stderr, "reaping worker threads\n");
+        time_fprintf(stderr, "reaping worker threads\n");
     for (i = 0; i < settings.num_threads; i++) {
         pthread_join(threads[i].thread_id, NULL);
     }
 
     if (settings.verbose > 0)
-        fprintf(stderr, "all background threads stopped\n");
+        time_fprintf(stderr, "all background threads stopped\n");
 
     // At this point, every background thread must be stopped.
 }

--- a/util.h
+++ b/util.h
@@ -41,3 +41,5 @@ extern uint64_t ntohll(uint64_t);
  */
 void vperror(const char *fmt, ...)
     __gcc_attribute__ ((format (printf, 1, 2)));
+
+int time_fprintf(FILE *fd, const char *format, ...);


### PR DESCRIPTION
This PR add date/timestamp information to memcached log.

Before:
```
$ ./memcached -vv
... ...
<17 server listening (auto-negotiate)
<18 server listening (auto-negotiate)
<19 new auto-negotiating client connection
<19 connection closed.
^CSignal handled: Interrupt: 2.
stopped assoc
asking workers to stop
asking background threads to stop
stopped lru crawler
stopped maintainer
stopped slab mover
stopped logger thread
stopped idle timeout thread
closing connections
<17 connection closed.
<18 connection closed.
reaping worker threads
all background threads stopped
```

After:
```
$ ./memcached -vv
... ...
2022-12-29_16:08:17,932431 <17 server listening (auto-negotiate)
2022-12-29_16:08:17,932629 <18 server listening (auto-negotiate)
2022-12-29_16:08:22,078384 <19 new auto-negotiating client connection
2022-12-29_16:08:32,304416 <19 connection closed.
^CSignal handled: Interrupt: 2.
2022-12-29_16:08:43,015118 stopped assoc
2022-12-29_16:08:43,015134 asking workers to stop
2022-12-29_16:08:43,015183 asking background threads to stop
2022-12-29_16:08:43,015209 stopped lru crawler
2022-12-29_16:08:43,407434 stopped maintainer
2022-12-29_16:08:43,407467 stopped slab mover
2022-12-29_16:08:43,407498 stopped logger thread
2022-12-29_16:08:43,407511 stopped idle timeout thread
2022-12-29_16:08:43,407519 closing connections
2022-12-29_16:08:43,407523 <17 connection closed.
2022-12-29_16:08:43,407543 <18 connection closed.
2022-12-29_16:08:43,407554 reaping worker threads
2022-12-29_16:08:43,407630 all background threads stopped
```

If this patch is ok, I will continue to replace other `fprintf` with `time_fprintf`.

