### PR TITLE
proxy: log time now relative to resp lifetime

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -300,7 +300,13 @@ void proxy_return_cb(io_pending_t *pending) {
     if (p->is_await) {
         mcplib_await_return(p);
     } else {
+        struct timeval end;
         lua_State *Lc = p->coro;
+
+        // stamp the elapsed time into the response object.
+        gettimeofday(&end, NULL);
+        p->client_resp->elapsed = (end.tv_sec - p->client_resp->start.tv_sec) * 1000000 +
+            (end.tv_usec - p->client_resp->start.tv_usec);
 
         // in order to resume we need to remove the objects that were
         // originally returned
@@ -840,6 +846,7 @@ static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
     memset(r, 0, sizeof(mcp_resp_t));
     r->buf = NULL;
     r->blen = 0;
+    gettimeofday(&r->start, NULL);
     // Set noreply mode.
     // TODO (v2): the response "inherits" the request's noreply mode, which isn't
     // strictly correct; we should inherit based on the request that spawned

--- a/proxy.h
+++ b/proxy.h
@@ -281,7 +281,6 @@ struct mcp_parser_s {
 #define MAX_REQ_TOKENS 2
 struct mcp_request_s {
     mcp_parser_t pr; // non-lua-specific parser handling.
-    struct timeval start; // time this object was created.
     mcp_backend_t *be; // backend handling this request.
     bool ascii_multiget; // ascii multiget mode. (hide errors/END)
     bool was_modified; // need to rewrite the request
@@ -396,6 +395,8 @@ typedef struct {
     mcmc_resp_t resp;
     char *buf; // response line + potentially value.
     size_t blen; // total size of the value to read.
+    struct timeval start; // time this object was created.
+    long elapsed; // time elapsed once handled.
     int status; // status code from mcmc_read()
     int bread; // amount of bytes read into value so far.
     uint8_t cmd; // from parser (pr.command)

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -7,6 +7,12 @@
 // normal library open:
 // int luaopen_mcp(lua_State *L) { }
 
+static int mcplib_response_elapsed(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+    lua_pushinteger(L, r->elapsed);
+    return 1;
+}
+
 // resp:ok()
 static int mcplib_response_ok(lua_State *L) {
     mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
@@ -811,6 +817,7 @@ static int mcplib_log_req(lua_State *L) {
     int rtype = 0;
     int rcode = 0;
     int rstatus = 0;
+    long elapsed = 0;
     char *rname = NULL;
     char *rport = NULL;
 
@@ -823,13 +830,10 @@ static int mcplib_log_req(lua_State *L) {
         rstatus = rs->status;
         rname = rs->be_name;
         rport = rs->be_port;
+        elapsed = rs->elapsed;
     }
     size_t dlen = 0;
     const char *detail = luaL_optlstring(L, 3, NULL, &dlen);
-
-    struct timeval end;
-    gettimeofday(&end, NULL);
-    long elapsed = (end.tv_sec - rq->start.tv_sec) * 1000000 + (end.tv_usec - rq->start.tv_usec);
 
     logger_log(l, LOGGER_PROXY_REQ, NULL, rq->pr.request, rq->pr.reqlen, elapsed, rtype, rcode, rstatus, detail, dlen, rname, rport);
 
@@ -871,6 +875,7 @@ static int mcplib_log_reqsample(lua_State *L) {
     int rtype = 0;
     int rcode = 0;
     int rstatus = 0;
+    long elapsed = 0;
     char *rname = NULL;
     char *rport = NULL;
 
@@ -886,13 +891,10 @@ static int mcplib_log_reqsample(lua_State *L) {
         rstatus = rs->status;
         rname = rs->be_name;
         rport = rs->be_port;
+        elapsed = rs->elapsed;
     }
     size_t dlen = 0;
     const char *detail = luaL_optlstring(L, 6, NULL, &dlen);
-
-    struct timeval end;
-    gettimeofday(&end, NULL);
-    long elapsed = (end.tv_sec - rq->start.tv_sec) * 1000000 + (end.tv_usec - rq->start.tv_usec);
 
     bool do_log = false;
     if (allerr && rstatus != MCMC_OK) {

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -449,7 +449,6 @@ mcp_request_t *mcp_new_request(lua_State *L, mcp_parser_t *pr, const char *comma
     memcpy(rq->request, command, cmdlen);
     rq->pr.request = rq->request;
     rq->pr.reqlen = cmdlen;
-    gettimeofday(&rq->start, NULL);
 
     luaL_getmetatable(L, "mcp.request");
     lua_setmetatable(L, -2);
@@ -584,7 +583,6 @@ int mcplib_request(lua_State *L) {
         }
         memcpy(rq->pr.vbuf, val, vlen);
     }
-    gettimeofday(&rq->start, NULL);
 
     // rq is now created, parsed, and on the stack.
     return 1;


### PR DESCRIPTION
Originally I envisioned taking an inbound request object, tagging it with the time, and at the very end of a function logging is called. This would give you the total time of the "backend" part of a request.

On rethinking, the timing information that's most useful in the proxy's perspective is the time it takes for a response to happen + the status of a response. One request may generate several sub-responses and it is impossible to check the timing of each of those and log outliers.

You now cannot get the total time elapsed in a function anymore, but I believe that is less useful information to the user of a proxy. The best picture of latency will still be from the client, and response latency can educate the proxy on issues with backends.

resp:elapsed() has been added as a compromise; it returns the elapsed microseconds that a response took, so you can add the time together and get an approximation of total time (if running req/resp's sequentially).

This change also means that calling mcp.await() and waiting for multiple responses will give the timing of each sub-response accurately.

Some more work:
- [ ] Adding some new logger versions of await()
- [ ] Raise lua error if "detail" is too long instead of checking length deep in the logger code.
- [ ] Maybe: allow calling log without a request object? Would just have blanks in the fields.