### PR TITLE
core: simplify background IO API

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -289,10 +289,6 @@ void proxy_submit_cb(io_queue_t *q) {
     return;
 }
 
-void proxy_complete_cb(io_queue_t *q) {
-    // empty/unused.
-}
-
 // called from worker thread after an individual IO has been returned back to
 // the worker thread. Do post-IO run and cleanup work.
 void proxy_return_cb(io_pending_t *pending) {
@@ -892,6 +888,8 @@ static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
     p->client_resp = r;
     p->flushed = false;
     p->ascii_multiget = rq->ascii_multiget;
+    p->return_cb = proxy_return_cb;
+    p->finalize_cb = proxy_finalize_cb;
     resp->io_pending = (io_pending_t *)p;
 
     // top of the main thread should be our coroutine.

--- a/proxy.h
+++ b/proxy.h
@@ -409,7 +409,10 @@ struct _io_pending_proxy_t {
     int io_queue_type;
     LIBEVENT_THREAD *thread;
     conn *c;
-    mc_resp *resp;  // original struct ends here
+    mc_resp *resp;
+    io_queue_cb return_cb; // called on worker thread.
+    io_queue_cb finalize_cb; // called back on the worker thread.
+    // original struct ends here
 
     struct _io_pending_proxy_t *next; // stack for IO submission
     STAILQ_ENTRY(_io_pending_proxy_t) io_next; // stack for backends

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -147,6 +147,8 @@ static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int aw
     p->client_resp = r;
     p->flushed = false;
     p->ascii_multiget = rq->ascii_multiget;
+    p->return_cb = proxy_return_cb;
+    p->finalize_cb = proxy_finalize_cb;
 
     // io_p needs to hold onto its own response reference, because we may or
     // may not include it in the final await() result.
@@ -201,6 +203,8 @@ static void mcp_queue_await_dummy_io(conn *c, lua_State *Lc, int await_ref) {
     p->is_await = true;
     p->await_ref = await_ref;
     p->await_background = true;
+    p->return_cb = proxy_return_cb;
+    p->finalize_cb = proxy_finalize_cb;
 
     // Dummy IO has no backend, and no request attached.
 

--- a/storage.h
+++ b/storage.h
@@ -17,10 +17,8 @@ void process_extstore_stats(ADD_STAT add_stats, conn *c);
 bool storage_validate_item(void *e, item *it);
 int storage_get_item(conn *c, item *it, mc_resp *resp);
 
-// callbacks for the IO queue subsystem.
+// callback for the IO queue subsystem.
 void storage_submit_cb(io_queue_t *q);
-void storage_complete_cb(io_queue_t *q);
-void storage_finalize_cb(io_pending_t *pending);
 
 // Thread functions.
 int start_storage_write_thread(void *arg);

--- a/thread.c
+++ b/thread.c
@@ -482,12 +482,11 @@ static void setup_thread(LIBEVENT_THREAD *me) {
     // me->storage is set just before this function is called.
     if (me->storage) {
         thread_io_queue_add(me, IO_QUEUE_EXTSTORE, me->storage,
-            storage_submit_cb, storage_complete_cb, NULL, storage_finalize_cb);
+            storage_submit_cb);
     }
 #endif
 #ifdef PROXY
-    thread_io_queue_add(me, IO_QUEUE_PROXY, settings.proxy_ctx, proxy_submit_cb,
-            proxy_complete_cb, proxy_return_cb, proxy_finalize_cb);
+    thread_io_queue_add(me, IO_QUEUE_PROXY, settings.proxy_ctx, proxy_submit_cb);
 
     // TODO: maybe register hooks to be called here from sub-packages? ie;
     // extstore, TLS, proxy.
@@ -495,7 +494,7 @@ static void setup_thread(LIBEVENT_THREAD *me) {
         proxy_thread_init(settings.proxy_ctx, me);
     }
 #endif
-    thread_io_queue_add(me, IO_QUEUE_NONE, NULL, NULL, NULL, NULL, NULL);
+    thread_io_queue_add(me, IO_QUEUE_NONE, NULL, NULL);
 }
 
 /*


### PR DESCRIPTION
- removes unused "completed" IO callback handler
- moves primary post-IO callback handlers from the queue definition to the actual IO objects.
- allows IO object callbacks to be handled generically instead of based on the queue they were submitted from.

TODO:
- [x] Benchmark extstore with/without this to ensure there's no major regression. (tests roughly similar, no huge measurable change while using heavy multigets)