### PR TITLE
proxy: clean logic around lua yielding

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -80,6 +80,10 @@
 #define MCP_BACKEND_UPVALUE 3
 #define MCP_CONTEXT_UPVALUE 4
 
+#define MCP_YIELD_POOL 1
+#define MCP_YIELD_AWAIT 2
+#define MCP_YIELD_LOCAL 3
+
 // all possible commands.
 #define CMD_FIELDS \
     X(CMD_MG) \
@@ -507,6 +511,7 @@ void mcp_request_attach(lua_State *L, mcp_request_t *rq, io_pending_proxy_t *p);
 int mcp_request_render(mcp_request_t *rq, int idx, const char *tok, size_t len);
 void proxy_lua_error(lua_State *L, const char *s);
 void proxy_lua_ferror(lua_State *L, const char *fmt, ...);
+void proxy_out_errstring(mc_resp *resp, const char *str);
 int _start_proxy_config_threads(proxy_ctx_t *ctx);
 int proxy_thread_loadconf(proxy_ctx_t *ctx, LIBEVENT_THREAD *thr);
 

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -89,7 +89,8 @@ int mcplib_await(lua_State *L) {
     aw->type = type;
     P_DEBUG("%s: about to yield [len: %d]\n", __func__, n);
 
-    return lua_yield(L, 1);
+    lua_pushinteger(L, MCP_YIELD_AWAIT);
+    return lua_yield(L, 2);
 }
 
 static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int await_ref, bool await_first) {

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -596,7 +596,8 @@ static int mcplib_pool_proxy_call(lua_State *L) {
     rq->be = mcplib_pool_proxy_call_helper(L, p, key, len);
 
     // now yield request, pool up.
-    return lua_yield(L, 2);
+    lua_pushinteger(L, MCP_YIELD_POOL);
+    return lua_yield(L, 3);
 }
 
 static int mcplib_tcp_keepalive(lua_State *L) {


### PR DESCRIPTION
We were duck typing the response code for a coroutine yield before. It would also pile random logic for overriding IO's in certain cases. This now makes everything explicit and more clear.