### PR TITLE
proxy: fix stats deadlock and mismatched responses

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -42,15 +42,15 @@
 
 #define WSTAT_L(t) pthread_mutex_lock(&t->stats.mutex);
 #define WSTAT_UL(t) pthread_mutex_unlock(&t->stats.mutex);
-#define WSTAT_INCR(c, stat, amount) { \
-    pthread_mutex_lock(&c->thread->stats.mutex); \
-    c->thread->stats.stat += amount; \
-    pthread_mutex_unlock(&c->thread->stats.mutex); \
+#define WSTAT_INCR(t, stat, amount) { \
+    pthread_mutex_lock(&t->stats.mutex); \
+    t->stats.stat += amount; \
+    pthread_mutex_unlock(&t->stats.mutex); \
 }
-#define WSTAT_DECR(c, stat, amount) { \
-    pthread_mutex_lock(&c->thread->stats.mutex); \
-    c->thread->stats.stat -= amount; \
-    pthread_mutex_unlock(&c->thread->stats.mutex); \
+#define WSTAT_DECR(t, stat, amount) { \
+    pthread_mutex_lock(&t->stats.mutex); \
+    t->stats.stat -= amount; \
+    pthread_mutex_unlock(&t->stats.mutex); \
 }
 #define STAT_L(ctx) pthread_mutex_lock(&ctx->stats_lock);
 #define STAT_UL(ctx) pthread_mutex_unlock(&ctx->stats_lock);

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -132,7 +132,7 @@ static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int aw
 
     io_pending_proxy_t *p = do_cache_alloc(c->thread->io_cache);
     if (p == NULL) {
-        WSTAT_INCR(c, proxy_conn_oom, 1);
+        WSTAT_INCR(c->thread, proxy_conn_oom, 1);
         proxy_lua_error(Lc, "out of memory allocating from IO cache");
         return;
     }
@@ -186,7 +186,7 @@ static void mcp_queue_await_dummy_io(conn *c, lua_State *Lc, int await_ref) {
 
     io_pending_proxy_t *p = do_cache_alloc(c->thread->io_cache);
     if (p == NULL) {
-        WSTAT_INCR(c, proxy_conn_oom, 1);
+        WSTAT_INCR(c->thread, proxy_conn_oom, 1);
         proxy_lua_error(Lc, "out of memory allocating from IO cache");
         return;
     }
@@ -223,7 +223,7 @@ static void mcp_queue_await_dummy_io(conn *c, lua_State *Lc, int await_ref) {
 // places. Else these errors currently crash the daemon.
 int mcplib_await_run(conn *c, mc_resp *resp, lua_State *L, int coro_ref) {
     P_DEBUG("%s: start\n", __func__);
-    WSTAT_INCR(c, proxy_await_active, 1);
+    WSTAT_INCR(c->thread, proxy_await_active, 1);
     mcp_await_t *aw = lua_touserdata(L, -1);
     int await_ref = luaL_ref(L, LUA_REGISTRYINDEX); // await is popped.
     assert(aw != NULL);
@@ -430,7 +430,7 @@ int mcplib_await_return(io_pending_proxy_t *p) {
         luaL_unref(L, LUA_REGISTRYINDEX, aw->argtable_ref);
         luaL_unref(L, LUA_REGISTRYINDEX, aw->req_ref);
         luaL_unref(L, LUA_REGISTRYINDEX, p->await_ref);
-        WSTAT_DECR(p->c, proxy_await_active, 1);
+        WSTAT_DECR(p->thread, proxy_await_active, 1);
     }
 
     // Just remove anything we could have left on the primary VM stack


### PR DESCRIPTION
- specifically the WSTAT_DECR in proxy_await.c's return code could potentially use the wrong thread's lock

This is why I've been swapping c with thread as lock/function arguments all over the code lately; it's very accident prone.

Am reasonably sure this causes the deadlock but need to attempt to verify more.

- Also fixes a bug I found while trying to reproduce the stats deadlock. See commit message for details there.