### PR TITLE
[devtools] Add new pkg-config dependency to dockerfiles

### DIFF
--- a/devtools/Dockerfile.alpine
+++ b/devtools/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 ARG CONFIGURE_OPTS="--enable-seccomp"
 
-RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf perl-test-harness-utils git
+RUN apk update && apk add --no-cache musl-dev libevent-dev libseccomp-dev linux-headers gcc make automake autoconf perl-test-harness-utils git pkgconfig
 
 RUN adduser -S memcached
 ADD . /src

--- a/devtools/Dockerfile.arch
+++ b/devtools/Dockerfile.arch
@@ -1,8 +1,8 @@
-FROM archlinux/base:latest
+FROM archlinux:latest
 
 ARG CONFIGURE_OPTS="--enable-seccomp"
 
-RUN pacman -Sy && pacman --noconfirm -S gcc automake autoconf libevent libseccomp git make perl
+RUN pacman -Sy && pacman --noconfirm -S gcc automake autoconf libevent libseccomp git make perl pkgconf
 RUN ln -s /usr/bin/core_perl/prove /usr/bin/prove
 
 RUN useradd -ms /bin/bash memcached

--- a/devtools/Dockerfile.fedora
+++ b/devtools/Dockerfile.fedora
@@ -2,7 +2,7 @@ FROM fedora:latest
 
 ARG CONFIGURE_OPTS="--enable-seccomp"
 
-RUN dnf install -y perl automake autoconf libseccomp-devel libevent-devel gcc make git
+RUN dnf install -y perl automake autoconf libseccomp-devel libevent-devel gcc make git pkgconf
 
 RUN useradd -ms /bin/bash memcached
 ADD . /src

--- a/devtools/Dockerfile.ubuntu
+++ b/devtools/Dockerfile.ubuntu
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 ARG CONFIGURE_OPTS="--enable-seccomp"
 
-RUN apt-get update && apt-get install -y build-essential automake1.11 autoconf libevent-dev libseccomp-dev git
+RUN apt-get update && apt-get install -y build-essential automake1.11 autoconf libevent-dev libseccomp-dev git pkg-config
 
 RUN useradd -ms /bin/bash memcached
 ADD . /src


### PR DESCRIPTION
Add new pkg-config dependency to dockerfiles

Attempting to build an image from the devtools Dockerfiles currently fails when executing ./autogen.sh.

As is documented in https://github.com/memcached/memcached/issues/932 memcached, and as such also the images, does not build without `pkg-config`.

To verify: run `docker-compose build` on master (build breaks) - execute `docker-compose build` on this branch and the images are built successfully.