### PR TITLE
proxy: add mcp.backend(t) for more overrides

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -175,8 +175,6 @@ void *proxy_init(bool use_uring) {
         pthread_mutex_init(&t->mutex, NULL);
         pthread_cond_init(&t->cond, NULL);
 
-        memcpy(&t->tunables, &ctx->tunables, sizeof(t->tunables));
-
 #ifdef HAVE_LIBURING
         if (t->use_uring) {
             pthread_create(&t->thread_id, NULL, proxy_event_thread_ur, t);

--- a/proxy.h
+++ b/proxy.h
@@ -308,6 +308,7 @@ struct mcp_backend_label_s {
     char port[MAX_PORTLEN+1];
     char label[MAX_LABELLEN+1];
     size_t llen; // cache label length for small speedup in pool creation.
+    struct proxy_tunables tunables;
 };
 
 // lua object wrapper meant to own a malloc'ed conn structure
@@ -333,6 +334,7 @@ struct mcp_backend_s {
     char *rbuf; // statically allocated read buffer.
     size_t rbufused; // currently active bytes in the buffer
     struct event event; // libevent
+    struct proxy_tunables tunables;
 #ifdef HAVE_LIBURING
     proxy_event_t ur_rd_ev; // liburing.
     proxy_event_t ur_wr_ev; // need a separate event/cb for writing/polling
@@ -357,13 +359,11 @@ struct proxy_event_thread_s {
     pthread_t thread_id;
     struct event_base *base;
     struct event notify_event; // listen event for the notify pipe/eventfd.
-    struct event clock_event; // timer for updating event thread data.
     struct event beconn_event; // listener for backends in connect state
 #ifdef HAVE_LIBURING
     struct io_uring ring;
     proxy_event_t ur_notify_event; // listen on eventfd.
     proxy_event_t ur_benotify_event; // listen on eventfd for backend connections.
-    proxy_event_t ur_clock_event; // timer for updating event thread data.
     eventfd_t event_counter;
     eventfd_t beevent_counter;
     bool use_uring;
@@ -383,7 +383,6 @@ struct proxy_event_thread_s {
     int be_notify_send_fd;
 #endif
     proxy_ctx_t *ctx; // main context.
-    struct proxy_tunables tunables; // periodically copied from main ctx
 };
 
 enum mcp_resp_mode {

--- a/t/proxyconfig.lua
+++ b/t/proxyconfig.lua
@@ -2,6 +2,8 @@
 -- so we can modify ourselves.
 local mode = dofile("/tmp/proxyconfigmode.lua")
 
+mcp.backend_read_timeout(4)
+
 function mcp_config_pools(old)
     if mode == "none" then
         return {}
@@ -9,6 +11,19 @@ function mcp_config_pools(old)
         local b1 = mcp.backend('b1', '127.0.0.1', 11511)
         local b2 = mcp.backend('b2', '127.0.0.1', 11512)
         local b3 = mcp.backend('b3', '127.0.0.1', 11513)
+
+        local pools = {
+            test = mcp.pool({b1, b2, b3})
+        }
+        return pools
+    elseif mode == "betable" then
+        local b1 = mcp.backend({ label = "b1", host = "127.0.0.1", port = 11511,
+            connecttimeout = 2, retrytimeout = 5, readtimeout = 0.1,
+            failurelimit = 0 })
+        local b2 = mcp.backend({ label = "b2", host = "127.0.0.1", port = 11512,
+            connecttimeout = 2, retrytimeout = 5, readtimeout = 5 })
+        local b3 = mcp.backend({ label = "b3", host = "127.0.0.1", port = 11513,
+            connecttimeout = 5, retrytimeout = 5, readtimeout = 5 })
 
         local pools = {
             test = mcp.pool({b1, b2, b3})
@@ -24,7 +39,7 @@ function mcp_config_routes(zones)
     if mode == "none" then
         mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR no mg route\r\n" end)
         mcp.attach(mcp.CMD_MS, function(r) return "SERVER_ERROR no ms route\r\n" end)
-    elseif mode == "start" then
+    elseif mode == "start" or mode == "betable" then
         mcp.attach(mcp.CMD_MG, function(r) return zones["test"](r) end)
         mcp.attach(mcp.CMD_MS, function(r) return zones["test"](r) end)
     end


### PR DESCRIPTION
ie:
```
local b1 = mcp.backend({ label = "b1", host = "127.0.0.1", port = 11511,
    connecttimeout = 1, retrytimeout = 0.5, readtimeout = 0.1,
    failurelimit = 11 })
```

... to allow for overriding connect/retry/etc tunables on a per-backend basis. If not passed in the global settings are used.

TODO:
- [x] add at least basic tests: I added some test lua and was able to hand verify a bit.
- [x] find the best way to test the overrides are actually being changed. I started by hand and was able to observe the retrytimeout was different across backends.

Note:
- The tradeoff: previously it was possible to change `mcp.backend_read_timeout` and similar without the proxy internally recreating any backends, but now modifying the global settings will re-create all backend objects. This makes reload slower when timeouts are adjusted; realistically this isn't done often and reload is still generally fast.
- If you are _not changing the global settings_, but _only changing individual backend overrides_, only those overridden backends will be recreated on reload. It is still fast.
- This actually fixes a long standing issue where toggling the `tcp_keepalive` function didn't work for reload.
