### PR TITLE
Update to -f logic

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -246,7 +246,8 @@ static void settings_init(void) {
     settings.evict_to_free = 1;       /* push old items out of cache when memory runs out */
     settings.socketpath = NULL;       /* by default, not using a unix socket */
     settings.auth_file = NULL;        /* by default, not using ASCII authentication tokens */
-    settings.factor = 1.25;
+    settings.factor[0] = 1.25;
+    settings.factor[1] = 0;
     settings.chunk_size = 48;         /* space for a modest key and value */
     settings.num_threads = 4;         /* N workers */
     settings.num_threads_per_udp = 0;
@@ -4023,10 +4024,12 @@ static void usage(void) {
            "-i, --license             print memcached and libevent license\n"
            "-V, --version             print version and exit\n"
            "-P, --pidfile=<file>      save PID in <file>, only used with -d option\n"
-           "-f, --slab-growth-factor=<num> chunk size growth factor (default: %2.2f)\n"
+           "-f <F1, ..Fn>             chunk size growth factor (default: %2.2f), you can\n"
+           "                          enter one or several factors, which will be used\n"
+           "                          proportionally. Separate by comma. Example: -f1.2,2\n"
            "-n, --slab-min-size=<bytes> min space used for key+value+flags (default: %d)\n",
            (unsigned long) settings.maxbytes / (1 << 20),
-           settings.maxconns, settings.factor, settings.chunk_size);
+           settings.maxconns, settings.factor[0], settings.chunk_size);
     verify_default("udp-port",settings.udpport == 0);
     printf("-L, --enable-largepages  try to use large memory pages (if available)\n");
     printf("-D <char>     Use <char> as the delimiter between key prefixes and IDs.\n"
@@ -5107,12 +5110,35 @@ int main (int argc, char **argv) {
             settings.memory_file = optarg;
             break;
         case 'f':
-            settings.factor = atof(optarg);
-            if (settings.factor <= 1.0) {
-                fprintf(stderr, "Factor must be greater than 1\n");
-                return 1;
-            }
             meta->slab_config = strdup(optarg);
+
+            int i = 0;
+            while (true) {
+                if (i >= FACTOR_MAX_COUNT) {
+                    fprintf(stderr, "Too many factors specified, maximum is: %d\n", FACTOR_MAX_COUNT);
+                    return 1;
+                }
+
+                char *pch = strchr(optarg, ',');
+                if (pch != NULL)
+                    *pch = 0;
+                if (strlen(optarg) == 0) {
+                    fprintf(stderr, "Factor component not specified, please use correct format\n");
+                    return 1;
+                }
+
+                double _tmp = atof(optarg);
+                if (_tmp < 1.0) {
+                    fprintf(stderr, "Factor value must be >=1 (`%s`).\n", optarg);
+                    return 1;
+                }
+                settings.factor[i++] = _tmp;
+
+                if (pch == NULL || strlen(optarg) == 0)
+                    break;
+                optarg = pch + 1;
+            }
+            settings.factor[i] = 0;
             break;
         case 'n':
             settings.chunk_size = atoi(optarg);

--- a/memcached.h
+++ b/memcached.h
@@ -89,6 +89,9 @@
 #define HASHPOWER_DEFAULT 16
 #define HASHPOWER_MAX 32
 
+/* maximum number of slab size grow factors the user can specify */
+#define FACTOR_MAX_COUNT 10
+
 /*
  * We only reposition items in the LRU queue if they haven't been repositioned
  * in this many seconds. That saves us from churning on frequently-accessed
@@ -447,7 +450,7 @@ struct settings {
     char *socketpath;   /* path to unix socket if using local socket */
     char *auth_file;    /* path to user authentication file */
     int access;  /* access mask (a la chmod) for unix domain socket */
-    double factor;          /* chunk size growth factor */
+    double factor[FACTOR_MAX_COUNT+1];          /* chunk size growth factors */
     int chunk_size;
     int num_threads;        /* number of worker (without dispatcher) libevent threads to run */
     int num_threads_per_udp; /* number of worker threads serving each udp socket */

--- a/slabs.h
+++ b/slabs.h
@@ -8,7 +8,7 @@
     3rd argument specifies if the slab allocator should allocate all memory
     up front (if true), or allocate memory in chunks as it is needed (if false)
 */
-void slabs_init(const size_t limit, const double factor, const bool prealloc, const uint32_t *slab_sizes, void *mem_base_external, bool reuse_mem);
+void slabs_init(const size_t limit, const double* factors, const bool prealloc, const uint32_t *slab_sizes, void *mem_base_external, bool reuse_mem);
 
 /** Call only during init. Pre-allocates all available memory */
 void slabs_prefill_global(void);


### PR DESCRIPTION
- You can now have several -f (factors) that'll be used evenly to calculate slab sizes, there's maximum of 10 factors which is defined as FACTOR_MAX_COUNT.

- Some more logic that'll prevent having incorrect slab sizes instead of throwing an error, eg. if there's 8 byte alignment, having factor of 1 will increase next slab size by 8 bytes

- No longer slabs with different sizes and same perslab will be created