### PR TITLE
proxy: redo libevent handling code

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -323,7 +323,8 @@ struct mcp_backend_wrap_s {
 // FIXME: inline the mcmc client data.
 // TODO: event_thread -> something? union of owner type?
 struct mcp_backend_s {
-    int depth;
+    int depth; // total number of requests in queue
+    int pending_read; // number of requests written to socket, pending read.
     int failed_count; // number of fails (timeouts) in a row
     proxy_event_thread_t *event_thread; // event thread owning this backend.
     void *client; // mcmc client
@@ -333,7 +334,9 @@ struct mcp_backend_s {
     io_pending_proxy_t *io_next; // next request to write.
     char *rbuf; // statically allocated read buffer.
     size_t rbufused; // currently active bytes in the buffer
-    struct event event; // libevent
+    struct event main_event; // libevent: changes role, mostly for main read events
+    struct event write_event; // libevent: only used when socket wbuf full
+    struct event timeout_event; // libevent: alarm for pending reads
     struct proxy_tunables tunables;
 #ifdef HAVE_LIBURING
     proxy_event_t ur_rd_ev; // liburing.

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -337,7 +337,9 @@ static mcp_backend_wrap_t *_mcplib_make_backendconn(lua_State *L, mcp_backend_la
     }
 
     // initialize libevent.
-    memset(&be->event, 0, sizeof(be->event));
+    memset(&be->main_event, 0, sizeof(be->main_event));
+    memset(&be->write_event, 0, sizeof(be->write_event));
+    memset(&be->timeout_event, 0, sizeof(be->timeout_event));
 
     // initialize the client
     be->client = malloc(mcmc_size(MCMC_OPTION_BLANK));


### PR DESCRIPTION
The event handling code was unoptimized and temporary; it was slated for a rewrite for performance and non-critical bugs alone. However the old code may be causing critical bugs so it's being rewritten now.

Fixes:
- backend disconnects are detected immediately instead of on the next time they are used.
- backend reconnects happen _after_ the retry timeout, not before
- use a persistent read handler and a temporary write handler to avoid constantly calling epoll_ctl syscalls for potential performance boost.
- avoids overwriting the read timeout when many requests are being queued for the same non responsive backend

Commit in progress, still hunting some other related timing bugs that seem to still happen.