### PR TITLE
log: fix race condition while incrementing log entries dropped

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -913,8 +913,8 @@ enum logger_ret_type logger_log(logger *l, const enum log_entry_type event, cons
     /* Request a maximum length of data to write to */
     e = (logentry *) bipbuf_request(buf, (sizeof(logentry) + reqlen));
     if (e == NULL) {
-        pthread_mutex_unlock(&l->mutex);
         l->dropped++;
+        pthread_mutex_unlock(&l->mutex);
         return LOGGER_RET_NOSPACE;
     }
     e->event = event;


### PR DESCRIPTION
This fixes the bug reported in #885 

Looks like the reporter didn't make a patch, and the issue has been open for a while, so I took the liberty to make a PR.