### PR TITLE
Proxy limiters

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -716,7 +716,8 @@ typedef struct {
 #endif
     int napi_id;                /* napi id associated with this thread */
 #ifdef PROXY
-    void *L;
+    void *proxy_ctx; // proxy global context
+    void *L; // lua VM
     void *proxy_hooks;
     void *proxy_user_stats;
     void *proxy_int_stats;

--- a/memcached.h
+++ b/memcached.h
@@ -722,6 +722,10 @@ typedef struct {
     void *proxy_user_stats;
     void *proxy_int_stats;
     void *proxy_event_thread; // worker threads can also be proxy IO threads
+    pthread_mutex_t proxy_limit_lock;
+    uint64_t proxy_active_req_limit;
+    uint64_t proxy_buffer_memory_limit; // protected by limit_lock
+    uint64_t proxy_buffer_memory_used; // protected by limit_lock
     uint32_t proxy_rng[4]; // fast per-thread rng for lua.
     // TODO: add ctx object so we can attach to queue.
 #endif

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -166,6 +166,7 @@ void proxy_thread_init(void *ctx, LIBEVENT_THREAD *thr) {
         fprintf(stderr, "Failed to allocate proxy thread stats\n");
         exit(EXIT_FAILURE);
     }
+    thr->proxy_ctx = ctx;
 
     // Initialize the lua state.
     lua_State *L = luaL_newstate();

--- a/proxy.h
+++ b/proxy.h
@@ -76,10 +76,7 @@
 #define ENDSTR "END\r\n"
 #define ENDLEN sizeof(ENDSTR)-1
 
-#define MCP_THREAD_UPVALUE 1
-#define MCP_ATTACH_UPVALUE 2
-#define MCP_BACKEND_UPVALUE 3
-#define MCP_CONTEXT_UPVALUE 4
+#define MCP_BACKEND_UPVALUE 1
 
 #define MCP_YIELD_POOL 1
 #define MCP_YIELD_AWAIT 2
@@ -216,6 +213,11 @@ typedef struct {
     struct proxy_tunables tunables; // NOTE: updates covered by stats_lock
     pthread_mutex_t stats_lock; // used for rare global counters
 } proxy_ctx_t;
+
+#define PROXY_GET_THR_CTX(L) ((*(LIBEVENT_THREAD **)lua_getextraspace(L))->proxy_ctx)
+#define PROXY_GET_THR(L) (*(LIBEVENT_THREAD **)lua_getextraspace(L))
+// Operations from the config VM don't have a libevent thread.
+#define PROXY_GET_CTX(L) (*(proxy_ctx_t **)lua_getextraspace(L))
 
 struct proxy_hook_tagged {
     uint64_t tag;

--- a/proxy.h
+++ b/proxy.h
@@ -195,6 +195,8 @@ typedef struct {
     lua_State *proxy_state;
     void *proxy_code;
     proxy_event_thread_t *proxy_io_thread;
+    uint64_t active_req_limit; // max total in-flight requests
+    uint64_t buffer_memory_limit; // max bytes for send/receive buffers.
     pthread_mutex_t config_lock;
     pthread_cond_t config_cond;
     pthread_t config_tid;
@@ -496,6 +498,9 @@ typedef struct {
     mcp_pool_t *main; // ptr to original
     mcp_pool_be_t *pool; // ptr to main->pool starting offset for owner thread.
 } mcp_pool_proxy_t;
+
+// utils
+bool proxy_bufmem_checkadd(LIBEVENT_THREAD *t, int len);
 
 // networking interface
 void proxy_init_event_thread(proxy_event_thread_t *t, proxy_ctx_t *ctx, struct event_base *base);

--- a/proxy_await.c
+++ b/proxy_await.c
@@ -121,6 +121,8 @@ static void mcp_queue_await_io(conn *c, lua_State *Lc, mcp_request_t *rq, int aw
     // reserve one uservalue for a lua-supplied response.
     mcp_resp_t *r = lua_newuserdatauv(Lc, sizeof(mcp_resp_t), 1);
     memset(r, 0, sizeof(mcp_resp_t));
+    r->thread = c->thread;
+    assert(r->thread != NULL);
     gettimeofday(&r->start, NULL);
     // Set noreply mode.
     // TODO (v2): the response "inherits" the request's noreply mode, which isn't

--- a/proxy_config.c
+++ b/proxy_config.c
@@ -458,7 +458,14 @@ int proxy_thread_loadconf(proxy_ctx_t *ctx, LIBEVENT_THREAD *thr) {
         tus->num_stats = us->num_stats;
         pthread_mutex_unlock(&thr->stats.mutex);
     }
+    // also grab the concurrent request limit
+    thr->proxy_active_req_limit = ctx->active_req_limit;
     STAT_UL(ctx);
+
+    // update limit counter(s)
+    pthread_mutex_lock(&thr->proxy_limit_lock);
+    thr->proxy_buffer_memory_limit = ctx->buffer_memory_limit;
+    pthread_mutex_unlock(&thr->proxy_limit_lock);
 
     return 0;
 }

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -1049,12 +1049,25 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
 
             // r->resp.reslen + r->resp.vlen is the total length of the response.
             // TODO (v2): need to associate a buffer with this response...
-            // for now lets abuse write_and_free on mc_resp and simply malloc the
-            // space we need, stuffing it into the resp object.
+            // for now we simply malloc, but reusable buffers should be used
 
             r->blen = r->resp.reslen + r->resp.vlen;
+            {
+                bool oom = proxy_bufmem_checkadd(r->thread, r->blen + extra_space);
+
+                if (oom) {
+                    flags = P_BE_FAIL_OOM;
+                    stop = true;
+                    break;
+                }
+            }
             r->buf = malloc(r->blen + extra_space);
             if (r->buf == NULL) {
+                // Enforce accounting.
+                pthread_mutex_lock(&r->thread->proxy_limit_lock);
+                r->thread->proxy_buffer_memory_used -= r->blen + extra_space;
+                pthread_mutex_unlock(&r->thread->proxy_limit_lock);
+
                 flags = P_BE_FAIL_OOM;
                 stop = true;
                 break;

--- a/proxy_ustats.c
+++ b/proxy_ustats.c
@@ -5,11 +5,6 @@
 // mcp.add_stat(index, name)
 // creates a custom lua stats counter
 int mcplib_add_stat(lua_State *L) {
-    LIBEVENT_THREAD *t = lua_touserdata(L, lua_upvalueindex(MCP_THREAD_UPVALUE));
-    if (t != NULL) {
-        proxy_lua_error(L, "add_stat must be called from config_pools");
-        return 0;
-    }
     int idx = luaL_checkinteger(L, -2);
     const char *name = luaL_checkstring(L, -1);
 
@@ -36,7 +31,7 @@ int mcplib_add_stat(lua_State *L) {
         }
     }
 
-    proxy_ctx_t *ctx = lua_touserdata(L, lua_upvalueindex(MCP_CONTEXT_UPVALUE));
+    proxy_ctx_t *ctx = PROXY_GET_CTX(L);
 
     STAT_L(ctx);
     struct proxy_user_stats *us = &ctx->user_stats;
@@ -70,7 +65,7 @@ int mcplib_add_stat(lua_State *L) {
 }
 
 int mcplib_stat(lua_State *L) {
-    LIBEVENT_THREAD *t = lua_touserdata(L, lua_upvalueindex(MCP_THREAD_UPVALUE));
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
     if (t == NULL) {
         proxy_lua_error(L, "stat must be called from router handlers");
         return 0;

--- a/t/proxyconfig.lua
+++ b/t/proxyconfig.lua
@@ -2,10 +2,10 @@
 -- so we can modify ourselves.
 local mode = dofile("/tmp/proxyconfigmode.lua")
 
-mcp.backend_read_timeout(4)
-mcp.backend_connect_timeout(5)
-
 function mcp_config_pools(old)
+    mcp.backend_read_timeout(4)
+    mcp.backend_connect_timeout(5)
+
     if mode == "none" then
         return {}
     elseif mode == "start" then

--- a/t/proxyconfig.lua
+++ b/t/proxyconfig.lua
@@ -39,6 +39,57 @@ function mcp_config_pools(old)
             test = mcp.pool({b1, b2, b3}, { iothread = false })
         }
         return pools
+    elseif mode == "reqlimit" then
+        mcp.active_req_limit(4)
+        local b1 = mcp.backend('b1', '127.0.0.1', 11511)
+        local b2 = mcp.backend('b2', '127.0.0.1', 11512)
+        local b3 = mcp.backend('b3', '127.0.0.1', 11513)
+
+        -- Direct all traffic at a single backend to simplify the test.
+        local pools = {
+            test = mcp.pool({b1}),
+            hold = mcp.pool({b2, b3})
+        }
+        return pools
+    elseif mode == "noreqlimit" then
+        mcp.active_req_limit(0)
+        local b1 = mcp.backend('b1', '127.0.0.1', 11511)
+        local b2 = mcp.backend('b2', '127.0.0.1', 11512)
+        local b3 = mcp.backend('b3', '127.0.0.1', 11513)
+
+        -- Direct all traffic at a single backend to simplify the test.
+        local pools = {
+            test = mcp.pool({b1}),
+            hold = mcp.pool({b2, b3})
+        }
+        return pools
+    elseif mode == "buflimit" or mode == "buflimit2" then
+        mcp.buffer_memory_limit(20)
+        if mode == "buflimit2" then
+            mcp.buffer_memory_limit(200)
+        end
+        local b1 = mcp.backend('b1', '127.0.0.1', 11511)
+        local b2 = mcp.backend('b2', '127.0.0.1', 11512)
+        local b3 = mcp.backend('b3', '127.0.0.1', 11513)
+
+        -- Direct all traffic at a single backend to simplify the test.
+        local pools = {
+            test = mcp.pool({b1}),
+            hold = mcp.pool({b2, b3})
+        }
+        return pools
+    elseif mode == "nobuflimit" then
+        mcp.buffer_memory_limit(0)
+        local b1 = mcp.backend('b1', '127.0.0.1', 11511)
+        local b2 = mcp.backend('b2', '127.0.0.1', 11512)
+        local b3 = mcp.backend('b3', '127.0.0.1', 11513)
+
+        -- Direct all traffic at a single backend to simplify the test.
+        local pools = {
+            test = mcp.pool({b1}),
+            hold = mcp.pool({b2, b3})
+        }
+        return pools
     end
 end
 
@@ -49,10 +100,7 @@ function mcp_config_routes(zones)
     if mode == "none" then
         mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR no mg route\r\n" end)
         mcp.attach(mcp.CMD_MS, function(r) return "SERVER_ERROR no ms route\r\n" end)
-    elseif mode == "start" or mode == "betable" then
-        mcp.attach(mcp.CMD_MG, function(r) return zones["test"](r) end)
-        mcp.attach(mcp.CMD_MS, function(r) return zones["test"](r) end)
-    elseif mode == "noiothread" then
+    else
         mcp.attach(mcp.CMD_MG, function(r) return zones["test"](r) end)
         mcp.attach(mcp.CMD_MS, function(r) return zones["test"](r) end)
     end

--- a/t/proxyconfig.t
+++ b/t/proxyconfig.t
@@ -60,7 +60,7 @@ sub wait_reload {
 }
 
 my @mocksrvs = ();
-diag "making mock servers";
+#diag "making mock servers";
 for my $port (11511, 11512, 11513) {
     my $srv = mock_server($port);
     ok(defined $srv, "mock server created");
@@ -267,7 +267,182 @@ is(<$watcher>, "OK\r\n", "watcher enabled");
 
 }
 
+###
+# diag "starting proxy again from scratch"
+###
+
+# TODO: probably time to abstract the entire "start the server with mocked
+# listeners" routine.
+$watcher = undef;
+write_modefile('return "reqlimit"');
+$p_srv->stop;
+while (1) {
+    if ($p_srv->is_running) {
+        sleep 1;
+    } else {
+        ok(!$p_srv->is_running, "stopped proxy");
+        last;
+    }
+}
+
+@mocksrvs = ();
+# re-create the mock servers so we get clean connects, the previous
+# backends could be reconnecting still.
+for my $port (11511, 11512, 11513) {
+    my $srv = mock_server($port);
+    ok(defined $srv, "mock server created");
+    push(@mocksrvs, $srv);
+}
+
+# Start up a clean server.
+# Since limits are per worker thread, cut the worker threads down to 1 to ease
+# testing.
+$p_srv = new_memcached('-o proxy_config=./t/proxyconfig.lua -l 127.0.0.1 -t 1', 11510);
+$ps = $p_srv->sock;
+$ps->autoflush(1);
+
+{
+    for my $msrv ($mocksrvs[0], $mocksrvs[1], $mocksrvs[2]) {
+        my $be = $msrv->accept();
+        $be->autoflush(1);
+        ok(defined $be, "mock backend created");
+        push(@mbe, $be);
+    }
+
+    for my $be (@mbe) {
+        like(<$be>, qr/version/, "received version command");
+        print $be "VERSION 1.0.0-mock\r\n";
+    }
+
+    my $stats = mem_stats($ps, 'proxy');
+    isnt($stats->{active_req_limit}, 0, "active request limit is set");
+
+    # active request limit is 4, pipeline 6 requests and ensure the last two
+    # get junked
+    my $cmd = '';
+    for ('a', 'b', 'c', 'd', 'e', 'f') {
+        $cmd .= "mg /test/$_\r\n";
+    }
+    print $ps $cmd;
+
+    # Lua config only sends commands to the first backend for this test.
+    my $be = $mbe[0];
+    for (1 .. 4) {
+        like(<$be>, qr/^mg \/test\/\w\r\n$/, "backend received mg");
+        print $be "EN\r\n";
+    }
+    my $s = IO::Select->new();
+    $s->add($be);
+    my @readable = $s->can_read(0.25);
+    is(scalar @readable, 0, "no more pending reads on backend");
+
+    for (1 .. 4) {
+        is(scalar <$ps>, "EN\r\n", "received miss from backend");
+    }
+
+    is(scalar <$ps>, "SERVER_ERROR active request limit reached\r\n", "got error back");
+    is(scalar <$ps>, "SERVER_ERROR active request limit reached\r\n", "got two limit errors");
+
+    # Test turning the limit back off.
+    write_modefile('return "noreqlimit"');
+    $watcher = $p_srv->new_sock;
+    print $watcher "watch proxyevents\n";
+    is(<$watcher>, "OK\r\n", "watcher enabled");
+    $p_srv->reload();
+    wait_reload($watcher);
+
+    $stats = mem_stats($ps, 'proxy');
+    is($stats->{active_req_limit}, 0, "active request limit unset");
+
+    $cmd = '';
+    for ('a', 'b', 'c', 'd', 'e', 'f') {
+        $cmd .= "mg /test/$_\r\n";
+    }
+    print $ps $cmd;
+    for (1 .. 6) {
+        like(<$be>, qr/^mg \/test\/\w\r\n$/, "backend received mg");
+        print $be "EN\r\n";
+    }
+    for (1 .. 6) {
+        is(scalar <$ps>, "EN\r\n", "received miss from backend");
+    }
+}
+
+{
+    # Test the buffer memory limiter.
+    # - limit per worker will be 1/t global limit
+    write_modefile('return "buflimit"');
+    $p_srv->reload();
+    wait_reload($watcher);
+    # Get a secondary client to trample limit.
+    my $sps = $p_srv->new_sock;
+
+    my $stats = mem_stats($ps, 'proxy');
+    isnt($stats->{buffer_memory_limit}, 0, "buf mem limit is set");
+
+    # - test SET commands with values, but nothing being read on backend
+    my $data = 'x' x 30000;
+    my $cmd = "ms foo 30000 T30\r\n" . $data . "\r\n";
+    print $ps $cmd;
+
+    my $be = $mbe[0];
+    my $s = IO::Select->new;
+    $s->add($be);
+    # Wait until the backend has the request queued, then send the second one.
+    my @readable = $s->can_read(1);
+    print $sps $cmd;
+
+    my $res;
+    is(scalar <$be>, "ms foo 30000 T30\r\n", "received first ms");
+    $res = scalar <$be>;
+    print $be "HD\r\n";
+
+    # The second request should have been caught by the memory limiter
+    is(scalar <$sps>, "SERVER_ERROR out of memory\r\n", "got server error");
+    # FIXME: The original response cannot succeed because we cannot allocate
+    # enough memory to read the response from the backend.
+    # This is conveniently testing both paths right here but I would prefer
+    # something better.
+    # TODO: need to see if it's possible to surface an OOM from the backend
+    # handler, but that requires more rewiring.
+    is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "first request succeeded");
+
+    # Backend gets killed from a read OOM, so we need to re-establish.
+    $mbe[0] = $mocksrvs[0]->accept();
+    $be = $mbe[0];
+    $be->autoflush(1);
+    like(<$be>, qr/version/, "received version command");
+    print $be "VERSION 1.0.0-mock\r\n";
+    like(<$watcher>, qr/error=outofmemory/, "OOM log line");
+
+    # Memory limits won't drop until the garbage collectors run, which
+    # requires a bit more push, so instead we raise the limits here so we can
+    # retry from the pre-existing connections to test swallow mode.
+    write_modefile('return "buflimit2"');
+    $p_srv->reload();
+    wait_reload($watcher);
+
+    # Test sending another request down both pipes to ensure they still work.
+    $cmd = "ms foo 2 T30\r\nhi\r\n";
+    print $ps $cmd;
+    is(scalar <$be>, "ms foo 2 T30\r\n", "client works after oom");
+    is(scalar <$be>, "hi\r\n", "client works after oom");
+    print $be "HD\r\n";
+    is(scalar <$ps>, "HD\r\n", "client received resp after oom");
+    print $sps $cmd;
+    is(scalar <$be>, "ms foo 2 T30\r\n", "client works after oom");
+    is(scalar <$be>, "hi\r\n", "client works after oom");
+    print $be "HD\r\n";
+    is(scalar <$sps>, "HD\r\n", "client received resp after oom");
+
+    # - test GET commands but don't read back, large backend values
+    # - test disabling the limiter
+    # extended testing:
+    # - create errors while holding the buffers?
+}
+
 # TODO:
+# check reqlimit/bwlimit counters
 # remove backends
 # do dead sockets close?
 # adding user stats

--- a/t/proxyunits.lua
+++ b/t/proxyunits.lua
@@ -1,8 +1,7 @@
-mcp.backend_read_timeout(0.5)
-mcp.backend_connect_timeout(5)
-
 function mcp_config_pools(oldss)
     local srv = mcp.backend
+    mcp.backend_read_timeout(0.5)
+    mcp.backend_connect_timeout(5)
 
     -- Single backend for zones to ease testing.
     -- For purposes of this config the proxy is always "zone 1" (z1)

--- a/t/startfile.lua
+++ b/t/startfile.lua
@@ -9,11 +9,11 @@ local my_zone = 'z1'
 
 local STAT_EXAMPLE <const> = 1
 local STAT_ANOTHER <const> = 2
---mcp.tcp_keepalive(true)
 
 function mcp_config_pools(oldss)
     mcp.add_stat(STAT_EXAMPLE, "example")
     mcp.add_stat(STAT_ANOTHER, "another")
+    --mcp.tcp_keepalive(true)
     mcp.backend_connect_timeout(5.5) -- 5 and a half second timeout.
     -- alias mcp.backend for convenience.
     -- important to alias global variables in routes where speed is concerned.


### PR DESCRIPTION
Adds two limiters:
- mcp.active_req_limit(count) - number of concurrent active requests
- mcp.buffer_memory_limit(kilobytes) - Amount of kilobytes of buffer memory used for request and response values for the proxy.

Not quite as straightforward as I hoped. Needed to make access to mcp.* functions more strict for the config and route routines; you can no longer call config functions from routes and vice versa.

Performance should be good; the counters are per-worker-thread and uses an uncontested mutex to cover. I wanted to go nuts with atomics but that should be a distinct change.

Caveat:
- There is a "hole" for request accounting where the memory can't be accounted for until after it's fully read from the network. More restructuring is required; this is probably fine for the scope of this particular PR as the only way to get into this situation would be for many parallel clients to send a set header, without payload, then hang indefinitely.

TODO:
- [x] unit tests. was going to stop today after writing them but I feel like shit :(
- [x] find a better way to do the read buffer accounting. The IO thread makes this the most difficult.
- [x] audit to see if `AWAIT_BACKGROUND` can escape the limiters (I'm pretty sure it can, but not sure if I will deal with that in this PR)
- [x] Set conn_swallow and sbytes if OOM or active req limit on a set.
- [x] Fix active_req_limit stats output when disabled