### PR TITLE
Watch deletions

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1174,7 +1174,7 @@ Watchers are a way to connect to memcached and inspect what's going on
 internally. This is an evolving feature so new endpoints should show up over
 time.
 
-watch <fetchers|mutations|evictions|connevents>
+watch <fetchers|mutations|evictions|connevents|deletions>
 
 - Turn connection into a watcher. Options can be stacked and are
   space-separated. Logs will be sent to the watcher until it disconnects.
@@ -1222,6 +1222,9 @@ The arguments are:
   configuration reloads.
 
 - "proxyuser": Emits log entries created from lua configuration files.
+
+- "deletions": Emits logs when an item is successfully deleted from the
+  cache using `delete` or `md` commands. delete misses wouldn't be logged
 
 Statistics
 ----------

--- a/logger.h
+++ b/logger.h
@@ -22,6 +22,7 @@ enum log_entry_type {
     LOGGER_SLAB_MOVE,
     LOGGER_CONNECTION_NEW,
     LOGGER_CONNECTION_CLOSE,
+    LOGGER_DELETIONS,
 #ifdef EXTSTORE
     LOGGER_EXTSTORE_WRITE,
     LOGGER_COMPACT_START,
@@ -108,6 +109,14 @@ struct logentry_item_store {
     char key[];
 };
 
+struct logentry_deletion {
+    int nbytes;
+    int cmd;
+    uint8_t nkey;
+    uint8_t clsid;
+    char key[];
+};
+
 struct logentry_conn_event {
     int transport;
     int reason;
@@ -164,6 +173,7 @@ struct _logentry {
 #define LOG_PROXYREQS  (1<<10) /* command logs from proxy */
 #define LOG_PROXYEVENTS (1<<11) /* error log stream from proxy */
 #define LOG_PROXYUSER (1<<12) /* user generated logs from proxy */
+#define LOG_DELETIONS (1<<13) /* see whats deleted */
 
 typedef struct _logger {
     struct _logger *prev;

--- a/memcached.h
+++ b/memcached.h
@@ -272,6 +272,9 @@ enum close_reasons {
 #define CAS_ALLOW_STALE true
 #define CAS_NO_STALE false
 
+#define LOG_TYPE_DELETE 1
+#define LOG_TYPE_META_DELETE 2
+
 enum store_item_type {
     NOT_STORED=0, STORED, EXISTS, NOT_FOUND, TOO_LARGE, NO_MEMORY
 };

--- a/proto_text.c
+++ b/proto_text.c
@@ -1684,6 +1684,7 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
             c->thread->stats.slab_stats[ITEM_clsid(it)].delete_hits++;
             pthread_mutex_unlock(&c->thread->stats.mutex);
 
+            LOGGER_LOG(NULL, LOG_DELETIONS, LOGGER_DELETIONS, it, LOG_TYPE_META_DELETE);
             do_item_unlink(it, hv);
             STORAGE_delete(c->thread->storage, it);
             if (c->noreply)
@@ -2176,7 +2177,7 @@ static void process_delete_command(conn *c, token_t *tokens, const size_t ntoken
         pthread_mutex_lock(&c->thread->stats.mutex);
         c->thread->stats.slab_stats[ITEM_clsid(it)].delete_hits++;
         pthread_mutex_unlock(&c->thread->stats.mutex);
-
+        LOGGER_LOG(NULL, LOG_DELETIONS, LOGGER_DELETIONS, it, LOG_TYPE_DELETE);
         do_item_unlink(it, hv);
         STORAGE_delete(c->thread->storage, it);
         do_item_remove(it);      /* release our reference */
@@ -2322,6 +2323,8 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
                 f |= LOG_PROXYEVENTS;
             } else if ((strcmp(tokens[x].value, "proxyuser") == 0)) {
                 f |= LOG_PROXYUSER;
+            } else if ((strcmp(tokens[x].value, "deletions") == 0)) {
+                f |= LOG_DELETIONS;
             } else {
                 out_string(c, "ERROR");
                 return;


### PR DESCRIPTION
This PR add supports for `watch deletions` in memcached. 
The log line will only be invoked when there's an explicit `delete` or `md` call on existing key (i.e. log won't show up on `delete_misses`)

regular evictions or expirations will also not call the logger. 

Example output on `watch deletions`:
```log
echo watch deletions | nc localhost 11211
OK
ts=1678306844.17204 gid=2 type=deleted key=1 cmd=delete clsid=1 size=1
ts=1678306863.472877 gid=3 type=deleted key=1 cmd=delete clsid=1 size=1
ts=1678306880.268208 gid=4 type=deleted key=1 cmd=md clsid=1 size=1
```