### PR TITLE
meta: N flag changes append/prepend. ms s flag.

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -726,8 +726,10 @@ The flags used by the 'ms' command are:
 - k: return key as a token
 - O(token): opaque value, consumes a token and copies back with response
 - q: use noreply semantics for return codes
+- s: return the size of the stored item on success (ie; new size on append)
 - T(token): Time-To-Live for item, see "Expiration" above.
 - M(token): mode switch to change behavior to add, replace, append, prepend
+- N(token): if in append mode, autovivify on miss with supplied TTL
 
 The flags are now repeated with detailed information where useful:
 
@@ -774,6 +776,14 @@ S: "set" command. The default mode, added for completeness.
 
 The "cas" command is supplanted by specifying the cas value with the 'C' flag.
 Append and Prepend modes will also respect a supplied cas value.
+
+- N(token): if in append mode, autovivify on miss with supplied TTL
+
+Append and Prepend modes normally ignore the T argument, as they cannot create
+a new item on a miss. If N is supplied, and append reaches a miss, it will
+create a new item seeded with the data from the append command. It uses the
+TTL from N instead of T to be consistent with the usage of N in other
+commands.
 
 Meta Delete
 -----------

--- a/logger.c
+++ b/logger.c
@@ -206,9 +206,9 @@ static int _logger_parse_ise(logentry *e, char *scratch) {
     const char * const status_map[] = {
         "not_stored", "stored", "exists", "not_found", "too_large", "no_memory" };
     const char * const cmd_map[] = {
-        "null", "add", "set", "replace", "append", "prepend", "cas" };
+        "null", "add", "set", "replace", "append", "prepend", "cas", "append", "prepend" };
 
-    if (le->cmd <= 6)
+    if (le->cmd <= 8)
         cmd = cmd_map[le->cmd];
 
     uriencode(le->key, keybuf, le->nkey, KEY_MAX_URI_ENCODED_LENGTH);

--- a/memcached.h
+++ b/memcached.h
@@ -266,6 +266,8 @@ enum close_reasons {
 #define NREAD_APPEND 4
 #define NREAD_PREPEND 5
 #define NREAD_CAS 6
+#define NREAD_APPENDVIV 7 // specific to meta
+#define NREAD_PREPENDVIV 8 // specific to meta
 
 #define CAS_ALLOW_STALE true
 #define CAS_NO_STALE false
@@ -909,7 +911,7 @@ enum delta_result_type do_add_delta(LIBEVENT_THREAD *t, const char *key,
                                     const int64_t delta, char *buf,
                                     uint64_t *cas, const uint32_t hv,
                                     item **it_ret);
-enum store_item_type do_store_item(item *item, int comm, LIBEVENT_THREAD *t, const uint32_t hv, uint64_t *cas, bool cas_stale);
+enum store_item_type do_store_item(item *item, int comm, LIBEVENT_THREAD *t, const uint32_t hv, int *nbytes, uint64_t *cas, bool cas_stale);
 void thread_io_queue_add(LIBEVENT_THREAD *t, int type, void *ctx, io_queue_stack_cb cb);
 void conn_io_queue_setup(conn *c);
 io_queue_t *conn_io_queue_get(conn *c, int type);
@@ -992,7 +994,7 @@ LIBEVENT_THREAD *get_worker_thread(int id);
 void append_stat(const char *name, ADD_STAT add_stats, conn *c,
                  const char *fmt, ...);
 
-enum store_item_type store_item(item *item, int comm, LIBEVENT_THREAD *t, uint64_t *cas, bool cas_stale);
+enum store_item_type store_item(item *item, int comm, LIBEVENT_THREAD *t, int *nbytes, uint64_t *cas, bool cas_stale);
 
 /* Protocol related code */
 void out_string(conn *c, const char *str);

--- a/proto_bin.c
+++ b/proto_bin.c
@@ -328,7 +328,7 @@ static void complete_incr_bin(conn *c, char *extbuf) {
                 memcpy(ITEM_data(it) + res, "\r\n", 2);
                 c->thread->cur_sfd = c->sfd; // for store_item logging.
 
-                if (store_item(it, NREAD_ADD, c->thread, &cas, CAS_NO_STALE)) {
+                if (store_item(it, NREAD_ADD, c->thread, NULL, &cas, CAS_NO_STALE)) {
                     c->cas = cas;
                     write_bin_response(c, &rsp->message.body, 0, 0, sizeof(rsp->message.body.value));
                 } else {
@@ -386,7 +386,7 @@ static void complete_update_bin(conn *c) {
 
     uint64_t cas = 0;
     c->thread->cur_sfd = c->sfd; // for store_item logging.
-    ret = store_item(it, c->cmd, c->thread, &cas, CAS_NO_STALE);
+    ret = store_item(it, c->cmd, c->thread, NULL, &cas, CAS_NO_STALE);
     c->cas = cas;
 
 #ifdef ENABLE_DTRACE

--- a/thread.c
+++ b/thread.c
@@ -917,13 +917,13 @@ enum delta_result_type add_delta(LIBEVENT_THREAD *t, const char *key,
 /*
  * Stores an item in the cache (high level, obeys set/add/replace semantics)
  */
-enum store_item_type store_item(item *item, int comm, LIBEVENT_THREAD *t, uint64_t *cas, bool cas_stale) {
+enum store_item_type store_item(item *item, int comm, LIBEVENT_THREAD *t, int *nbytes, uint64_t *cas, bool cas_stale) {
     enum store_item_type ret;
     uint32_t hv;
 
     hv = hash(ITEM_key(item), item->nkey);
     item_lock(hv);
-    ret = do_store_item(item, comm, t, hv, cas, cas_stale);
+    ret = do_store_item(item, comm, t, hv, nbytes, cas, cas_stale);
     item_unlock(hv);
     return ret;
 }


### PR DESCRIPTION
Sending 's' flag to metaset now returns the size of the item stored. Useful if you want to know how large an append/prepended item now is.

If the 'N' flag is supplied while in append/prepend mode, allows autovivifying (with exptime supplied from N) for append/prepend style keys that don't need headers created first.

These flags all pre-existed and their meanings are re-used. So fancy.

TODO:
- [x] Code self-review after day delay
- [ ] doc/protocol.txt updates