### PR TITLE
check for sys/auxv.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -556,6 +556,7 @@ AH_BOTTOM([#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
 ])
+AC_CHECK_HEADERS([sys/auxv.h])
 
 dnl **********************************************************************
 dnl Figure out if this system has the stupid sasl_callback_ft

--- a/crc32c.c
+++ b/crc32c.c
@@ -274,7 +274,7 @@ void crc32c_init(void) {
 }
 
 #elif defined(__aarch64__) && (defined(__linux__) || defined(__APPLE__))
-#if defined(__linux__)
+#if defined(__linux__) && defined(HAVE_SYS_AUX_H)
 #include <sys/auxv.h>
 #elif defined(__APPLE__)
 #include <sys/sysctl.h>


### PR DESCRIPTION
Check for `sys/auxv.h` to avoid the following uclibc build failure on aarch64:

```
crc32c.c:277:10: fatal error: sys/auxv.h: No such file or directory
  277 | #include <sys/auxv.h>
      |          ^~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/08591fbf9677ff126492c50c15170c641bcab56a