### PR TITLE
proxy: overhaul backend error handling

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -595,7 +595,7 @@ int proxy_run_coroutine(lua_State *Lc, mc_resp *resp, io_pending_proxy_t *p, con
         if (type == LUA_TUSERDATA) {
             mcp_resp_t *r = luaL_checkudata(Lc, 1, "mcp.response");
             _set_noreply_mode(resp, r);
-            if (r->status != MCMC_OK) {
+            if (r->status != MCMC_OK && r->resp.type != MCMC_RESP_ERRMSG) {
                 proxy_out_errstring(resp, "backend failure");
             } else if (r->cresp) {
                 mc_resp *tresp = r->cresp;

--- a/proxy.h
+++ b/proxy.h
@@ -251,6 +251,7 @@ enum mcp_backend_states {
     mcp_backend_read_end, // looking for an "END" marker for GET
     mcp_backend_want_read, // read more data to complete command
     mcp_backend_next, // advance to the next IO
+    mcp_backend_next_close, // complete current request, then close socket
 };
 
 typedef struct mcp_backend_wrap_s mcp_backend_wrap_t;

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1176,6 +1176,10 @@ static void proxy_register_defines(lua_State *L) {
     X(MCMC_CODE_OK);
     X(MCMC_CODE_NOP);
     X(MCMC_CODE_END);
+    X(MCMC_CODE_ERROR);
+    X(MCMC_CODE_CLIENT_ERROR);
+    X(MCMC_CODE_SERVER_ERROR);
+    X(MCMC_ERR);
     X(P_OK);
     X(CMD_ANY);
     X(CMD_ANY_STORAGE);

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -17,6 +17,7 @@ enum proxy_be_failures {
     P_BE_FAIL_OOM,
     P_BE_FAIL_ENDSYNC,
     P_BE_FAIL_TRAILINGDATA,
+    P_BE_FAIL_INVALIDPROTOCOL,
 };
 
 const char *proxy_be_failure_text[] = {
@@ -33,6 +34,7 @@ const char *proxy_be_failure_text[] = {
     [P_BE_FAIL_OOM] = "outofmemory",
     [P_BE_FAIL_ENDSYNC] = "missingend",
     [P_BE_FAIL_TRAILINGDATA] = "trailingdata",
+    [P_BE_FAIL_INVALIDPROTOCOL] = "invalidprotocol",
     NULL
 };
 
@@ -954,19 +956,31 @@ static void _stop_timeout_event(mcp_backend_t *be) {
     event_del(&be->timeout_event);
 }
 
+static void _drive_machine_next(mcp_backend_t *be, io_pending_proxy_t *p) {
+    struct timeval end;
+    // set the head here. when we break the head will be correct.
+    STAILQ_REMOVE_HEAD(&be->io_head, io_next);
+    be->depth--;
+    be->pending_read--;
+
+    // stamp the elapsed time into the response object.
+    gettimeofday(&end, NULL);
+    p->client_resp->elapsed = (end.tv_sec - p->client_resp->start.tv_sec) * 1000000 +
+        (end.tv_usec - p->client_resp->start.tv_usec);
+
+    // have to do the q->count-- and == 0 and redispatch_conn()
+    // stuff here. The moment we call return_io here we
+    // don't own *p anymore.
+    return_io_pending((io_pending_t *)p);
+    be->state = mcp_backend_read;
+}
+
 // NOTES:
 // - mcp_backend_read: grab req_stack_head, do things
 // read -> next, want_read -> next | read_end, etc.
-// issue: want read back to read_end as necessary. special state?
-//   - it's fine: p->client_resp->type.
-// - mcp_backend_next: advance, consume, etc.
-// TODO (v2): second argument with enum for a specific error.
-// - probably just for logging. for app if any of these errors shouldn't
-// result in killing the request stack!
 static int proxy_backend_drive_machine(mcp_backend_t *be) {
     bool stop = false;
     io_pending_proxy_t *p = NULL;
-    struct timeval end;
     int flags = 0;
 
     p = STAILQ_FIRST(&be->io_head);
@@ -995,30 +1009,38 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
             r = p->client_resp;
             r->status = mcmc_parse_buf(be->client, be->rbuf, be->rbufused, &r->resp);
 
-            if (r->status == MCMC_ERR) {
-                P_DEBUG("%s: mcmc_read failed [%d]\n", __func__, r->status);
-                if (r->resp.code == MCMC_WANT_READ) {
-                    return 0;
-                }
-                flags = P_BE_FAIL_PARSING;
-                stop = true;
-                break;
+            // Quick check if we need more data.
+            if (r->resp.code == MCMC_WANT_READ) {
+                return 0;
             }
 
             // we actually don't care about anything but the value length
             // TODO (v2): if vlen != vlen_read, pull an item and copy the data.
             int extra_space = 0;
+            // if all goes well, move to the next request.
+            be->state = mcp_backend_next;
             switch (r->resp.type) {
                 case MCMC_RESP_GET:
                     // We're in GET mode. we only support one key per
                     // GET in the proxy backends, so we need to later check
                     // for an END.
                     extra_space = ENDLEN;
+                    be->state = mcp_backend_read_end;
                     break;
                 case MCMC_RESP_END:
                     // this is a MISS from a GET request
                     // or final handler from a STAT request.
                     assert(r->resp.vlen == 0);
+                    if (p->ascii_multiget) {
+                        // Ascii multiget hack mode; consume END's
+                        be->rbufused -= r->resp.reslen;
+                        if (be->rbufused > 0) {
+                            memmove(be->rbuf, be->rbuf+r->resp.reslen, be->rbufused);
+                        }
+
+                        be->state = mcp_backend_next;
+                        continue;
+                    }
                     break;
                 case MCMC_RESP_META:
                     // we can handle meta responses easily since they're self
@@ -1027,6 +1049,18 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
                 case MCMC_RESP_GENERIC:
                 case MCMC_RESP_NUMERIC:
                     break;
+                case MCMC_RESP_ERRMSG: // received an error message
+                    if (r->resp.code != MCMC_CODE_SERVER_ERROR) {
+                        // Non server errors are protocol errors; can't trust
+                        // the connection anymore.
+                        be->state = mcp_backend_next_close;
+                    }
+                    break;
+                case MCMC_RESP_FAIL:
+                    P_DEBUG("%s: mcmc_read failed [%d]\n", __func__, r->status);
+                    flags = P_BE_FAIL_PARSING;
+                    stop = true;
+                    break;
                 // TODO (v2): No-op response?
                 default:
                     P_DEBUG("%s: Unhandled response from backend: %d\n", __func__, r->resp.type);
@@ -1034,17 +1068,6 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
                     flags = P_BE_FAIL_UNHANDLEDRES;
                     stop = true;
                     break;
-            }
-
-            if (p->ascii_multiget && r->resp.type == MCMC_RESP_END) {
-                // Ascii multiget hack mode; consume END's
-                be->rbufused -= r->resp.reslen;
-                if (be->rbufused > 0) {
-                    memmove(be->rbuf, be->rbuf+r->resp.reslen, be->rbufused);
-                }
-
-                be->state = mcp_backend_next;
-                break;
             }
 
             // r->resp.reslen + r->resp.vlen is the total length of the response.
@@ -1097,12 +1120,6 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
             be->rbufused -= r->resp.reslen + r->resp.vlen_read;
             if (be->rbufused > 0) {
                 memmove(be->rbuf, be->rbuf+r->resp.reslen+r->resp.vlen_read, be->rbufused);
-            }
-
-            if (r->resp.type == MCMC_RESP_GET) {
-                be->state = mcp_backend_read_end;
-            } else {
-                be->state = mcp_backend_next;
             }
 
             break;
@@ -1176,21 +1193,7 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
 
             break;
         case mcp_backend_next:
-            // set the head here. when we break the head will be correct.
-            STAILQ_REMOVE_HEAD(&be->io_head, io_next);
-            be->depth--;
-            be->pending_read--;
-
-            // stamp the elapsed time into the response object.
-            gettimeofday(&end, NULL);
-            p->client_resp->elapsed = (end.tv_sec - p->client_resp->start.tv_sec) * 1000000 +
-                (end.tv_usec - p->client_resp->start.tv_usec);
-
-            // have to do the q->count-- and == 0 and redispatch_conn()
-            // stuff here. The moment we call return_io here we
-            // don't own *p anymore.
-            return_io_pending((io_pending_t *)p);
-            be->state = mcp_backend_read;
+            _drive_machine_next(be, p);
 
             if (STAILQ_EMPTY(&be->io_head)) {
                 stop = true;
@@ -1216,6 +1219,13 @@ static int proxy_backend_drive_machine(mcp_backend_t *be) {
                 // need to read more data, buffer is empty.
                 stop = true;
             }
+
+            break;
+        case mcp_backend_next_close:
+            // we advance and return the current IO, then kill the conn.
+            _drive_machine_next(be, p);
+            stop = true;
+            flags = P_BE_FAIL_INVALIDPROTOCOL;
 
             break;
         default:
@@ -1296,6 +1306,7 @@ static void _backend_failed(mcp_backend_t *be) {
 // _must_ be called from within the event thread.
 static int _reset_bad_backend(mcp_backend_t *be, enum proxy_be_failures err) {
     io_pending_proxy_t *io = NULL;
+    P_DEBUG("%s: resetting bad backend: %s\n", __func__, proxy_be_failure_text[err]);
     // Can't use STAILQ_FOREACH() since return_io_pending() free's the current
     // io. STAILQ_FOREACH_SAFE maybe?
     int depth = be->depth;

--- a/t/proxyunits.lua
+++ b/t/proxyunits.lua
@@ -89,6 +89,22 @@ function mcp_config_routes(zones)
     pfx_md["b"] = basic
     pfx_ma["b"] = basic
 
+    pfx_get["errcheck"] = function(r)
+        local res = zones.z1(r)
+        -- expect an error
+        if res:ok() then
+            return "FAIL\r\n"
+        end
+        if res:code() == mcp.MCMC_CODE_ERROR then
+            return "ERROR\r\n"
+        elseif res:code() == mcp.MCMC_CODE_CLIENT_ERROR then
+            return "CLIENT_ERROR\r\n"
+        elseif res:code() == mcp.MCMC_CODE_SERVER_ERROR then
+            return "SERVER_ERROR\r\n"
+        end
+        return "FAIL"
+    end
+
     -- show that we fetched the key by generating our own response string.
     pfx_get["getkey"] = function(r)
         return "VALUE |" .. r:key() .. " 0 2\r\nts\r\nEND\r\n"

--- a/vendor/mcmc/mcmc.c
+++ b/vendor/mcmc/mcmc.c
@@ -115,6 +115,33 @@ static int _mcmc_parse_value_line(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
     return MCMC_CODE_OK;
 }
 
+static int _mcmc_parse_stat_line(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
+    char *buf = ctx->buffer_head;
+    char *p = buf+5; // pass "STAT "
+    size_t l = ctx->buffer_request_len;
+
+    // STAT key value
+    char *sname = p;
+    p = memchr(p, ' ', l-5);
+    if (p == NULL) {
+        return -MCMC_ERR_VALUE;
+    }
+
+    int snamelen = p - sname;
+    while (*p == ' ') {
+        p++;
+    }
+    char *stat = p;
+    int statlen = l - (p - ctx->buffer_head) - 2;
+
+    r->sname = sname;
+    r->snamelen = snamelen;
+    r->stat = stat;
+    r->statlen = statlen;
+
+    return MCMC_CODE_OK;
+}
+
 // FIXME: This is broken for ASCII multiget.
 // if we get VALUE back, we need to stay in ASCII GET read mode until an END
 // is seen.
@@ -125,7 +152,7 @@ static int _mcmc_parse_response(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
     int rlen; // response code length.
     int more = 0;
     r->reslen = ctx->buffer_request_len;
-    r->type = MCMC_RESP_GENERIC;
+    r->type = MCMC_RESP_FAIL;
 
     // walk until the \r\n
     while (l-- > 2) {
@@ -213,6 +240,7 @@ static int _mcmc_parse_response(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
                         char *n = NULL;
                         uint32_t vsize = strtoul(cur, &n, 10);
                         if ((errno == ERANGE) || (cur == n)) {
+                            r->type = MCMC_RESP_FAIL;
                             code = -MCMC_ERR_PARSE;
                         } else {
                             r->vlen = vsize + 2; // tag in the \r\n.
@@ -230,6 +258,7 @@ static int _mcmc_parse_response(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
                             code = MCMC_CODE_OK;
                         }
                     } else {
+                        r->type = MCMC_RESP_FAIL;
                         code = -MCMC_ERR_PARSE;
                     }
                 }
@@ -257,7 +286,7 @@ static int _mcmc_parse_response(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
             if (memcmp(buf, "STAT", 4) == 0) {
                 r->type = MCMC_RESP_STAT;
                 ctx->state = STATE_STAT_RESP;
-                // TODO: initialize stat reader mode.
+                code = _mcmc_parse_stat_line(ctx, r);
             }
             break;
         case 5:
@@ -268,20 +297,27 @@ static int _mcmc_parse_response(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
                 } else {
                     code = -MCMC_ERR_PARSE;
                 }
+            } else if (memcmp(buf, "ERROR", 5) == 0) {
+                r->type = MCMC_RESP_ERRMSG;
+                code = -MCMC_CODE_ERROR;
             }
             break;
         case 6:
             if (memcmp(buf, "STORED", 6) == 0) {
+                r->type = MCMC_RESP_GENERIC;
                 code = MCMC_CODE_STORED;
             } else if (memcmp(buf, "EXISTS", 6) == 0) {
+                r->type = MCMC_RESP_GENERIC;
                 code = MCMC_CODE_EXISTS;
                 // TODO: type -> ASCII?
             }
             break;
         case 7:
             if (memcmp(buf, "DELETED", 7) == 0) {
+                r->type = MCMC_RESP_GENERIC;
                 code = MCMC_CODE_DELETED;
             } else if (memcmp(buf, "TOUCHED", 7) == 0) {
+                r->type = MCMC_RESP_GENERIC;
                 code = MCMC_CODE_TOUCHED;
             } else if (memcmp(buf, "VERSION", 7) == 0) {
                 code = MCMC_CODE_VERSION;
@@ -291,16 +327,25 @@ static int _mcmc_parse_response(mcmc_ctx_t *ctx, mcmc_resp_t *r) {
             break;
         case 9:
             if (memcmp(buf, "NOT_FOUND", 9) == 0) {
+                r->type = MCMC_RESP_GENERIC;
                 code = MCMC_CODE_NOT_FOUND;
             }
             break;
         case 10:
             if (memcmp(buf, "NOT_STORED", 10) == 0) {
+                r->type = MCMC_RESP_GENERIC;
                 code = MCMC_CODE_NOT_STORED;
             }
             break;
         default:
             // Unknown code, assume error.
+            if (memcmp(buf, "SERVER_ERROR", 12) == 0) {
+                r->type = MCMC_RESP_ERRMSG;
+                code = -MCMC_CODE_SERVER_ERROR;
+            } else if (memcmp(buf, "CLIENT_ERROR", 12) == 0) {
+                r->type = MCMC_RESP_ERRMSG;
+                code = -MCMC_CODE_CLIENT_ERROR;
+            }
             break;
     }
 

--- a/vendor/mcmc/mcmc.h
+++ b/vendor/mcmc/mcmc.h
@@ -27,6 +27,9 @@
 #define MCMC_ERR_SHORT 18
 #define MCMC_ERR_PARSE 19
 #define MCMC_ERR_VALUE 20
+#define MCMC_CODE_ERROR 21
+#define MCMC_CODE_CLIENT_ERROR 22
+#define MCMC_CODE_SERVER_ERROR 23
 
 // response types
 #define MCMC_RESP_GET 100
@@ -36,6 +39,8 @@
 #define MCMC_RESP_END 105
 #define MCMC_RESP_VERSION 106
 #define MCMC_RESP_NUMERIC 107 // for weird incr/decr syntax.
+#define MCMC_RESP_ERRMSG 108 // ERROR, CLIENT_ERROR, SERVER_ERRROR
+#define MCMC_RESP_FAIL 109 // Complete failure to parse, garbage, etc
 
 #define MCMC_OPTION_BLANK 0
 #define MCMC_OPTION_NONBLOCK 1
@@ -69,8 +74,10 @@ typedef struct {
         };
         // STAT response
         struct {
+            char *sname;
+            size_t snamelen;
             char *stat;
-            size_t slen;
+            size_t statlen;
         };
     };
 } mcmc_resp_t;


### PR DESCRIPTION
Cleans up logic around response handling in general. Allows returning
server-sent error messages upstream for handling.

In general SERVER_ERROR means we can keep the connection to the backend.
The rest of the errors are protocol errors, and while some are perfectly
safe to whitelist, clients should not be causing those sorts of errors
and we should cycle the backend regardless.

TODO:
- [x] Could use a few more tests; ensure pipelined commands don't send responses, and that garbage gives garbage errors.
- [x] Tests around the lua API; ensure :ok() fails for an error and :code() works right. It should function the same as an error, it just doesn't blow away the response data further up the chain.
- [x] Self code review. Feels like I'm missing something but it just took a lot of thinking to clean it all up.

At some point I'll either merge code/resp in mcmc or figure out some better way of representing that data, as they do overlap.