### PR TITLE
proxy: fix reversal of pipelined backend queries

### DIFF
--- a/t/proxyunits.t
+++ b/t/proxyunits.t
@@ -343,19 +343,15 @@ check_version($ps);
     my $be = $mbe[0];
     my $cmd = "get /b/a /b/b /b/c\r\n";
     print $ps $cmd;
-    # NOTE: the proxy ends up reversing the keys to the backend, but returns keys in the
-    # proper order. This is undesireable but not problematic: because of how
-    # ascii multiget syntax works the server cannot start responding until all
-    # answers are resolved anyway.
-    is(scalar <$be>, "get /b/c\r\n", "multiget breakdown c");
-    is(scalar <$be>, "get /b/b\r\n", "multiget breakdown b");
     is(scalar <$be>, "get /b/a\r\n", "multiget breakdown a");
+    is(scalar <$be>, "get /b/b\r\n", "multiget breakdown b");
+    is(scalar <$be>, "get /b/c\r\n", "multiget breakdown c");
 
-    print $be "VALUE /b/c 0 1\r\nc\r\n",
+    print $be "VALUE /b/a 0 1\r\na\r\n",
               "END\r\n",
               "VALUE /b/b 0 1\r\nb\r\n",
               "END\r\n",
-              "VALUE /b/a 0 1\r\na\r\n",
+              "VALUE /b/c 0 1\r\nc\r\n",
               "END\r\n";
 
     for my $key ('a', 'b', 'c') {
@@ -366,9 +362,9 @@ check_version($ps);
 
     # Test multiget workaround with misses (known bug)
     print $ps $cmd;
-    is(scalar <$be>, "get /b/c\r\n", "multiget breakdown c");
-    is(scalar <$be>, "get /b/b\r\n", "multiget breakdown b");
     is(scalar <$be>, "get /b/a\r\n", "multiget breakdown a");
+    is(scalar <$be>, "get /b/b\r\n", "multiget breakdown b");
+    is(scalar <$be>, "get /b/c\r\n", "multiget breakdown c");
 
     print $be "END\r\nEND\r\nEND\r\n";
     is(scalar <$ps>, "END\r\n", "final END from multiget");


### PR DESCRIPTION
If a client sends multiple requests in the same packet, the proxy would reverse the requests before sending them to the backend. They would return to client in the correct order because top level responses are sent in the order they were created.

In practice I guess this is rarely noticed. If a client sends a series of commands where the first one generates a syntax error, all prior commands would still succeed.

It would also trip people up if they test pipelining commands as read-your-write would fail as the write gets ordered after the read.

Did run into this before, but I thought it was just the ascii multiget code reversing keys, which would be harmless as the whole command has to complete regardless of key order.

---
I'm creating a PR for this but it will be short lived, so there can be discussion or references here if desired.

So far as I can tell fixing this shouldn't _break_ anything. I discovered it while testing pipelined errors in a different commit.