### PR TITLE
[docker] Add debian, upgrade autoconf Ubuntu dependency

### DIFF
--- a/devtools/Dockerfile.debian
+++ b/devtools/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM debian:latest
 
 ARG CONFIGURE_OPTS="--enable-seccomp"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@ services:
         build:
             context: .
             dockerfile: devtools/Dockerfile.ubuntu
+    debian:
+        build:
+            context: .
+            dockerfile: devtools/Dockerfile.debian
     arch:
         build:
             context: .


### PR DESCRIPTION
Hello memcached!

Following my previous docker maintenance work (#988), here is another small docker PR.

This one is two-fold:

1) Add a new Debian dockerfile. (perhaps not needed yet, as maintainers are running Debian already?). I do not know which distributions memcached focuses on, but with this file in place without much effort, the Debian people out there might be happier. 

2) Use latest `automake` dependency to build and test ubuntu and debian images. From git history, I understand that v1.11 was verison locked back in 2018 with the initial push for the Ubuntu dockerfile. From what I can tell, the current automake version is 1.16.x.