### PR TITLE
proxy: easier usage of N sockets per backend

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -268,7 +268,6 @@ void proxy_submit_cb(io_queue_t *q) {
             be->depth++;
             if (!be->stacked) {
                 be->stacked = true;
-                be->be_next.stqe_next = NULL; // paranoia
                 STAILQ_INSERT_TAIL(&w_head, be, be_next);
             }
         }

--- a/t/proxyconfig.lua
+++ b/t/proxyconfig.lua
@@ -39,6 +39,13 @@ function mcp_config_pools(old)
             test = mcp.pool({b1, b2, b3}, { iothread = false })
         }
         return pools
+    elseif mode == "connections" then
+        local b1 = mcp.backend({ label = "b1c", host = "127.0.0.1", port = 11511,
+                               connections = 3})
+        local pools = {
+            test = mcp.pool({b1})
+        }
+        return pools
     end
 end
 

--- a/t/proxyunits.t
+++ b/t/proxyunits.t
@@ -153,6 +153,15 @@ sub proxy_test {
     }
 }
 
+{
+    note("Test dead backend");
+    my $start = int(time());
+    print $ps "get /dead/foo\r\n";
+    is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "Backend failed");
+    my $end = int(time());
+    cmp_ok($end - $start, '<', 3, "backend failed immediately");
+}
+
 # Basic test with a backend; write a request to the client socket, read it
 # from a backend socket, and write a response to the backend socket.
 #


### PR DESCRIPTION
mcp.backend({ etc, connections = N })

allow creating N tcp sockets for this described backend.

when a request is matched against a pool to retrieve a backend, a container object is pulled:
- the container object holds all tcp sockets
- a tcp socket is selected from the container just before the request is executed
- otherwise all execution is identical to the previous code.

Changing the connection count does not interfere with key distribution within a pool.

TODO:
- [x] specific tests. the test suite does pass as-is, so single connection counts seem to work fine.
- [x] move the connection selection logic to re-enable work batching
- [x] simplify the selection logic
- [x] remove second bad backend checker in backend_run code.
- [x] limit total number of sockets per backend to 8-12? more is unlikely to be helpful to anyone.
- [x] some benchmark testing to ensure no major regressions.

This also deduplicates a little code. Since most related code doesn't change this should be simple to verify.

@feihu-stripe - probably of interest.