### PR TITLE
proxy: fix bug ignoring -R setting for proxy reqs

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -862,6 +862,8 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
 
         conn_set_state(c, conn_nread);
         return;
+    } else {
+        conn_set_state(c, conn_new_cmd);
     }
 
     proxy_run_coroutine(Lc, c->resp, NULL, c);


### PR DESCRIPTION
The client connection state machine loops through a few states when handling pipelined requests.

To start:
conn_waiting -> conn_read -> conn_parse_cmd (execution)

After conn_parse_cmd, we can enter:
conn_nread (read a mutation payload from the network) -> conn_new_cmd or directly: conn_new_cmd

conn_new_cmd checks the limit specified in -R, flushing the pipeline if we exceed that limit. Else it wraps back to conn_parse_cmd

The proxy code was _not_ resetting state to conn_new_cmd after any non-mutation command. If a value was set it would properly run through nread -> conn_new_cmd

This means that clients issuing requests against a proxy server have unlimited pipelines, and the proxy will buffer the entire result set before beginning to return data to the client. Especially if requests are for very large items, this can cause a very high Time To First Byte in the response to the client.