### PR TITLE
#1792  Centralized the use of pthread_create and thread_setname in the create_thread_with_name function that uses thread_wrapper for compatibility across platforms and with Linux GLIBC<2.12

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -275,12 +275,11 @@ int start_assoc_maintenance_thread(void) {
         }
     }
 
-    if ((ret = pthread_create(&maintenance_tid, NULL,
-                              assoc_maintenance_thread, NULL)) != 0) {
+    if ((ret = create_thread_with_name(&maintenance_tid, "mc-assocmaint", NULL, assoc_maintenance_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create thread: %s\n", strerror(ret));
         return -1;
     }
-    thread_setname(maintenance_tid, "mc-assocmaint");
+
     return 0;
 }
 

--- a/crawler.c
+++ b/crawler.c
@@ -636,14 +636,12 @@ int start_item_crawler_thread(void) {
         return -1;
     pthread_mutex_lock(&lru_crawler_lock);
     do_run_lru_crawler_thread = 1;
-    if ((ret = pthread_create(&item_crawler_tid, NULL,
-        item_crawler_thread, NULL)) != 0) {
+    if ((ret = create_thread_with_name(&item_crawler_tid, "mc-itemcrawler", NULL, item_crawler_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create LRU crawler thread: %s\n",
             strerror(ret));
         pthread_mutex_unlock(&lru_crawler_lock);
         return -1;
     }
-    thread_setname(item_crawler_tid, "mc-itemcrawler");
     /* Avoid returning until the crawler has actually started */
     pthread_cond_wait(&lru_crawler_cond, &lru_crawler_lock);
     pthread_mutex_unlock(&lru_crawler_lock);

--- a/items.c
+++ b/items.c
@@ -1722,14 +1722,12 @@ int start_lru_maintainer_thread(void *arg) {
     pthread_mutex_lock(&lru_maintainer_lock);
     do_run_lru_maintainer_thread = 1;
     settings.lru_maintainer_thread = true;
-    if ((ret = pthread_create(&lru_maintainer_tid, NULL,
-        lru_maintainer_thread, arg)) != 0) {
+    if ((ret = create_thread_with_name(&lru_maintainer_tid, "mc-lrumaint", NULL, lru_maintainer_thread, arg)) != 0) {
         fprintf(stderr, "Can't create LRU maintainer thread: %s\n",
             strerror(ret));
         pthread_mutex_unlock(&lru_maintainer_lock);
         return -1;
     }
-    thread_setname(lru_maintainer_tid, "mc-lrumaint");
     pthread_mutex_unlock(&lru_maintainer_lock);
 
     return 0;

--- a/logger.c
+++ b/logger.c
@@ -880,12 +880,11 @@ static void *logger_thread(void *arg) {
 static int start_logger_thread(void) {
     int ret;
     do_run_logger_thread = 1;
-    if ((ret = pthread_create(&logger_tid, NULL,
-                              logger_thread, NULL)) != 0) {
+    if ((ret = create_thread_with_name(&logger_tid, "mc-log", NULL, logger_thread, NULL)) != 0) {
         fprintf(stderr, "Can't start logger thread: %s\n", strerror(ret));
         return -1;
     }
-    thread_setname(logger_tid, "mc-log");
+
     return 0;
 }
 

--- a/memcached.c
+++ b/memcached.c
@@ -381,13 +381,11 @@ static int start_conn_timeout_thread(void) {
         return -1;
 
     do_run_conn_timeout_thread = 1;
-    if ((ret = pthread_create(&conn_timeout_tid, NULL,
-        conn_timeout_thread, NULL)) != 0) {
+    if ((ret = create_thread_with_name(&conn_timeout_tid, "mc-idletimeout", NULL, conn_timeout_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create idle connection timeout thread: %s\n",
             strerror(ret));
         return -1;
     }
-    thread_setname(conn_timeout_tid, "mc-idletimeout");
 
     return 0;
 }

--- a/memcached.h
+++ b/memcached.h
@@ -985,7 +985,7 @@ void STATS_UNLOCK(void);
 void threadlocal_stats_reset(void);
 void threadlocal_stats_aggregate(struct thread_stats *stats);
 void slab_stats_aggregate(struct thread_stats *stats, struct slab_stats *out);
-void thread_setname(pthread_t thread, const char *name);
+int create_thread_with_name(pthread_t *thread, const char *name, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);
 LIBEVENT_THREAD *get_worker_thread(int id);
 
 /* Stat processing functions */

--- a/slabs.c
+++ b/slabs.c
@@ -1321,12 +1321,11 @@ int start_slab_maintenance_thread(void) {
     slab_rebalance_signal = 0;
     slab_rebal.slab_start = NULL;
 
-    if ((ret = pthread_create(&rebalance_tid, NULL,
-                              slab_rebalance_thread, NULL)) != 0) {
+    if ((ret = create_thread_with_name(&rebalance_tid, "mc-slabmaint", NULL, slab_rebalance_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create rebal thread: %s\n", strerror(ret));
         return -1;
     }
-    thread_setname(rebalance_tid, "mc-slabmaint");
+
     return 0;
 }
 

--- a/storage.c
+++ b/storage.c
@@ -683,13 +683,11 @@ int start_storage_write_thread(void *arg) {
     int ret;
 
     pthread_mutex_init(&storage_write_plock, NULL);
-    if ((ret = pthread_create(&storage_write_tid, NULL,
-        storage_write_thread, arg)) != 0) {
+    if ((ret = create_thread_with_name(&storage_write_tid, "mc-ext-write", NULL, storage_write_thread, arg)) != 0) {
         fprintf(stderr, "Can't create storage_write thread: %s\n",
             strerror(ret));
         return -1;
     }
-    thread_setname(storage_write_tid, "mc-ext-write");
 
     return 0;
 }
@@ -1017,13 +1015,11 @@ int start_storage_compact_thread(void *arg) {
     int ret;
 
     pthread_mutex_init(&storage_compact_plock, NULL);
-    if ((ret = pthread_create(&storage_compact_tid, NULL,
-        storage_compact_thread, arg)) != 0) {
+    if ((ret = create_thread_with_name(&storage_compact_tid, "mc-ext-compact", NULL, storage_compact_thread, arg)) != 0) {
         fprintf(stderr, "Can't create storage_compact thread: %s\n",
             strerror(ret));
         return -1;
     }
-    thread_setname(storage_compact_tid, "mc-ext-compact");
 
     return 0;
 }


### PR DESCRIPTION
- Adjusted the thread_setname function for compatibility across platforms and with Linux GLIBC<2.12;
- Centralized the use of pthread_create and thread_setname in the create_thread_with_name function that uses thread_wrapper for compatibility;