### PR TITLE
proxy: add check_sanity() to check proxy and backends at boarder sections.

### DIFF
--- a/t/proxyunits.lua
+++ b/t/proxyunits.lua
@@ -275,6 +275,11 @@ function mcp_config_routes(zones)
         return good_res
     end
 
+    pfx_touch["sanity"] = function(r)
+        local rtable = mcp.await(r, { zones.z1, zones.z2, zones.z3 })
+        return rtable[3]
+    end
+
     mcp.attach(mcp.CMD_GET, toproute_factory(pfx_get, "get"))
     mcp.attach(mcp.CMD_SET, toproute_factory(pfx_set, "set"))
     mcp.attach(mcp.CMD_TOUCH, toproute_factory(pfx_touch, "touch"))


### PR DESCRIPTION
Migrate check_version() to check_sanity() to make sure both proxy and backends buffers are clean between tests.

Found and fixed a bug where a backend was accidentally killed without reconnection.