### PR TITLE
proxy: print info of test groups in proxyunits.t.

### DIFF
--- a/t/proxyunits.t
+++ b/t/proxyunits.t
@@ -41,6 +41,8 @@ sub accept_backend {
     return $be;
 }
 
+note("Initialization:" . __LINE__);
+
 my @mocksrvs = ();
 #diag "making mock servers";
 for my $port (11411, 11412, 11413) {
@@ -99,6 +101,8 @@ sub check_sanity {
 # In this case the client will receive an error and the backend gets closed,
 # so we have to re-establish it.
 {
+    note("Test missing END:" . __LINE__);
+
     # Test a fix for passing through partial read data if END ends up missing.
     print $ps "get /b/a\r\n";
     my $be = $mbe[0];
@@ -114,6 +118,8 @@ sub check_sanity {
 # This test is similar to the above one, except we also establish a watcher to
 # check for appropriate log entries.
 {
+    note("Test trailingdata:" . __LINE__);
+
     # Test a log line with detailed data from backend failures.
     my $be = $mbe[0];
     my $w = $p_srv->new_sock;
@@ -133,6 +139,8 @@ sub check_sanity {
 
     $mbe[0] = accept_backend($mocksrvs[0]);
 }
+
+note("Test bugfix for missingend:" . __LINE__);
 
 # This is an example of a test which will only pass before a bugfix is issued.
 # It's good practice where possible to write a failing test, then check it
@@ -193,6 +201,8 @@ SKIP: {
 # Should test all command types.
 # uses /b/ path for "basic"
 {
+    note("Test all commands to a single backend:" . __LINE__);
+
     # Test invalid route.
     print $ps "set /invalid/a 0 0 2\r\nhi\r\n";
     is(scalar <$ps>, "SERVER_ERROR no set route\r\n");
@@ -363,6 +373,8 @@ SKIP: {
 check_sanity($ps);
 
 {
+    note("Test multiget:" . __LINE__);
+
     # multiget syntax
     # - gets broken into individual gets on backend
     my $be = $mbe[0];
@@ -404,6 +416,8 @@ check_sanity($ps);
 check_sanity($ps);
 
 {
+    note("Test noreply:" . __LINE__);
+
     # noreply tests.
     # - backend should receive with noreply/q stripped or mangled
     # - backend should reply as normal
@@ -434,6 +448,8 @@ check_sanity($ps);
 
 # Test Lua request API
 {
+    note("Test Lua request APIs:" . __LINE__);
+
     my $be = $mbe[0];
 
     # fetching the key.
@@ -490,6 +506,8 @@ check_sanity($ps);
 
 # Test requests land in proper backend in basic scenarios
 {
+    note("Test routing by zone:" . __LINE__);
+
     # TODO: maybe should send values to ensure the right response?
     # I don't think this test is very useful though; probably better to try
     # harder when testing error conditions.
@@ -517,6 +535,8 @@ check_sanity($ps);
 
 # Test Lua logging (see t/watcher.t)
 {
+    note("Test Lua logging:" . __LINE__);
+
     my $be = $mbe[0];
     my $watcher = $p_srv->new_sock;
     print $watcher "watch proxyuser proxyreqs\n";
@@ -550,6 +570,8 @@ check_sanity($ps);
 # regardless of the mode.
 # need some tests that show this.
 {
+    note("Test await argument:" . __LINE__);
+
     my $cmd;
     # await(r, p)
     # this should hit all three backends
@@ -712,6 +734,8 @@ check_sanity($ps);
 check_sanity($ps);
 
 {
+    note("Test await_logerrors:" . __LINE__);
+
     my $watcher = $p_srv->new_sock;
     print $watcher "watch proxyreqs\n";
     is(<$watcher>, "OK\r\n", "watcher enabled");
@@ -757,6 +781,8 @@ check_sanity($ps);
 # - certain errors pass through to the client, most close the backend.
 # - should be able to retrieve the error message
 {
+    note("Test error/garbage from backend:" . __LINE__);
+
     my $be = $mbe[0];
     print $ps "set /b/foo 0 0 2\r\nhi\r\n";
     is(scalar <$be>, "set /b/foo 0 0 2\r\n", "received set cmd");


### PR DESCRIPTION
Should improve on readability of test output by separating test group out with line numbers.

In the future, as we add more tests, should split into individual files based on functionality.

```
t/proxyunits.t ..
# Initialization:44
ok 1 - mock server created
ok 2 - mock server created
ok 3 - mock server created
ok 4 - mock backend created
ok 5 - received version command
ok 6 - mock backend created
ok 7 - received version command
ok 8 - mock backend created
ok 9 - received version command
ok 10 - got CLIENT_ERROR for bad syntax
# Test missing END:104
ok 11 - get passthrough
ok 12 - backend failure error
ok 13 - mock backend created
ok 14 - received version command
# Test trailingdata:121
ok 15 - watcher enabled
ok 16 - get passthrough
ok 17 - got value back
ok 18 - got data back
ok 19 - got end string
ok 20 - got backend error log line
ok 21 - mock backend created
ok 22 - received version command
# Test bugfix for missingend:142
ok 23 # skip Remove this skip line to demonstrate pre-patch bug
ok 24 - get passthrough
ok 25 - got value back
ok 26 - got data back
ok 27 - got end string
# Test all commands to a single backend:202
ok 28
ok 29 - set passthrough
ok 30 - set value
ok 31 - got STORED from set
ok 32 - get passthrough
ok 33 - get rline
ok 34 - get data
ok 35 - get end
ok 36 - touch passthrough
ok 37 - got touch response
ok 38 - gets passthrough
ok 39 - gets rline
ok 40 - gets data
ok 41 - gets end
ok 42 - gat passthrough
ok 43 - gat rline
ok 44 - gat data
ok 45 - gat end
ok 46 - gats passthrough
ok 47 - gats rline
ok 48 - gats data
ok 49 - gats end
ok 50 - cas passthrough
ok 51 - cas value
ok 52 - got STORED from cas
ok 53 - add passthrough
ok 54 - add value
ok 55 - got STORED from add
ok 56 - delete passthrough
ok 57 - got delete response
ok 58 - incr passthrough
ok 59 - got incr response
ok 60 - decr passthrough
ok 61 - got decr response
ok 62 - append passthrough
ok 63 - append value
ok 64 - got STORED from append
ok 65 - prepend passthrough
ok 66 - prepend value
ok 67 - got STORED from prepend
ok 68 - mg passthrough
ok 69 - got mg response
ok 70 - ms passthrough
ok 71 - ms value
ok 72 - got HD from ms
ok 73 - md passthrough
ok 74 - got HD from md
ok 75 - ma passthrough
ok 76 - got HD from ma
ok 77 - sanity check: touch cmd received
ok 78 - sanity check: touch cmd received
ok 79 - sanity check: touch cmd received
ok 80 - sanity check: TOUCHED response received.
# Test multiget:374
ok 81 - multiget breakdown a
ok 82 - multiget breakdown b
ok 83 - multiget breakdown c
ok 84 - multiget res a
ok 85 - multiget value a
ok 86 - multiget res b
ok 87 - multiget value b
ok 88 - multiget res c
ok 89 - multiget value c
ok 90 - final END from multiget
ok 91 - multiget breakdown a
ok 92 - multiget breakdown b
ok 93 - multiget breakdown c
ok 94 - final END from multiget
ok 95 - get works after empty multiget
ok 96 - end after empty multiget
ok 97 - sanity check: touch cmd received
ok 98 - sanity check: touch cmd received
ok 99 - sanity check: touch cmd received
ok 100 - sanity check: TOUCHED response received.
# Test noreply:417
ok 101 - set received with broken noreply
ok 102 - set payload received
ok 103 - canary touch received
ok 104 - got TOUCHED instread of STORED
ok 105 - sanity check: touch cmd received
ok 106 - sanity check: touch cmd received
ok 107 - sanity check: touch cmd received
ok 108 - sanity check: TOUCHED response received.
# Test Lua request APIs:449
ok 109 - request:key()
ok 110 - request:key() value
ok 111 - request:key() END
ok 112 - request:rtrimkey()
ok 113 - rtrimkey END
ok 114 - request:ltrimkey()
ok 115 - ltrimkey END
ok 116 - sanity check: touch cmd received
ok 117 - sanity check: touch cmd received
ok 118 - sanity check: touch cmd received
ok 119 - sanity check: TOUCHED response received.
# Test routing by zone:507
ok 120 - routed proper zone: a
ok 121 - end from zone fetch
ok 122 - routed proper zone: b
ok 123 - end from zone fetch
ok 124 - routed proper zone: c
ok 125 - end from zone fetch
ok 126 - END from invalid route
ok 127 - sanity check: touch cmd received
ok 128 - sanity check: touch cmd received
ok 129 - sanity check: touch cmd received
ok 130 - sanity check: TOUCHED response received.
# Test Lua logging:536
ok 131 - watcher enabled
ok 132 - log a manual message
ok 133 - logtest END
ok 134 - got passthru for log
ok 135 - got END from log test
ok 136 - found request log entry
ok 137 - sanity check: touch cmd received
ok 138 - sanity check: touch cmd received
ok 139 - sanity check: touch cmd received
ok 140 - sanity check: TOUCHED response received.
# Test await argument:571
ok 141 - awaitbasic backend req
ok 142 - awaitbasic backend req
ok 143 - awaitbasic backend req
ok 144 - response from await
ok 145 - hit responses from await
ok 146 - end from await
ok 147 - awaitone backend req
ok 148 - awaitone backend req
ok 149 - awaitone backend req
ok 150 - response from await
ok 151 - looking for a single response
ok 152 - end from await
ok 153 - awaitone backend req
ok 154 - awaitone backend req
ok 155 - awaitone backend req
ok 156 - response from await
ok 157 - looking two responses
ok 158 - end from await
ok 159 - awaitgood backend req
ok 160 - awaitgood backend req
ok 161 - awaitgood backend req
ok 162 - response from await
ok 163 - looking for a single response
ok 164 - end from await
ok 165 - awaitany backend req
ok 166 - awaitany backend req
ok 167 - awaitany backend req
ok 168 - response from await
ok 169 - looking for a two responses
ok 170 - end from await
ok 171 - awaitfastgood backend req
ok 172 - response from await
ok 173 - await value
ok 174 - end from await
ok 175 - awaitfastgood backend req
ok 176 - awaitfastgood backend req
ok 177 - awaitfastgood backend req
ok 178 - awaitfastgood backend req
ok 179 - awaitfastgood backend req
ok 180 - response from await
ok 181 - await value
ok 182 - end from await
ok 183 - awaitfastgood backend req
ok 184 - awaitfastgood backend req
ok 185 - awaitfastgood backend req
ok 186 - miss from awaitfastgood
ok 187 - set backend req
ok 188 - set backend data
ok 189 - set backend req
ok 190 - set backend data
Set Response count: 2
ok 191 - got stored from await
ok 192 - set backend req
ok 193 - set backend data
ok 194 - set backend req
ok 195 - set backend data
ok 196 - set backend req
ok 197 - set backend data
ok 198 - set backend req
ok 199 - set backend data
ok 200 - set doesn't return early
Set Response count: 2
ok 201 - set completed normally
ok 202 - response from await
ok 203 - looking for zero responses
ok 204 - end from await
ok 205 - awaitbg backend req
ok 206 - awaitbg backend req
ok 207 - awaitbg backend req
ok 208 - sanity check: touch cmd received
ok 209 - sanity check: touch cmd received
ok 210 - sanity check: touch cmd received
ok 211 - sanity check: TOUCHED response received.
# Test await_logerrors:735
ok 212 - watcher enabled
ok 213 - await_logerrors backend req
ok 214 - await_logerrors set payload
ok 215 - block until await responded
ok 216 - await_logerrors backend req
ok 217 - await_logerrors set payload
ok 218 - await_logerrors backend req
ok 219 - await_logerrors set payload
ok 220 - await_logerrors log entry 1
ok 221 - await_logerrors log entry 2
ok 222 - got passthru for log
ok 223 - got END from log test
ok 224 - found request log entry
ok 225 - sanity check: touch cmd received
ok 226 - sanity check: touch cmd received
ok 227 - sanity check: touch cmd received
ok 228 - sanity check: TOUCHED response received.
# Test error/garbage from backend:782
ok 229 - received set cmd
ok 230 - received set data
ok 231 - client received error message
ok 232 - backend still works
ok 233 - got end back
ok 234 - received get command
ok 235 - client received error message
ok 236 - backend disconnected
ok 237 - mock backend created
ok 238 - received version command
ok 239 - received get command
ok 240 - client received error message
ok 241 - backend disconnected
ok 242 - mock backend created
ok 243 - received version command
ok 244 - received get command
ok 245 - client received error message
ok 246 - backend disconnected
ok 247 - mock backend created
ok 248 - received version command
ok 249 - received get command
ok 250 - generic backend error
ok 251 - mock backend created
ok 252 - received version command
ok 253 - received get command
ok 254 - received next get command
ok 255 - backend error
ok 256 - backend error
ok 257 - mock backend created
ok 258 - received version command
ok 259 - received get command
ok 260 - lua saw correct error code
ok 261 - mock backend created
ok 262 - received version command
ok 263 - received get command
ok 264 - lua saw correct error code
ok 265 - mock backend created
ok 266 - received version command
ok 267 - received get command
ok 268 - lua saw correct error code
ok 269 - sanity check: touch cmd received
ok 270 - sanity check: touch cmd received
ok 271 - sanity check: touch cmd received
ok 272 - sanity check: TOUCHED response received.
1..272
ok
All tests successful.
Files=1, Tests=272,  2 wallclock secs ( 0.03 usr  0.00 sys +  0.07 cusr  0.02 csys =  0.12 CPU)
Result: PASS
```