### PR TITLE
Bucketstore proof of concept

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -81,6 +81,7 @@
 #define MCP_YIELD_POOL 1
 #define MCP_YIELD_AWAIT 2
 #define MCP_YIELD_LOCAL 3
+#define MCP_YIELD_RECACHE 4
 
 // all possible commands.
 #define CMD_FIELDS \
@@ -544,6 +545,7 @@ int mcplib_request_ntokens(lua_State *L);
 int mcplib_request_has_flag(lua_State *L);
 int mcplib_request_flag_token(lua_State *L);
 int mcplib_request_gc(lua_State *L);
+int mcplib_request_bucket(lua_State *L);
 
 int mcplib_open_dist_jump_hash(lua_State *L);
 int mcplib_open_dist_ring_hash(lua_State *L);


### PR DESCRIPTION
Takes keys in the format of: `/first/part/of/keyNNNN`, takes everything after the _final_ `/` character and turns that into a hashed bucket. Appends data together.

Example configuration:

```
function mcp_config_pools()
    return {}
end

function mcp_config_routes(o)
    mcp.attach(mcp.CMD_MS, function(r)
        local new = r:bucket(20)
        local res = mcp.force_recache(new)
        if res == nil then
            --print("miss, fine to run command")
            return mcp.internal(new)
        elseif res == true then
            --print("successfuly recached or already in memory, fine to run command")
            return mcp.internal(new)
        else
            print("failed to fetch or recache")
            return "NS\r\n"
        end
    end)
    mcp.attach(mcp.CMD_MG, function(r)
        local new = r:bucket(20)
        local resp = mcp.internal(new)
        local value = resp:bucketscan(r)
        if value ~= nil then
            -- value has \r\n already.
            return "VA " .. string.len(value)-2 .. "\r\n" .. value
        else
            return "EN\r\n"
        end
    end)
end
```

TODO:
- [ ] Update example configuration for set retries. (it should be fine to retry 1-3 times if you hit the "failed to fetch" condition)
- [ ] Edge handling and cleanups.
- [ ] Configuration on how to parse the key
- [ ] Copy meta flags around internally.

DO NOT attempt to clean up this code! It is written deliberately to make it easier to rebase in the future.