### PR TITLE
Fix confusing cflags comment in struct item, and replace suffix with cflags.

### DIFF
--- a/items.c
+++ b/items.c
@@ -330,7 +330,7 @@ item *do_item_alloc(const char *key, const size_t nkey, const unsigned int flags
     memcpy(ITEM_key(it), key, nkey);
     it->exptime = exptime;
     if (flags > 0) {
-        memcpy(ITEM_suffix(it), &flags, sizeof(flags));
+        memcpy(ITEM_client_flags(it), &flags, sizeof(flags));
     }
 
     /* Initialize internal chunk. */

--- a/memcached.h
+++ b/memcached.h
@@ -595,7 +595,7 @@ typedef struct _stritem {
     } data[];
     /* if it_flags & ITEM_CAS we have 8 bytes CAS */
     /* then null-terminated key */
-    /* then " flags length\r\n" (no terminating null) */
+    /* if it_flags & ITEM_CFLAGS we have 4 bytes client flags */
     /* then data with terminating \r\n (no terminating null; it's binary!) */
 } item;
 

--- a/memcached.h
+++ b/memcached.h
@@ -127,7 +127,7 @@
 #define ITEM_key(item) (((char*)&((item)->data)) \
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
-#define ITEM_suffix(item) ((char*) &((item)->data) + (item)->nkey + 1 \
+#define ITEM_client_flags(item) ((char*) &((item)->data) + (item)->nkey + 1 \
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
 #define ITEM_data(item) ((char*) &((item)->data) + (item)->nkey + 1 \
@@ -163,7 +163,7 @@
 /** Item client flag conversion */
 #define FLAGS_CONV(it, flag) { \
     if ((it)->it_flags & ITEM_CFLAGS) { \
-        flag = *((uint32_t *)ITEM_suffix((it))); \
+        flag = *((uint32_t *)ITEM_client_flags((it))); \
     } else { \
         flag = 0; \
     } \

--- a/proto_text.c
+++ b/proto_text.c
@@ -529,7 +529,7 @@ static inline int make_ascii_get_suffix(char *suffix, item *it, bool return_cas,
         *p = '0';
         p++;
     } else {
-        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+        p = itoa_u32(*((uint32_t *) ITEM_client_flags(it)), p);
     }
     *p = ' ';
     p = itoa_u32(nbytes-2, p+1);
@@ -1197,7 +1197,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
                         *p = '0';
                         p++;
                     } else {
-                        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+                        p = itoa_u32(*((uint32_t *) ITEM_client_flags(it)), p);
                     }
                     break;
                 case 'l':

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -203,7 +203,7 @@ static inline int make_ascii_get_suffix(char *suffix, item *it, bool return_cas,
         *p = '0';
         p++;
     } else {
-        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+        p = itoa_u32(*((uint32_t *) ITEM_client_flags(it)), p);
     }
     *p = ' ';
     p = itoa_u32(nbytes-2, p+1);
@@ -854,7 +854,7 @@ static void process_mget_cmd(LIBEVENT_THREAD *t, mcp_parser_t *pr, mc_resp *resp
                         *p = '0';
                         p++;
                     } else {
-                        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+                        p = itoa_u32(*((uint32_t *) ITEM_client_flags(it)), p);
                     }
                     break;
                 case 'l':


### PR DESCRIPTION
The comment `flags length\r\n` in struct `item` is outdated and incorrect, which introduces confusing.
There should be comment on client flags.

And the old `suffix` related code should be updated.