### PR TITLE
Note that counts for `track_sizes` are best effort

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1599,7 +1599,8 @@ The server terminates this list with the line
 END\r\n
 
 'size' is an approximate size of the item, within 32 bytes.
-'count' is the amount of items that exist within that 32-byte range.
+'count' is the approximate amount of items that exist within that 32-byte
+range.
 
 This is essentially a display of all of your items if there was a slab class
 for every 32 bytes. You can use this to determine if adjusting the slab growth

--- a/memcached.c
+++ b/memcached.c
@@ -4107,6 +4107,7 @@ static void usage(void) {
            "   - worker_logbuf_size:  size in kilobytes of per-worker-thread buffer\n"
            "                          read by background thread, then written to watchers. (default: %u)\n"
            "   - track_sizes:         enable dynamic reports for 'stats sizes' command.\n"
+           "                          note that counts for each size are approximate.\n"
            "   - no_hashexpand:       disables hash table expansion (dangerous)\n"
            "   - modern:              enables options which will be default in future.\n"
            "                          currently: nothing\n"


### PR DESCRIPTION
Add note to help and protocol docs that counters for the sizes histogram are approximate since increments and decrements are not synchronized.

Related #1051