### PR TITLE
proxy: add mcp.ratelim_tbf({})

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,6 +59,7 @@ if ENABLE_PROXY
 memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_xxhash.c proxy.h \
 					 proxy_await.c proxy_ustats.c \
+					 proxy_ratelim.c \
 					 proxy_jump_hash.c proxy_request.c \
 					 proxy_network.c proxy_lua.c \
 					 proxy_config.c proxy_ring_hash.c \

--- a/proxy.h
+++ b/proxy.h
@@ -543,6 +543,10 @@ size_t _process_request_next_key(mcp_parser_t *pr);
 int process_request(mcp_parser_t *pr, const char *command, size_t cmdlen);
 mcp_request_t *mcp_new_request(lua_State *L, mcp_parser_t *pr, const char *command, size_t cmdlen);
 
+// rate limit interfaces
+int mcplib_ratelim_tbf(lua_State *L);
+int mcplib_ratelim_tbf_call(lua_State *L);
+
 // request interface
 int mcplib_request(lua_State *L);
 int mcplib_request_command(lua_State *L);

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1241,6 +1241,11 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {NULL, NULL}
     };
 
+    const struct luaL_Reg mcplib_ratelim_tbf_m[] = {
+        {"__call", mcplib_ratelim_tbf_call},
+        {NULL, NULL}
+    };
+
     const struct luaL_Reg mcplib_f_config [] = {
         {"pool", mcplib_pool},
         {"backend", mcplib_backend},
@@ -1265,6 +1270,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"log_reqsample", mcplib_log_reqsample},
         {"stat", mcplib_stat},
         {"request", mcplib_request},
+        {"ratelim_tbf", mcplib_ratelim_tbf},
         {NULL, NULL}
     };
     // VM's have void* extra space in the VM by default for fast-access to a
@@ -1292,6 +1298,12 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         lua_setfield(L, -2, "__index"); // mt.__index = mt
         luaL_setfuncs(L, mcplib_pool_proxy_m, 0); // register methods
         lua_pop(L, 1); // drop the hash selector metatable
+
+        luaL_newmetatable(L, "mcp.ratelim_tbf");
+        lua_pushvalue(L, -1); // duplicate metatable.
+        lua_setfield(L, -2, "__index"); // mt.__index = mt
+        luaL_setfuncs(L, mcplib_ratelim_tbf_m, 0); // register methods
+        lua_pop(L, 1);
 
         luaL_newlibtable(L, mcplib_f_routes);
     } else {

--- a/proxy_ratelim.c
+++ b/proxy_ratelim.c
@@ -1,0 +1,78 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+
+// No GC necessary.
+struct mcp_ratelim_tbf {
+    uint32_t bucket;
+    uint32_t limit;
+    uint32_t fill_rate; // tokens to add per tick rate
+    uint32_t tick_rate; // in milliseconds
+    int64_t last_update; // time in milliseconds
+};
+
+#define TIMEVAL_TO_MILLIS(n) (n.tv_usec / 1000 + n.tv_sec * (uint64_t)1000)
+
+static lua_Integer _tbf_check(lua_State *L, char *key) {
+    lua_Integer n = 0;
+    if (lua_getfield(L, 1, key) != LUA_TNIL) {
+        n = lua_tointeger(L, -1);
+        if (n < 0 || n > UINT_MAX-1) {
+            proxy_lua_error(L, "mcp.ratelim_tbf: arguments must be unsigned 32 bit integer");
+        }
+    }
+    lua_pop(L, 1); // pops value or nil.
+    return n;
+}
+
+int mcplib_ratelim_tbf(lua_State *L) {
+    struct mcp_ratelim_tbf *lim = lua_newuserdatauv(L, sizeof(*lim), 0);
+    struct timeval now;
+    memset(lim, 0, sizeof(*lim));
+    luaL_setmetatable(L, "mcp.ratelim_tbf");
+
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lim->limit = _tbf_check(L, "limit");
+    lim->fill_rate = _tbf_check(L, "fillrate");
+    lim->tick_rate = _tbf_check(L, "tickrate");
+
+    // seed the token bucket filter.
+    lim->bucket = lim->limit;
+    gettimeofday(&now, NULL);
+    lim->last_update = TIMEVAL_TO_MILLIS(now);
+    return 1;
+}
+
+int mcplib_ratelim_tbf_call(lua_State *L) {
+    struct mcp_ratelim_tbf *lim = luaL_checkudata(L, 1, "mcp.ratelim_tbf");
+    luaL_checktype(L, 2, LUA_TNUMBER);
+    int take = lua_tointeger(L, 2);
+    struct timeval now;
+    uint64_t now_millis = 0;
+    uint64_t delta = 0;
+
+    gettimeofday(&now, NULL);
+    now_millis = TIMEVAL_TO_MILLIS(now);
+    delta = now_millis - lim->last_update;
+
+    if (delta > lim->tick_rate) {
+        // find how many ticks to add to the bucket.
+        uint32_t toadd = delta / lim->tick_rate;
+        // advance time up to the most recent tick.
+        lim->last_update += toadd * lim->tick_rate;
+        // add tokens to the bucket
+        lim->bucket += toadd * lim->fill_rate;
+        if (lim->bucket > lim->limit) {
+            lim->bucket = lim->limit;
+        }
+    }
+
+    if (lim->bucket > take) {
+        lim->bucket -= take;
+        lua_pushboolean(L, 1);
+    } else {
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}

--- a/t/proxyratelim.lua
+++ b/t/proxyratelim.lua
@@ -1,0 +1,19 @@
+
+function mcp_config_pools()
+    return {}
+end
+
+function mcp_config_routes(t)
+    -- limit is an arbitrary token count (bytes, requests, etc)
+    -- fillrate is tokens per tickrate
+    -- tickrate is milliseconds
+    local tbf = mcp.ratelim_tbf({limit = 50, fillrate = 4, tickrate = 500})
+
+    mcp.attach(mcp.CMD_MG, function(r)
+        if tbf(15) then
+            return "HD\r\n"
+        else
+            return "SERVER_ERROR slow down\r\n"
+        end
+    end)
+end

--- a/t/proxyratelim.t
+++ b/t/proxyratelim.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyratelim.lua');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+{
+    my $x = 10;
+    while ($x--) {
+        print $ps "mg na\r\n";
+        my $res = scalar <$ps>;
+        last if $res =~ m/SERVER_ERROR/;
+    }
+    cmp_ok($x, '>', 0, "hit rate limit without trying too many times");
+    sleep 0.5;
+    print $ps "mg na\r\n";
+    is(scalar <$ps>, "SERVER_ERROR slow down\r\n", "still blocked after short sleep");
+    sleep 3;
+    print $ps "mg na\r\n";
+    is(scalar <$ps>, "HD\r\n", "not blocked after longer sleep");
+}
+
+done_testing();


### PR DESCRIPTION
See t/proxyratelim.lua for usage.

Trivial interface with good enough performance for some situations. Allows having an arbitrary number of limiters (ie; one per path) by creating more objects.

trivial. going to let it sit overnight then merge to staging after a self review.