### PR TITLE
proxy: mcp.backend({ down = true }) option

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -188,6 +188,7 @@ struct proxy_tunables {
 #endif // HAVE_LIBURING
     int backend_failure_limit;
     bool tcp_keepalive;
+    bool down; // backend is forced into a down/bad state.
 };
 
 typedef STAILQ_HEAD(pool_head_s, mcp_pool_s) pool_head_t;

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -249,6 +249,12 @@ static int mcplib_backend(lua_State *L) {
         }
         lua_pop(L, 1);
 
+        if (lua_getfield(L, 1, "down") != LUA_TNIL) {
+            int down = lua_toboolean(L, -1);
+            be->tunables.down = down;
+        }
+        lua_pop(L, 1);
+
         if (lua_getfield(L, 1, "connections") != LUA_TNIL) {
             int c = luaL_checkinteger(L, -1);
             if (c <= 0) {
@@ -262,6 +268,7 @@ static int mcplib_backend(lua_State *L) {
             be->conncount = c;
         }
         lua_pop(L, 1);
+
     } else {
         label = luaL_checklstring(L, 1, &llen);
         name = luaL_checklstring(L, 2, &nlen);

--- a/t/proxyconfig.lua
+++ b/t/proxyconfig.lua
@@ -53,6 +53,20 @@ function mcp_config_pools(old)
             test = mcp.pool({b1})
         }
         return pools
+    elseif mode == "down" then
+        local down = mcp.backend({ label = "down", host = "127.0.0.1", port = 11517,
+                                   down = true })
+        local pools = {
+            test = mcp.pool({down})
+        }
+        return pools
+    elseif mode == "notdown" then
+        local down = mcp.backend({ label = "down", host = "127.0.0.1", port = 11517,
+                                   down = false })
+        local pools = {
+            test = mcp.pool({down})
+        }
+        return pools
     end
 end
 


### PR DESCRIPTION
Starts backend in a "bad" state, so any attempt to access it will result in "SERVER_ERROR backend failure".

The only times a backend's bad flag can be removed is on a successful connection attempt. So all we need to do is avoid fully setting up or tearing down the backend and starting it marked bad.

TODO:
- [x] one more code audit pass.
- [x] walk through code in debugger during the cleanup phase to verify.
- [x] maybe one more test with down = false to ensure it does still connect? use the same label to ensure it updates.