### PR TITLE
proxy: backend antiflap detection.

### DIFF
--- a/logger.h
+++ b/logger.h
@@ -142,6 +142,7 @@ struct logentry_proxy_errbe {
     size_t be_portlen;
     size_t be_rbuflen;
     int be_depth;
+    int retry;
     char data[];
 };
 #endif

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -156,6 +156,8 @@ void *proxy_init(bool use_uring) {
     ctx->tunables.connect.tv_sec = 5;
     ctx->tunables.retry.tv_sec = 3;
     ctx->tunables.read.tv_sec = 3;
+    ctx->tunables.flap_backoff_ramp = 1.5;
+    ctx->tunables.flap_backoff_max = 3600;
 
     STAILQ_INIT(&ctx->manager_head);
     lua_State *L = luaL_newstate();

--- a/t/proxyantiflap.lua
+++ b/t/proxyantiflap.lua
@@ -1,0 +1,26 @@
+if reload_count == nil then
+    reload_count = 0
+end
+
+function mcp_config_pools()
+    mcp.backend_read_timeout(0.25)
+    mcp.backend_connect_timeout(5)
+    mcp.backend_flap_time(30) -- need a long time to reset the flap counter
+    mcp.backend_flap_backoff_ramp(1.2) -- very slow ramp
+    mcp.backend_retry_waittime(1) -- a quick retry for the test.
+    mcp.backend_failure_limit(2) -- reduced from default to speed up test.
+
+    reload_count = reload_count + 1
+    local arg = { label = 'b1', host = '127.0.0.1', port = 11799 }
+
+    if reload_count == 1 then
+        return mcp.pool({mcp.backend(arg)})
+    elseif reload_count == 2 then
+        mcp.backend_flap_time(2)
+        return mcp.pool({mcp.backend(arg)})
+    end
+end
+
+function mcp_config_routes(pool)
+    mcp.attach(mcp.CMD_MG, function(r) return pool(r) end)
+end

--- a/t/proxyantiflap.t
+++ b/t/proxyantiflap.t
@@ -1,0 +1,147 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Select;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up some server sockets.
+sub mock_server {
+    my $port = shift;
+    my $srv = IO::Socket->new(
+        Domain => AF_INET,
+        Type => SOCK_STREAM,
+        Proto => 'tcp',
+        LocalHost => '127.0.0.1',
+        LocalPort => $port,
+        ReusePort => 1,
+        Listen => 5) || die "IO::Socket: $@";
+    return $srv;
+}
+
+sub accept_backend {
+    my $srv = shift;
+    my $be = $srv->accept();
+    $be->autoflush(1);
+    ok(defined $be, "mock backend created");
+    like(<$be>, qr/version/, "received version command");
+    print $be "VERSION 1.0.0-mock\r\n";
+
+    return $be;
+}
+
+# Put a version command down the pipe to ensure the socket is clear.
+# client version commands skip the proxy code
+sub check_version {
+    my $ps = shift;
+    print $ps "version\r\n";
+    like(<$ps>, qr/VERSION /, "version received");
+}
+
+sub wait_reload {
+    my $w = shift;
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=start/, "reload started");
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=done/, "reload completed");
+}
+
+# We just need a single backend here; there's no logical difference if it's in
+# a cluster or not.
+note "making mock servers";
+my $msrv = mock_server(11799);
+
+# Start up a clean server.
+my $p_srv = new_memcached('-o proxy_config=./t/proxyantiflap.lua');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+{
+    my $watcher = $p_srv->new_sock;
+    print $watcher "watch proxyevents\n";
+    is(<$watcher>, "OK\r\n", "watcher enabled");
+
+    my $be = accept_backend($msrv);
+    my $s = IO::Select->new();
+    $s->add($be);
+
+    # Make some backend requests but refuse to answer.
+    for (1 .. 3) {
+        print $ps "mg foo\r\n";
+        # Block until we error and reconnect.
+        is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "request cancelled");
+        like(<$watcher>, qr/error=timeout/, "timeout error log");
+        $be = accept_backend($msrv);
+    }
+    print $ps "mg bar\r\n";
+    # Block until we error and reconnect.
+    is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "request cancelled");
+    $be = accept_backend($msrv);
+    like(<$watcher>, qr/error=markedbadflap name=\S+ port=\S+ retry=1/, "got caught flapping");
+
+    print $ps "mg baz\r\n";
+    is(scalar <$be>, "mg baz\r\n", "backend does reconnect and still works");
+    print $be "HD\r\n";
+    is(scalar <$ps>, "HD\r\n", "client still works post-flap");
+
+    # clear error logs.
+    like(<$watcher>, qr/error=timeout/, "timeout error log");
+    like(<$watcher>, qr/error=markedbadflap name=\S+ port=\S+ retry=2/, "re-flapped, longer retry");
+    $p_srv->reload();
+    wait_reload($watcher);
+
+    # Hold the previous backend so its descriptor doesn't log
+    my $oldbe = $be;
+
+    # This should reset the flap counter as the backend description changes.
+    $be = accept_backend($msrv);
+
+    check_version($ps);
+
+    # Make some backend requests but refuse to answer.
+    for (1 .. 3) {
+        print $ps "mg foo\r\n";
+        # Block until we error and reconnect.
+        is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "request cancelled");
+        like(<$watcher>, qr/error=timeout/, "timeout error log");
+        $be = accept_backend($msrv);
+    }
+    print $ps "mg bar\r\n";
+    # Block until we error and reconnect.
+    is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "request cancelled");
+    like(<$watcher>, qr/error=markedbadflap/, "got caught flapping");
+
+    $be = accept_backend($msrv);
+
+    like(<$watcher>, qr/error=timeout/, "previous backend goes away");
+    like(<$watcher>, qr/error=markedbadflap/, "still considered flapping");
+    check_version($ps);
+
+    # verify the new backend works.
+    print $ps "mg baz\r\n";
+    is(scalar <$be>, "mg baz\r\n", "backend does work");
+    print $be "HD\r\n";
+    is(scalar <$ps>, "HD\r\n", "client still works");
+
+    # Now wait and see if the next failure causes a flap or not.
+    sleep 3;
+
+    print $ps "mg bar\r\n";
+    # Block until we error and reconnect.
+    is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "request cancelled");
+
+    like(<$watcher>, qr/error=timeout/, "normal timeout error");
+    # This will pause until readvalidate fails, so we can be sure a flap error
+    # didn't follow the timeout error.
+    unlike(<$watcher>, qr/error=markedbadflap/, "didn't flap again");
+}
+
+done_testing();


### PR DESCRIPTION
This change allows detecting if backend servers are "flapping" when
given traffic. This means they connect, validate, and can answer
responses, but under normal traffic workloads they break. This could be
due to noisy neighbor issues, network congestion, bugs, etc.

This change also updates an existing setting:
mcp.backend_retry_timeout(seconds), is now:
mcp.backend_retry_waittime(whole seconds)

... this setting is the amount of time to hold a backend in a "bad"
state, before attempting to reconnect again, once it has exceeded its
consecutive failure limit. It must be at least one second and is
specified as whole seconds.

The new tunables are:
mcp.backend_flap_time(seconds) (default: 0)
- Once a backend is successfully connected, if this much time does not
  pass before it throws a connection error (timeout/read/write/etc), we
increase a "flap" counter. This flap counter is checked against
"backend_failure_limit"; once exceeded we consider the backend to be
flapping.

When it is flapping we mark the backend as bad even if it has not
exceeded the _consecutive_ backend_failure_limit count.

Two additional tunables govern how long we wait before trying to connect
again:

mcp.backend_flap_backoff_ramp(seconds) (default: 1.5)
This is a factorial multiplied against backend_retry_waittime() by the
number of times we have consecutively flapped. This increases the
waittime between attempts.

mcp.backend_flap_backeoff_max(whole seconds) (default: 3600)
The maximum amount of time to wait before retrying a flapping server.
With the default we would try at least once per hour.

TODO:
- [x] Make a decision on adding a new log type or overriding the backend_error log.