### PR TITLE
proxy: fix off-by-one if \r is missing

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -276,6 +276,7 @@ struct mcp_parser_s {
     uint8_t keytoken; // because GAT. sigh. also cmds without a key.
     uint32_t parsed; // how far into the request we parsed already
     uint32_t reqlen; // full length of request buffer.
+    uint32_t endlen; // index to the start of \r\n or \n
     int vlen;
     uint32_t klen; // length of key.
     uint16_t tokens[PARSER_MAX_TOKENS]; // offsets for start of each token

--- a/t/proxy.t
+++ b/t/proxy.t
@@ -151,13 +151,14 @@ my $p_sock = $p_srv->sock;
 # NOTE: memcached always allowed [\r]\n for single command lines, but payloads
 # (set/etc) require exactly \r\n as termination.
 # doc/protocol.txt has always specified \r\n for command/response.
-# Proxy is more strict than normal server in this case.
+# Note a bug lead me to believe that the proxy was more strict, we accept any
+# \n or \r\n terminated commands.
 {
     my $s = $srv[0]->sock;
     print $s "version\n";
     like(<$s>, qr/VERSION/, "direct server version cmd with just newline");
     print $p_sock "version\n";
-    like(<$p_sock>, qr/CLIENT_ERROR/, "proxy version cmd with just newline");
+    like(<$p_sock>, qr/VERSION/, "proxy version cmd with just newline");
     print $p_sock "version\r\n";
     like(<$p_sock>, qr/VERSION/, "proxy version cmd with full CRLF");
 }


### PR DESCRIPTION
A bunch of the parser assumed we only had \r\n, but I didn't actually have that strictness set. Some commands worked and some broke in subtle ways when just "\n" was being submitted.

I'm not 100% confident in this change yet so I'm opening a PR to stage it while I run some more thorough tests.