### PR TITLE
Fix proxy response code for backend error

### DIFF
--- a/proxy_network.c
+++ b/proxy_network.c
@@ -303,6 +303,7 @@ void proxy_run_backend_queue(be_head_t *head) {
                 io = STAILQ_FIRST(&bec->io_head);
                 STAILQ_REMOVE_HEAD(&bec->io_head, io_next);
                 io->client_resp->status = MCMC_ERR;
+                io->client_resp->resp.code = MCMC_CODE_SERVER_ERROR;
                 bec->depth--;
                 return_io_pending((io_pending_t *)io);
             }
@@ -845,6 +846,7 @@ static void _reset_bad_backend(struct mcp_backendconn_s *be, enum proxy_be_failu
         // TODO (v2): Unsure if this is the best way of surfacing errors to lua,
         // but will do for V1.
         io->client_resp->status = MCMC_ERR;
+        io->client_resp->resp.code = MCMC_CODE_SERVER_ERROR;
         be->depth--;
         return_io_pending((io_pending_t *)io);
     }

--- a/t/proxyunits.lua
+++ b/t/proxyunits.lua
@@ -552,6 +552,15 @@ function mcp_config_routes(zones)
         return zones.dead(r)
     end
 
+   pfx_get["deadrespcode"] = function(r)
+       local res = zones.dead(r)
+
+       if res:code() == mcp.MCMC_CODE_SERVER_ERROR then
+         return "ERROR code_correct\r\n"
+       end
+       return "ERROR code_incorrect: " .. res:code() .. "\r\n"
+   end
+
     mcp.attach(mcp.CMD_GET, toproute_factory(pfx_get, "get"))
     mcp.attach(mcp.CMD_SET, toproute_factory(pfx_set, "set"))
     mcp.attach(mcp.CMD_TOUCH, toproute_factory(pfx_touch, "touch"))

--- a/t/proxyunits.t
+++ b/t/proxyunits.t
@@ -166,6 +166,9 @@ sub proxy_test {
     is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "Backend failed");
     my $end = int(time());
     cmp_ok($end - $start, '<', 3, "backend failed immediately");
+
+    print $ps "get /deadrespcode/foo\r\n";
+    is(scalar <$ps>, "ERROR code_correct\r\n", "Backend had correct response code on failure");
 }
 
 # Basic test with a backend; write a request to the client socket, read it


### PR DESCRIPTION
## Background 
The error code returned by the proxy to the Lua routing layer in the event that one or more backend nodes fail was not being set. As a result, after a backend error, invocations to `res:code()` in Lua returned `0` rather than the intended `MCMC_SERVER_ERROR`, even though the _error status_ was correctly being set to `SERVER_ERROR`. This fix correctly sets the response code in the event of a backend error.

## Testing
### Manual Testing
I performed manual testing to ensure that the response code was set correctly.

I first added the following print statement to our Lua routing code for proxy writes:
```
print("RES CODE AFTER OPERATION: " .. res:code())
```

Then, I executed the following command sequence on a proxy instance (CAS IDs obscured for sake of example). Between executing the meta-get and meta-set commands, I terminated a backend memcached instance to induce a server error.

```
mg /testnamespace/key v c N100
VA 0 c1234 W

ms /testnamespace/key 4 C1234
data
SERVER_ERROR backend failure
``` 

The emitted log lines in both the original code and the modified code are shown below.

Original Code
```
RES CODE AFTER OPERATION: 0
```

Modified Code
```
RES CODE AFTER OPERATION: 23
```

### Automated Testing
I had intended to create unit tests to test this new error functionality. However, it appeared that a comparable test of the Lua response code already existed [here](https://github.com/memcached/memcached/blob/next/t/proxyunits.t#L1409-L1412). We confirmed that this test is not being skipped, and we are thus unclear on why this test passes for the existing implementation. Any idea @dormando? I am happy to write additional tests, but I wanted to clear up my confusion around the existing tests first -- thanks.