### PR TITLE
proxy: fix race condition in first load

### DIFF
--- a/proxy_config.c
+++ b/proxy_config.c
@@ -136,6 +136,7 @@ static void *_proxy_config_thread(void *arg) {
 
     logger_create();
     pthread_mutex_lock(&ctx->config_lock);
+    pthread_cond_signal(&ctx->config_cond);
     while (1) {
         ctx->loading = false;
         pthread_cond_wait(&ctx->config_cond, &ctx->config_lock);
@@ -203,6 +204,8 @@ int _start_proxy_config_threads(proxy_ctx_t *ctx) {
         return -1;
     }
     thread_setname(ctx->config_tid, "mc-prx-config");
+    // Avoid returning until the config thread has actually started.
+    pthread_cond_wait(&ctx->config_cond, &ctx->config_lock);
     pthread_mutex_unlock(&ctx->config_lock);
 
     pthread_mutex_lock(&ctx->manager_lock);


### PR DESCRIPTION
Missed two lines from the lru crawler init routine, because I'm an idiot who didn't abstract the start function.

The dance to wait for a thread to start isn't trivial. It's done here via:

main thread:
- lock mutex
- create new thread while holding lock
- go into condition wait, which releases the lock

new thread:
- start function
- lock mutex
  * at this point, we are blocked until main thread starts waiting on the condition.
- send condition signal.
  * at this point the main thread _would_ wake up, but we are still holding the lock.
- start our main routine, go into condition wait, which releases the lock

main thread:
- wake up from the condition wait, with the lock held.
- unlock the mutex.

now the main thread can continue while being confident the side thread is waiting for work properly.