### PR TITLE
logger.c: initialize rport

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -301,7 +301,7 @@ static int _logger_parse_extw(logentry *e, char *scratch) {
 
 static int _logger_parse_cne(logentry *e, char *scratch) {
     int total;
-    unsigned short rport;
+    unsigned short rport = 0;
     char rip[64];
     struct logentry_conn_event *le = (struct logentry_conn_event *) e->data;
     const char * const transport_map[] = { "local", "tcp", "udp" };
@@ -318,7 +318,7 @@ static int _logger_parse_cne(logentry *e, char *scratch) {
 
 static int _logger_parse_cce(logentry *e, char *scratch) {
     int total;
-    unsigned short rport;
+    unsigned short rport = 0;
     char rip[64];
     struct logentry_conn_event *le = (struct logentry_conn_event *) e->data;
     const char * const transport_map[] = { "local", "tcp", "udp" };


### PR DESCRIPTION
Fix the following build failure raised since version 1.6.11 and https://github.com/memcached/memcached/commit/617d7cd64d04698b76fee74882627690017e20ad:

```
logger.c: In function '_logger_parse_cce':
logger.c:297:13: error: 'rport' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  297 |     total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  298 |             "ts=%d.%d gid=%llu type=conn_close rip=%s rport=%hu transport=%s reason=%s cfd=%d\n",
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  299 |             (int) e->tv.tv_sec, (int) e->tv.tv_usec, (unsigned long long) e->gid,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  300 |             rip, rport, transport_map[le->transport],
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  301 |             reason_map[le->reason], le->sfd);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/7a46ac38d10b1859034017e0294961daa8f48dd2