### PR TITLE
proxy: add lua operation label in backend proxy event logs

### DIFF
--- a/logger.h
+++ b/logger.h
@@ -140,6 +140,7 @@ struct logentry_proxy_errbe {
     size_t errlen;
     size_t be_namelen;
     size_t be_portlen;
+    size_t be_labellen;
     size_t be_rbuflen;
     int be_depth;
     int retry;

--- a/proxy.h
+++ b/proxy.h
@@ -388,6 +388,7 @@ struct mcp_backend_s {
     io_head_t io_head; // stack of inbound requests.
     char name[MAX_NAMELEN+1];
     char port[MAX_PORTLEN+1];
+    char label[MAX_LABELLEN+1];
     struct proxy_tunables tunables; // this gets copied a few times for speed.
     struct mcp_backendconn_s be[];
 };

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -404,6 +404,7 @@ static mcp_backend_wrap_t *_mcplib_make_backendconn(lua_State *L, mcp_backend_la
 
     strncpy(be->name, bel->name, MAX_NAMELEN+1);
     strncpy(be->port, bel->port, MAX_PORTLEN+1);
+    strncpy(be->label, bel->label, MAX_LABELLEN+1);
     memcpy(&be->tunables, &bel->tunables, sizeof(bel->tunables));
     be->conncount = bel->conncount;
     STAILQ_INIT(&be->io_head);

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -773,7 +773,7 @@ static void _backend_reschedule(struct mcp_backendconn_s *be) {
         if (!be->bad) {
             P_DEBUG("%s: marking backend as bad\n", __func__);
             STAT_INCR(be->event_thread->ctx, backend_marked_bad, 1);
-            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, badtext, be->be_parent->name, be->be_parent->port, 0, NULL, 0, retry_time);
+            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, badtext, be->be_parent->name, be->be_parent->port, be->be_parent->label, 0, NULL, 0, retry_time);
         }
         be->bad = true;
         be->depth = INT_MAX/2; // fast-path cache for "bad" marker
@@ -856,7 +856,7 @@ static void _reset_bad_backend(struct mcp_backendconn_s *be, enum proxy_be_failu
 
     // Only log if we don't already know it's messed up.
     if (!be->bad) {
-        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, proxy_be_failure_text[err], be->be_parent->name, be->be_parent->port, depth, be->rbuf, be->rbufused, 0);
+        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, proxy_be_failure_text[err], be->be_parent->name, be->be_parent->port, be->be_parent->label, depth, be->rbuf, be->rbufused, 0);
     }
 
     // reset buffer to blank state.

--- a/t/proxyantiflap.t
+++ b/t/proxyantiflap.t
@@ -85,7 +85,7 @@ $ps->autoflush(1);
     # Block until we error and reconnect.
     is(scalar <$ps>, "SERVER_ERROR backend failure\r\n", "request cancelled");
     $be = accept_backend($msrv);
-    like(<$watcher>, qr/error=markedbadflap name=\S+ port=\S+ retry=1/, "got caught flapping");
+    like(<$watcher>, qr/error=markedbadflap name=\S+ port=\S+ label=b\d+ retry=1/, "got caught flapping");
 
     print $ps "mg baz\r\n";
     is(scalar <$be>, "mg baz\r\n", "backend does reconnect and still works");
@@ -94,7 +94,7 @@ $ps->autoflush(1);
 
     # clear error logs.
     like(<$watcher>, qr/error=timeout/, "timeout error log");
-    like(<$watcher>, qr/error=markedbadflap name=\S+ port=\S+ retry=2/, "re-flapped, longer retry");
+    like(<$watcher>, qr/error=markedbadflap name=\S+ port=\S+ label=b\d+ retry=2/, "re-flapped, longer retry");
     $p_srv->reload();
     wait_reload($watcher);
 

--- a/t/proxyunits.lua
+++ b/t/proxyunits.lua
@@ -16,6 +16,8 @@ function mcp_config_pools(oldss)
 
     local dead = srv('dead', '127.9.9.9', 11011);
 
+    local no_label = srv('', '127.0.0.1', 11414)
+
     -- convert the backends to pools.
     -- as per a normal full config see simple.lua or t/startfile.lua
     local zones = {
@@ -23,6 +25,7 @@ function mcp_config_pools(oldss)
         z2 = mcp.pool(b2z),
         z3 = mcp.pool(b3z),
         dead = mcp.pool({dead}),
+        no_label = mcp.pool({no_label})
     }
 
     return zones
@@ -122,6 +125,10 @@ function mcp_config_routes(zones)
     pfx_get["ltrimkey"] = function(r)
         r:ltrimkey(10)
         return zones.z1(r)
+    end
+
+    pfx_get["nolabel"] = function(r)
+        return zones.no_label(r)
     end
 
     pfx_mg["ntokens"] = function(r)


### PR DESCRIPTION
## Background
The `label` field passed at the Lua layer, typically used to denote specifics about the given type of operation, is currently only stored in Lua memory and not stored in the internal backend struct. Therefore, proxy events concerning backend errors are currently unable to emit the label provided in Lua.

This change extracts the `label` provided by Lua and stores it in the backend struct. It then logs it as a proxy event whenever a backend failure takes place.  

## Tests
### Automated Testing
Modified existing backend error proxy event tests to include `label` in their expected output for proxy events.

Created a new unit tests which tests that proxy events for backends without a label provided are correctly emitted.
### Manual Testing
Manually tested by bringing down a single backend node and attempting a meta-get operation on a proxy node. Observed the following events emitted, with hostnames and ports omitted:
```
watch proxyevents
OK
ts=1696457089.21527 gid=6 type=proxy_backend error=disconnected name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.21784 gid=7 type=proxy_backend error=connecting name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.21980 gid=8 type=proxy_backend error=connecting name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.22147 gid=9 type=proxy_backend error=connecting name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.22150 gid=10 type=proxy_backend error=markedbad name=[hostname] port=[port] label=[hostname]-read retry=3
```