### PR TITLE
core: add --enable-large-client-flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,9 @@ AC_ARG_ENABLE(proxy-uring,
 AC_ARG_ENABLE(werror,
   [AS_HELP_STRING([--enable-werror], [Enable -Werror])])
 
+AC_ARG_ENABLE(large-client-flags,
+  [AS_HELP_STRING([--enable-large-client-flags], [Change client flags from 32bit to 64bit EXPERIMENTAL])])
+
 dnl **********************************************************************
 dnl DETECT_SASL_CB_GETCONF
 dnl
@@ -252,6 +255,10 @@ if test "x$enable_proxy_uring" = "xyes"; then
     CPPFLAGS="-Ivendor/liburing/src/include $CPPFLAGS"
 fi
 
+if test "x$enable_large_client_flags" = "xyes"; then
+    AC_DEFINE([LARGE_CLIENT_FLAGS],1,[Set to nonzero if you want 64bit client flags])
+fi
+
 AM_CONDITIONAL([BUILD_DTRACE],[test "$build_dtrace" = "yes"])
 AM_CONDITIONAL([DTRACE_INSTRUMENT_OBJ],[test "$dtrace_instrument_obj" = "yes"])
 AM_CONDITIONAL([ENABLE_SASL],[test "$enable_sasl" = "yes"])
@@ -263,6 +270,7 @@ AM_CONDITIONAL([ENABLE_STATIC],[test "$enable_static" = "yes"])
 AM_CONDITIONAL([DISABLE_UNIX_SOCKET],[test "$enable_unix_socket" = "no"])
 AM_CONDITIONAL([ENABLE_PROXY],[test "$enable_proxy" = "yes"])
 AM_CONDITIONAL([ENABLE_PROXY_URING],[test "$enable_proxy_uring" = "yes"])
+AM_CONDITIONAL([LARGE_CLIENT_FLAGS],[test "$enable_large_client_flags" = "yes"])
 
 
 AC_SUBST(DTRACE)

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1498,6 +1498,7 @@ other stats command.
                     | bool     | If proxy is configured to use IO_URING.      |
                     |          | NOTE: uring may be used if kernel too old    |
 | memory_file       | char     | Warm restart memory file path, if enabled    |
+| client_flags_size | 32u      | Size in bytes of client flags                |
 |-------------------+----------+----------------------------------------------|
 
 

--- a/items.c
+++ b/items.c
@@ -161,7 +161,7 @@ unsigned int do_get_lru_size(uint32_t id) {
  *
  * Returns the total size of the header.
  */
-static size_t item_make_header(const uint8_t nkey, const unsigned int flags, const int nbytes,
+static size_t item_make_header(const uint8_t nkey, const client_flags_t flags, const int nbytes,
                      char *suffix, uint8_t *nsuffix) {
     if (flags == 0) {
         *nsuffix = 0;
@@ -258,7 +258,7 @@ item_chunk *do_item_alloc_chunk(item_chunk *ch, const size_t bytes_remain) {
     return nch;
 }
 
-item *do_item_alloc(const char *key, const size_t nkey, const unsigned int flags,
+item *do_item_alloc(const char *key, const size_t nkey, const client_flags_t flags,
                     const rel_time_t exptime, const int nbytes) {
     uint8_t nsuffix;
     item *it = NULL;
@@ -377,7 +377,7 @@ void item_free(item *it) {
  * Returns true if an item will fit in the cache (its size does not exceed
  * the maximum for a cache entry.)
  */
-bool item_size_ok(const size_t nkey, const int flags, const int nbytes) {
+bool item_size_ok(const size_t nkey, const client_flags_t flags, const int nbytes) {
     char prefix[40];
     uint8_t nsuffix;
     if (nbytes < 2)

--- a/items.h
+++ b/items.h
@@ -11,11 +11,11 @@ uint64_t get_cas_id(void);
 void set_cas_id(uint64_t new_cas);
 
 /*@null@*/
-item *do_item_alloc(const char *key, const size_t nkey, const unsigned int flags, const rel_time_t exptime, const int nbytes);
+item *do_item_alloc(const char *key, const size_t nkey, const client_flags_t flags, const rel_time_t exptime, const int nbytes);
 item_chunk *do_item_alloc_chunk(item_chunk *ch, const size_t bytes_remain);
 item *do_item_alloc_pull(const size_t ntotal, const unsigned int id);
 void item_free(item *it);
-bool item_size_ok(const size_t nkey, const int flags, const int nbytes);
+bool item_size_ok(const size_t nkey, const client_flags_t flags, const int nbytes);
 
 int  do_item_link(item *it, const uint32_t hv);     /** may fail if transgresses limits */
 void do_item_unlink(item *it, const uint32_t hv);

--- a/memcached.c
+++ b/memcached.c
@@ -1588,7 +1588,7 @@ enum store_item_type do_store_item(item *it, int comm, LIBEVENT_THREAD *t, const
     enum cas_result { CAS_NONE, CAS_MATCH, CAS_BADVAL, CAS_STALE, CAS_MISS };
 
     item *new_it = NULL;
-    uint32_t flags;
+    client_flags_t flags;
 
     /* Do the CAS test up front so we can apply to all store modes */
     enum cas_result cas_res = CAS_NONE;
@@ -2020,6 +2020,7 @@ void process_stat_settings(ADD_STAT add_stats, void *c) {
 #endif
     APPEND_STAT("num_napi_ids", "%s", settings.num_napi_ids);
     APPEND_STAT("memory_file", "%s", settings.memory_file);
+    APPEND_STAT("client_flags_size", "%d", sizeof(client_flags_t));
 }
 
 static int nz_strcmp(int nzlength, const char *nz, const char *z) {
@@ -2335,7 +2336,7 @@ enum delta_result_type do_add_delta(LIBEVENT_THREAD *t, const char *key, const s
         do_item_update(it);
     } else if (it->refcount > 1) {
         item *new_it;
-        uint32_t flags;
+        client_flags_t flags;
         FLAGS_CONV(it, flags);
         new_it = do_item_alloc(ITEM_key(it), it->nkey, flags, it->exptime, res + 2);
         if (new_it == 0) {

--- a/memcached.h
+++ b/memcached.h
@@ -50,6 +50,7 @@
 #include "cache.h"
 #include "logger.h"
 #include "queue.h"
+#include "util.h"
 
 #ifdef EXTSTORE
 #include "crc32c.h"
@@ -89,6 +90,15 @@
 /* Initial power multiplier for the hash table */
 #define HASHPOWER_DEFAULT 16
 #define HASHPOWER_MAX 32
+
+/* Abstract the size of an item's client flag suffix */
+#ifdef LARGE_CLIENT_FLAGS
+typedef uint64_t client_flags_t;
+#define safe_strtoflags safe_strtoull
+#else
+typedef uint32_t client_flags_t;
+#define safe_strtoflags safe_strtoul
+#endif
 
 /*
  * We only reposition items in the LRU queue if they haven't been repositioned
@@ -132,12 +142,12 @@
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
 #define ITEM_data(item) ((char*) &((item)->data) + (item)->nkey + 1 \
-         + (((item)->it_flags & ITEM_CFLAGS) ? sizeof(uint32_t) : 0) \
+         + (((item)->it_flags & ITEM_CFLAGS) ? sizeof(client_flags_t) : 0) \
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
 #define ITEM_ntotal(item) (sizeof(struct _stritem) + (item)->nkey + 1 \
          + (item)->nbytes \
-         + (((item)->it_flags & ITEM_CFLAGS) ? sizeof(uint32_t) : 0) \
+         + (((item)->it_flags & ITEM_CFLAGS) ? sizeof(client_flags_t) : 0) \
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 
 #define ITEM_clsid(item) ((item)->slabs_clsid & ~(3<<6))
@@ -164,13 +174,13 @@
 /** Item client flag conversion */
 #define FLAGS_CONV(it, flag) { \
     if ((it)->it_flags & ITEM_CFLAGS) { \
-        flag = *((uint32_t *)ITEM_suffix((it))); \
+        flag = *((client_flags_t *)ITEM_suffix((it))); \
     } else { \
         flag = 0; \
     } \
 }
 
-#define FLAGS_SIZE(item) (((item)->it_flags & ITEM_CFLAGS) ? sizeof(uint32_t) : 0)
+#define FLAGS_SIZE(item) (((item)->it_flags & ITEM_CFLAGS) ? sizeof(client_flags_t) : 0)
 
 /**
  * Callback for any function producing stats.
@@ -643,7 +653,7 @@ typedef struct _strchunk {
 #ifdef NEED_ALIGN
 static inline char *ITEM_schunk(item *it) {
     int offset = it->nkey + 1
-        + ((it->it_flags & ITEM_CFLAGS) ? sizeof(uint32_t) : 0)
+        + ((it->it_flags & ITEM_CFLAGS) ? sizeof(client_flags_t) : 0)
         + ((it->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0);
     int remain = offset % 8;
     if (remain != 0) {
@@ -653,7 +663,7 @@ static inline char *ITEM_schunk(item *it) {
 }
 #else
 #define ITEM_schunk(item) ((char*) &((item)->data) + (item)->nkey + 1 \
-         + (((item)->it_flags & ITEM_CFLAGS) ? sizeof(uint32_t) : 0) \
+         + (((item)->it_flags & ITEM_CFLAGS) ? sizeof(client_flags_t) : 0) \
          + (((item)->it_flags & ITEM_CAS) ? sizeof(uint64_t) : 0))
 #endif
 
@@ -955,7 +965,6 @@ extern int daemonize(int nochdir, int noclose);
 #include "crawler.h"
 #include "trace.h"
 #include "hash.h"
-#include "util.h"
 
 /*
  * Functions such as the libevent-related calls that need to do cross-thread
@@ -982,7 +991,7 @@ enum delta_result_type add_delta(LIBEVENT_THREAD *t, const char *key,
 void accept_new_conns(const bool do_accept);
 void  conn_close_idle(conn *c);
 void  conn_close_all(void);
-item *item_alloc(const char *key, size_t nkey, int flags, rel_time_t exptime, int nbytes);
+item *item_alloc(const char *key, size_t nkey, client_flags_t flags, rel_time_t exptime, int nbytes);
 #define DO_UPDATE true
 #define DONT_UPDATE false
 item *item_get(const char *key, const size_t nkey, LIBEVENT_THREAD *t, const bool do_update);

--- a/proto_text.c
+++ b/proto_text.c
@@ -529,7 +529,7 @@ static inline int make_ascii_get_suffix(char *suffix, item *it, bool return_cas,
         *p = '0';
         p++;
     } else {
-        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+        p = itoa_u64(*((client_flags_t *) ITEM_suffix(it)), p);
     }
     *p = ' ';
     p = itoa_u32(nbytes-2, p+1);
@@ -917,7 +917,7 @@ struct _meta_flags {
     rel_time_t exptime;
     rel_time_t autoviv_exptime;
     rel_time_t recache_time;
-    uint32_t client_flags;
+    client_flags_t client_flags;
     uint64_t req_cas_id;
     uint64_t delta; // ma
     uint64_t initial; // ma
@@ -1012,7 +1012,7 @@ static int _meta_flag_preparse(token_t *tokens, const size_t start,
                 break;
             // mset-related.
             case 'F':
-                if (!safe_strtoul(tokens[i].value+1, &of->client_flags)) {
+                if (!safe_strtoflags(tokens[i].value+1, &of->client_flags)) {
                     of->has_error = true;
                 }
                 break;
@@ -1196,7 +1196,7 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
                         *p = '0';
                         p++;
                     } else {
-                        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+                        p = itoa_u64(*((client_flags_t *) ITEM_suffix(it)), p);
                     }
                     break;
                 case 'l':
@@ -1944,7 +1944,7 @@ error:
 static void process_update_command(conn *c, token_t *tokens, const size_t ntokens, int comm, bool handle_cas) {
     char *key;
     size_t nkey;
-    unsigned int flags;
+    client_flags_t flags;
     int32_t exptime_int = 0;
     rel_time_t exptime = 0;
     int vlen;
@@ -1963,7 +1963,7 @@ static void process_update_command(conn *c, token_t *tokens, const size_t ntoken
     key = tokens[KEY_TOKEN].value;
     nkey = tokens[KEY_TOKEN].length;
 
-    if (! (safe_strtoul(tokens[2].value, (uint32_t *)&flags)
+    if (! (safe_strtoflags(tokens[2].value, &flags)
            && safe_strtol(tokens[3].value, &exptime_int)
            && safe_strtol(tokens[4].value, (int32_t *)&vlen))) {
         out_string(c, "CLIENT_ERROR bad command line format");

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -209,7 +209,7 @@ static inline int make_ascii_get_suffix(char *suffix, item *it, bool return_cas,
         *p = '0';
         p++;
     } else {
-        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+        p = itoa_u64(*((client_flags_t *) ITEM_suffix(it)), p);
     }
     *p = ' ';
     p = itoa_u32(nbytes-2, p+1);
@@ -309,7 +309,7 @@ static void process_get_cmd(LIBEVENT_THREAD *t, mcp_parser_t *pr, mc_resp *resp,
 static void process_update_cmd(LIBEVENT_THREAD *t, mcp_parser_t *pr, mc_resp *resp, int comm, bool handle_cas) {
     const char *key = &pr->request[pr->tokens[pr->keytoken]];
     size_t nkey = pr->klen;
-    unsigned int flags;
+    client_flags_t flags;
     int32_t exptime_int = 0;
     rel_time_t exptime = 0;
     uint64_t req_cas_id = 0;
@@ -326,7 +326,7 @@ static void process_update_cmd(LIBEVENT_THREAD *t, mcp_parser_t *pr, mc_resp *re
     // tokens simply end with a space or carriage return/newline, so we either
     // need custom functions or validate harder that these calls won't bite us
     // later.
-    if (! (safe_strtoul(&pr->request[pr->tokens[2]], (uint32_t *)&flags)
+    if (! (safe_strtoflags(&pr->request[pr->tokens[2]], &flags)
            && safe_strtol(&pr->request[pr->tokens[3]], &exptime_int))) {
         pout_string(resp, "CLIENT_ERROR bad command line format");
         return;
@@ -592,7 +592,7 @@ struct _meta_flags {
     rel_time_t exptime;
     rel_time_t autoviv_exptime;
     rel_time_t recache_time;
-    uint32_t client_flags;
+    client_flags_t client_flags;
     uint64_t req_cas_id;
     uint64_t delta; // ma
     uint64_t initial; // ma
@@ -689,7 +689,7 @@ static int _meta_flag_preparse(mcp_parser_t *pr, const size_t start,
                 break;
             // mset-related.
             case 'F':
-                if (!safe_strtoul(&pr->request[pr->tokens[i]+1], &of->client_flags)) {
+                if (!safe_strtoflags(&pr->request[pr->tokens[i]+1], &of->client_flags)) {
                     of->has_error = true;
                 }
                 break;
@@ -860,7 +860,7 @@ static void process_mget_cmd(LIBEVENT_THREAD *t, mcp_parser_t *pr, mc_resp *resp
                         *p = '0';
                         p++;
                     } else {
-                        p = itoa_u32(*((uint32_t *) ITEM_suffix(it)), p);
+                        p = itoa_u64(*((client_flags_t *) ITEM_suffix(it)), p);
                     }
                     break;
                 case 'l':

--- a/storage.c
+++ b/storage.c
@@ -248,7 +248,7 @@ int storage_get_item(conn *c, item *it, mc_resp *resp) {
     bool chunked = false;
     if (ntotal > settings.slab_chunk_size_max) {
         // Pull a chunked item header.
-        uint32_t flags;
+        client_flags_t flags;
         FLAGS_CONV(it, flags);
         new_it = item_alloc(ITEM_key(it), it->nkey, flags, it->exptime, it->nbytes);
         assert(new_it == NULL || (new_it->it_flags & ITEM_CHUNKED));
@@ -492,7 +492,7 @@ static int storage_write(void *storage, const int clsid, const int item_age) {
     item *it = it_info.it;
     /* First, storage for the header object */
     size_t orig_ntotal = ITEM_ntotal(it);
-    uint32_t flags;
+    client_flags_t flags;
     if ((it->it_flags & ITEM_HDR) == 0 &&
             (item_age == 0 || current_time - it->time > item_age)) {
         FLAGS_CONV(it, flags);
@@ -857,7 +857,7 @@ static void storage_compact_readback(void *storage, logger *l,
                         rescues++;
                     } else {
                         // re-alloc and replace header.
-                        uint32_t flags;
+                        client_flags_t flags;
                         FLAGS_CONV(hdr_it, flags);
                         item *new_it = do_item_alloc(ITEM_key(hdr_it), hdr_it->nkey, flags, hdr_it->exptime, sizeof(item_hdr));
                         if (new_it) {

--- a/t/flags.t
+++ b/t/flags.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 use strict;
-use Test::More tests => 8;
+use Test::More;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -9,10 +9,20 @@ use MemcachedTest;
 my $server = new_memcached();
 my $sock = $server->sock;
 
+my @fset = (0, 123, 2**16-1, 2**31);
+my $stats = mem_stats($sock, "settings");
+if ($stats->{client_flags_size} == 8) {
+    note "extra tests for large flags";
+    push(@fset, 2**32);
+    push(@fset, 2**48);
+}
+
 # set foo (and should get it)
-for my $flags (0, 123, 2**16-1, 2**31) {
+for my $flags (@fset) {
     print $sock "set foo $flags 0 6\r\nfooval\r\n";
     is(scalar <$sock>, "STORED\r\n", "stored foo");
     mem_get_is({ sock => $sock,
                  flags => $flags }, "foo", "fooval", "got flags $flags back");
 }
+
+done_testing();

--- a/thread.c
+++ b/thread.c
@@ -863,7 +863,7 @@ void sidethread_conn_close(conn *c) {
 /*
  * Allocates a new item.
  */
-item *item_alloc(const char *key, size_t nkey, int flags, rel_time_t exptime, int nbytes) {
+item *item_alloc(const char *key, size_t nkey, client_flags_t flags, rel_time_t exptime, int nbytes) {
     item *it;
     /* do_item_alloc handles its own locks */
     it = do_item_alloc(key, nkey, flags, exptime, nbytes);


### PR DESCRIPTION
turns client flag handling for text protocols from 4 bytes to 8 bytes.

TODO:
- [x] specific tests.
- [x] see about disabling or hobbling binprot
- [x] need some kind of stats output somewhere indicating size

@feihu-stripe 