### PR TITLE
proxy: request context refactor and new backend request API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,7 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_ratelim.c \
 					 proxy_jump_hash.c proxy_request.c \
 					 proxy_network.c proxy_lua.c \
+					 proxy_luafgen.c \
 					 proxy_config.c proxy_ring_hash.c \
 					 proxy_internal.c \
 					 md5.c md5.h

--- a/memcached.c
+++ b/memcached.c
@@ -876,7 +876,7 @@ static void conn_cleanup(conn *c) {
 
     conn_release_items(c);
 #ifdef PROXY
-    if (c->proxy_coro_ref) {
+    if (c->proxy_rctx) {
         proxy_cleanup_conn(c);
     }
 #endif

--- a/memcached.c
+++ b/memcached.c
@@ -3778,8 +3778,13 @@ static int server_sockets(int port, enum network_transport transport,
             const char *tagstr = "tag";
             if (strncmp(p, tagstr, strlen(tagstr)) == 0) {
                 p += strlen(tagstr);
-                if (*p == '[') {
+                // NOTE: should probably retire the [] dumbassery. those're
+                // shell characters.
+                if (*p == '[' || *p == '_') {
                     char *e = strchr(p, ']');
+                    if (e == NULL) {
+                        e = strchr(p+1, '_');
+                    }
                     if (e == NULL) {
                         fprintf(stderr, "Invalid tag in socket config: \"%s\"\n", p);
                         free(list);

--- a/memcached.h
+++ b/memcached.h
@@ -780,6 +780,9 @@ typedef struct _mc_resp {
      */
     bool skip;
     bool free; // double free detection.
+#ifdef PROXY
+    bool proxy_res; // we're handling a proxied response buffer.
+#endif
     // UDP bits. Copied in from the client.
     uint16_t    request_id; /* Incoming UDP request ID, if this is a UDP "connection" */
     uint16_t    udp_sequence; /* packet counter when transmitting result */
@@ -794,6 +797,7 @@ typedef struct _mc_resp {
 struct _mc_resp_bundle {
     uint8_t refcount;
     uint8_t next_check; // next object to check on assignment.
+    LIBEVENT_THREAD *thread;
     struct _mc_resp_bundle *next;
     struct _mc_resp_bundle *prev;
     mc_resp r[];

--- a/memcached.h
+++ b/memcached.h
@@ -861,7 +861,7 @@ struct conn {
     int io_queues_submitted; /* see notes on io_queue_t */
     io_queue_t io_queues[IO_QUEUE_COUNT]; /* set of deferred IO queues. */
 #ifdef PROXY
-    unsigned int proxy_coro_ref; /* lua reference for active coroutine */
+    void *proxy_rctx; /* pointer to active request context */
 #endif
 #ifdef EXTSTORE
     unsigned int recache_counter;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -408,6 +408,13 @@ void proxy_submit_cb(io_queue_t *q) {
 // pool calls and mcp.await()
 void proxy_return_rctx_cb(io_pending_t *pending) {
     io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
+    if (p->client_resp->blen) {
+        // FIXME: workaround for buffer memory being external to objects.
+        // can't run 0 since that means something special (run the GC)
+        unsigned int kb = p->client_resp->blen / 1000;
+        lua_gc(p->rctx->Lc, LUA_GCSTEP, kb > 0 ? kb : 1);
+    }
+
     if (p->is_await) {
         p->rctx->async_pending--;
         mcplib_await_return(p);

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -744,10 +744,9 @@ int proxy_run_rcontext(mcp_rcontext_t *rctx) {
         if (!rctx->parent) {
             WSTAT_DECR(c->thread, proxy_req_active, 1);
             int type = lua_type(Lc, 1);
+            mcp_resp_t *r = NULL;
             P_DEBUG("%s: coroutine completed. return type: %d\n", __func__, type);
-            if (type == LUA_TUSERDATA) {
-                // TODO: panic'ing here crashes the daemon.
-                mcp_resp_t *r = luaL_checkudata(Lc, 1, "mcp.response");
+            if (type == LUA_TUSERDATA && (r = luaL_testudata(Lc, 1, "mcp.response")) != NULL) {
                 _set_noreply_mode(resp, r);
                 if (r->status != MCMC_OK && r->resp.type != MCMC_RESP_ERRMSG) {
                     proxy_out_errstring(resp, PROXY_SERVER_ERROR, "backend failure");

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1023,7 +1023,7 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
     // hook is owned by a function generator.
     mcp_rcontext_t *rctx = mcp_funcgen_start(L, hook_ref.ctx, &pr);
     if (rctx == NULL) {
-        proxy_out_errstring(c->resp, PROXY_SERVER_ERROR, "lua failure");
+        proxy_out_errstring(c->resp, PROXY_SERVER_ERROR, "lua start failure");
         WSTAT_DECR(c->thread, proxy_req_active, 1);
         if (pr.vlen != 0) {
             c->sbytes = pr.vlen;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1169,7 +1169,6 @@ io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, m
     p->io_queue_type = IO_QUEUE_PROXY;
     p->thread = c->thread;
     p->c = c;
-    p->resp = rctx->resp; // FIXME: necessary?
     p->client_resp = r;
     p->flushed = false;
     p->return_cb = proxy_return_rctx_cb;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1022,7 +1022,7 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
         }
         return;
     }
-    // TODO: move some of this junk into mcp_funcgen_start.
+
     mcp_set_request(&pr, rctx->request, command, cmdlen);
     rctx->request->ascii_multiget = multiget;
     rctx->c = c;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -825,7 +825,7 @@ int proxy_run_rcontext(mcp_rcontext_t *rctx) {
                     proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad request");
                 }
                 break;
-            case MCP_YIELD_WAITFOR:
+            case MCP_YIELD_WAITCOND:
             case MCP_YIELD_WAITHANDLE:
                 // Even if we're in WAITHANDLE, we want to dispatch any queued
                 // requests, so we still need to iterate the full set of qslots.

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -14,7 +14,6 @@
 #define PROCESS_NORMAL false
 #define PROXY_GC_BACKGROUND_SECONDS 2
 static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool multiget);
-static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc);
 static void *mcp_profile_alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 
 /******** EXTERNAL FUNCTIONS ******/
@@ -233,6 +232,14 @@ void proxy_thread_init(void *ctx, LIBEVENT_THREAD *thr) {
     } else {
         L = luaL_newstate();
     }
+
+    // With smaller requests the default incremental collector appears to
+    // never complete. With this simple tuning (def-1, def, def) it seems
+    // fine.
+    // We can't use GCGEN until we manage pools with reference counting, as
+    // they may never hit GC and thus never release their connection
+    // resources.
+    lua_gc(L, LUA_GCINC, 199, 100, 13);
     thr->L = L;
     luaL_openlibs(L);
     proxy_register_libs(ctx, thr, L);
@@ -276,25 +283,19 @@ void proxy_submit_cb(io_queue_t *q) {
     while (p) {
         mcp_backend_t *be;
         P_DEBUG("%s: queueing req for backend: %p\n", __func__, (void *)p);
-        if (p->is_await) {
-            // need to not count await objects multiple times.
-            if (p->await_background) {
-                P_DEBUG("%s: fast-returning await_background object: %p\n", __func__, (void *)p);
-                // intercept await backgrounds
-                // this call cannot recurse if we're on the worker thread,
-                // since the worker thread has to finish executing this
-                // function in order to pick up the returned IO.
-                q->count++;
-                return_io_pending((io_pending_t *)p);
-                p = p->next;
-                continue;
-            } else if (p->await_first) {
-                q->count++;
-            }
+        if (p->await_background) {
+            P_DEBUG("%s: fast-returning await_background object: %p\n", __func__, (void *)p);
+            // intercept await backgrounds
+            // this call cannot recurse if we're on the worker thread,
+            // since the worker thread has to finish executing this
+            // function in order to pick up the returned IO.
+            return_io_pending((io_pending_t *)p);
+            p = p->next;
+            continue;
+        } else if (p->qcount_incr) {
             // funny workaround: awaiting IOP's don't count toward
             // resuming a connection, only the completion of the await
             // condition.
-        } else {
             q->count++;
         }
         be = p->backend;
@@ -354,40 +355,50 @@ void proxy_submit_cb(io_queue_t *q) {
     return;
 }
 
-// called from worker thread after an individual IO has been returned back to
-// the worker thread. Do post-IO run and cleanup work.
-void proxy_return_cb(io_pending_t *pending) {
+// This function handles return processing for the "old style" API: direct
+// pool calls and mcp.await()
+void proxy_return_rctx_cb(io_pending_t *pending) {
     io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
     if (p->is_await) {
+        p->rctx->async_pending--;
         mcplib_await_return(p);
-    } else {
-        lua_State *Lc = p->coro;
-
-        // in order to resume we need to remove the objects that were
-        // originally returned
-        // what's currently on the top of the stack is what we want to keep.
-        lua_rotate(Lc, 1, 1);
-        // We kept the original results from the yield so lua would not
-        // collect them in the meantime. We can drop those now.
-        lua_settop(Lc, 1);
-
-        // p can be freed/changed from the call below, so fetch the queue now.
-        io_queue_t *q = conn_io_queue_get(p->c, p->io_queue_type);
-        conn *c = p->c;
-        proxy_run_coroutine(Lc, p->resp, p, c);
-
-        q->count--;
-        if (q->count == 0) {
-            // call re-add directly since we're already in the worker thread.
-            conn_worker_readd(c);
+        // need to directly attempt to return the context,
+        // we may or may not be hitting proxy_run_rcontext from await_return.
+        if (p->rctx->async_pending == 0) {
+            mcp_funcgen_return_rctx(p->rctx);
         }
+        return;
+    }
+
+    mcp_rcontext_t *rctx = p->rctx;
+    lua_rotate(rctx->Lc, 1, 1);
+    lua_settop(rctx->Lc, 1);
+    // FIXME: ensure this was intentional.
+    // if we're making a sub-request that comes from extstore the iop needs to
+    // hang around.
+    //rctx->resp->io_pending = NULL;
+
+    proxy_run_rcontext(rctx);
+    mcp_funcgen_return_rctx(rctx);
+
+    io_queue_t *q = conn_io_queue_get(p->c, p->io_queue_type);
+    // Detatch the iop from the mc_resp and free it here.
+    conn *c = p->c;
+    do_cache_free(p->thread->io_cache, p);
+
+    q->count--;
+    if (q->count == 0) {
+        // call re-add directly since we're already in the worker thread.
+        conn_worker_readd(c);
     }
 }
 
-// called from the worker thread as an mc_resp is being freed.
-// must let go of the coroutine reference if there is one.
-// caller frees the pending IO.
-void proxy_finalize_cb(io_pending_t *pending) {
+// This is called if resp_finish is called while an iop exists on the
+// resp.
+// so we need to release our iop and rctx.
+// - This can't happen unless we're doing extstore fetches.
+// - the request context is freed before connection processing resumes.
+void proxy_finalize_rctx_cb(io_pending_t *pending) {
     io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
 
     if (p->io_type == IO_PENDING_TYPE_EXTSTORE) {
@@ -398,17 +409,10 @@ void proxy_finalize_cb(io_pending_t *pending) {
             }
             item_remove(p->hdr_it);
         }
+    } else {
+        // FIXME: remove this after completing audit.
+        assert(1 == 0);
     }
-
-    // release our coroutine reference.
-    // TODO (v2): coroutines are reusable in lua 5.4. we can stack this onto a freelist
-    // after a lua_resetthread(Lc) call.
-    if (p->coro_ref) {
-        // Note: lua registry is the same for main thread or a coroutine.
-        luaL_unref(p->coro, LUA_REGISTRYINDEX, p->coro_ref);
-    }
-
-    return;
 }
 
 int try_read_command_proxy(conn *c) {
@@ -468,11 +472,14 @@ int try_read_command_proxy(conn *c) {
 // Called when a connection is closed while in nread state reading a set
 // Must only be called with an active coroutine.
 void proxy_cleanup_conn(conn *c) {
-    assert(c->proxy_coro_ref != 0);
+    assert(c->proxy_rctx);
     LIBEVENT_THREAD *thr = c->thread;
-    lua_State *L = thr->L;
-    luaL_unref(L, LUA_REGISTRYINDEX, c->proxy_coro_ref);
-    c->proxy_coro_ref = 0;
+    mcp_rcontext_t *rctx = c->proxy_rctx;
+    assert(rctx->pending_reqs == 1);
+    rctx->pending_reqs = 0;
+
+    mcp_funcgen_return_rctx(rctx);
+    c->proxy_rctx = NULL;
     WSTAT_DECR(thr, proxy_req_active, 1);
 }
 
@@ -483,26 +490,23 @@ void complete_nread_proxy(conn *c) {
     LIBEVENT_THREAD *thr = c->thread;
     lua_State *L = thr->L;
 
-    if (c->proxy_coro_ref == 0) {
+    if (c->proxy_rctx == NULL) {
         complete_nread_ascii(c);
         return;
     }
 
     conn_set_state(c, conn_new_cmd);
 
-    // Grab our coroutine.
-    // Leave the reference alone in case we error out, so the conn cleanup
-    // routine can handle it properly.
-    lua_rawgeti(L, LUA_REGISTRYINDEX, c->proxy_coro_ref);
-    lua_State *Lc = lua_tothread(L, -1);
-    mcp_request_t *rq = luaL_checkudata(Lc, -1, "mcp.request");
+    assert(c->proxy_rctx);
+    mcp_rcontext_t *rctx = c->proxy_rctx;
+    mcp_request_t *rq = rctx->request;
 
-    // validate the data chunk.
     if (strncmp((char *)c->item + rq->pr.vlen - 2, "\r\n", 2) != 0) {
         lua_settop(L, 0); // clear anything remaining on the main thread.
         // FIXME (v2): need to set noreply false if mset_res, but that's kind
         // of a weird hack to begin with. Evaluate how to best do that here.
         out_string(c, "CLIENT_ERROR bad data chunk");
+        // TODO: return rctx.
         return;
     }
 
@@ -512,13 +516,13 @@ void complete_nread_proxy(conn *c) {
     rq->pr.vbuf = c->item;
     c->item = NULL;
     c->item_malloced = false;
-    luaL_unref(L, LUA_REGISTRYINDEX, c->proxy_coro_ref);
-    c->proxy_coro_ref = 0;
+    c->proxy_rctx = NULL;
     pthread_mutex_lock(&thr->proxy_limit_lock);
     thr->proxy_buffer_memory_used += rq->pr.vlen;
     pthread_mutex_unlock(&thr->proxy_limit_lock);
 
-    proxy_run_coroutine(Lc, c->resp, NULL, c);
+    proxy_run_rcontext(rctx);
+    mcp_funcgen_return_rctx(rctx);
 
     lua_settop(L, 0); // clear anything remaining on the main thread.
 
@@ -593,149 +597,167 @@ static void _set_noreply_mode(mc_resp *resp, mcp_resp_t *r) {
     }
 }
 
-// this resumes every yielded coroutine (and re-resumes if necessary).
-// called from the worker thread after responses have been pulled from the
-// network.
-// Flow:
-// - the response object should already be on the coroutine stack.
-// - fix up the stack.
-// - run coroutine.
-// - if LUA_YIELD, we need to swap out the pending IO from its mc_resp then call for a queue
-// again.
-// - if LUA_OK finalize the response and return
-// - else set error into mc_resp.
-int proxy_run_coroutine(lua_State *Lc, mc_resp *resp, io_pending_proxy_t *p, conn *c) {
+static void _proxy_run_rcontext_queues(mcp_rcontext_t *rctx) {
+    for (int x = 0; x < rctx->fgen->max_queues; x++) {
+        mcp_run_rcontext_handle(rctx, x);
+    }
+}
+
+static void _proxy_run_tresp_to_resp(mc_resp *tresp, mc_resp *resp) {
+    // The internal cache handler has created a resp we want to swap in
+    // here. It would be fastest to swap *resp's position in the
+    // link but if the set is deep this would instead be slow, so
+    // we copy over details from this temporary resp instead.
+
+    // So far all we fill is the wbuf and some iov's? so just copy
+    // that + the UDP info?
+    memcpy(resp->wbuf, tresp->wbuf, tresp->iov[0].iov_len);
+    for (int x = 0; x < tresp->iovcnt; x++) {
+        resp->iov[x] = tresp->iov[x];
+    }
+    // resp->iov[x].iov_base needs to be updated if it's
+    // pointing within its wbuf.
+    // FIXME: This is too fragile. we need to be able to
+    // inherit details and swap resp objects around.
+    if (tresp->iov[0].iov_base == tresp->wbuf) {
+        resp->iov[0].iov_base = resp->wbuf;
+    }
+    resp->iovcnt = tresp->iovcnt;
+    resp->chunked_total = tresp->chunked_total;
+    resp->chunked_data_iov = tresp->chunked_data_iov;
+    // copy UDP headers...
+    resp->request_id = tresp->request_id;
+    resp->udp_sequence = tresp->udp_sequence;
+    resp->udp_total = tresp->udp_total;
+    resp->request_addr = tresp->request_addr;
+    resp->request_addr_size = tresp->request_addr_size;
+    resp->item = tresp->item; // will be populated if not extstore fetch
+    resp->skip = tresp->skip;
+}
+
+// HACK NOTES:
+// These are self-notes for dormando mostly.
+// The IO queue system does not work well with the proxy, as we need to:
+// - only increment q->count during the submit phase
+//   - .. because a resumed coroutine can queue more data.
+//   - and we will never hit q->count == 0
+//   - .. and then never resume the main connection. (conn_worker_readd)
+//   - which will never submit the new sub-requests
+// - need to only increment q->count once per stack of requests coming from a
+//   resp.
+//
+// There are workarounds for this all over. In the await code, we test for
+// "the first await object" or "is an await background object", for
+// incrementing the q->count
+// For pool-backed requests we always increment in submit
+// For RQU backed requests (new API) there isn't an easy place to test for
+// "the first request", because:
+// - The connection queue is a stack of _all_ requests pending on this
+// connection, and many requests can arrive in one batch.
+//   - Thus we cannot simply check if there are items in the queue
+// - RQU's can be recursive, so we have to loop back to the parent to check to
+//   see if we're the first queue or not.
+//
+// This hack workaround exists so I can fix the IO queue subsystem as a change
+// independent of the RCTX change, as the IO queue touches everything and
+// scares the shit out of me. It's much easier to make changes to it in
+// isolation, when all existing systems are currently working and testable.
+//
+// Description of the hack:
+// - in mcp_queue_io: roll up rctx to parent, and if we are the first IO to queue
+// since the rcontext started, set p->qcounr_incr = true
+// Later in submit_cb:
+// - q->count++ if p->qcount_incr.
+//
+// Finally, in proxy_return_rqu_cb:
+// - If parent completed non-yielded work, q->count-- to allow conn
+// resumption.
+// - At bottom of rqu_cb(), flush any IO queues for the connection in case we
+// re-queued work.
+int proxy_run_rcontext(mcp_rcontext_t *rctx) {
     int nresults = 0;
+    lua_State *Lc = rctx->Lc;
     int cores = lua_resume(Lc, NULL, 1, &nresults);
     size_t rlen = 0;
+    conn *c = rctx->c;
+    mc_resp *resp = rctx->resp;
 
     if (cores == LUA_OK) {
-        WSTAT_DECR(c->thread, proxy_req_active, 1);
-        int type = lua_type(Lc, 1);
-        P_DEBUG("%s: coroutine completed. return type: %d\n", __func__, type);
-        if (type == LUA_TUSERDATA) {
-            mcp_resp_t *r = luaL_checkudata(Lc, 1, "mcp.response");
-            _set_noreply_mode(resp, r);
-            if (r->status != MCMC_OK && r->resp.type != MCMC_RESP_ERRMSG) {
-                proxy_out_errstring(resp, PROXY_SERVER_ERROR, "backend failure");
-            } else if (r->cresp) {
-                mc_resp *tresp = r->cresp;
-                // The internal cache handler has created a resp we want to swap in
-                // here. It would be fastest to swap *resp's position in the
-                // link but if the set is deep this would instead be slow, so
-                // we copy over details from this temporary resp instead.
-                assert(c != NULL);
+        // don't touch the result object if we were a sub-context.
+        if (!rctx->parent) {
+            WSTAT_DECR(c->thread, proxy_req_active, 1);
+            int type = lua_type(Lc, 1);
+            P_DEBUG("%s: coroutine completed. return type: %d\n", __func__, type);
+            if (type == LUA_TUSERDATA) {
+                // TODO: panic'ing here crashes the daemon.
+                mcp_resp_t *r = luaL_checkudata(Lc, 1, "mcp.response");
+                _set_noreply_mode(resp, r);
+                if (r->status != MCMC_OK && r->resp.type != MCMC_RESP_ERRMSG) {
+                    proxy_out_errstring(resp, PROXY_SERVER_ERROR, "backend failure");
+                } else if (r->cresp) {
+                    mc_resp *tresp = r->cresp;
+                    assert(c != NULL);
 
-                // So far all we fill is the wbuf and some iov's? so just copy
-                // that + the UDP info?
-                memcpy(resp->wbuf, tresp->wbuf, tresp->iov[0].iov_len);
-                for (int x = 0; x < tresp->iovcnt; x++) {
-                    resp->iov[x] = tresp->iov[x];
+                    _proxy_run_tresp_to_resp(tresp, resp);
+                    // we let the mcp_resp gc handler free up tresp and any
+                    // associated io_pending's of its own later.
+                } else if (r->buf) {
+                    // response set from C.
+                    resp->write_and_free = r->buf;
+                    resp_add_iov(resp, r->buf, r->blen);
+                    r->buf = NULL;
+                } else {
+                    // Empty response: used for ascii multiget emulation.
                 }
-                // resp->iov[x].iov_base needs to be updated if it's
-                // pointing within its wbuf.
-                // FIXME: This is too fragile. we need to be able to
-                // inherit details and swap resp objects around.
-                if (tresp->iov[0].iov_base == tresp->wbuf) {
-                    resp->iov[0].iov_base = resp->wbuf;
-                }
-                resp->iovcnt = tresp->iovcnt;
-                resp->chunked_total = tresp->chunked_total;
-                resp->chunked_data_iov = tresp->chunked_data_iov;
-                // copy UDP headers...
-                resp->request_id = tresp->request_id;
-                resp->udp_sequence = tresp->udp_sequence;
-                resp->udp_total = tresp->udp_total;
-                resp->request_addr = tresp->request_addr;
-                resp->request_addr_size = tresp->request_addr_size;
-                resp->item = tresp->item; // will be populated if not extstore fetch
-                resp->skip = tresp->skip;
 
-                // we let the mcp_resp gc handler free up tresp and any
-                // associated io_pending's of its own later.
-            } else if (r->buf) {
-                // response set from C.
-                resp->write_and_free = r->buf;
-                resp_add_iov(resp, r->buf, r->blen);
-                r->buf = NULL;
-            } else if (lua_getiuservalue(Lc, 1, 1) != LUA_TNIL) {
-                // uservalue slot 1 is pre-created, so we get TNIL instead of
-                // TNONE when nothing was set into it.
-                const char *s = lua_tolstring(Lc, -1, &rlen);
+            } else if (type == LUA_TSTRING) {
+                // response is a raw string from lua.
+                const char *s = lua_tolstring(Lc, 1, &rlen);
                 size_t l = rlen > WRITE_BUFFER_SIZE ? WRITE_BUFFER_SIZE : rlen;
                 memcpy(resp->wbuf, s, l);
                 resp_add_iov(resp, resp->wbuf, l);
                 lua_pop(Lc, 1);
             } else {
-                // Empty response: used for ascii multiget emulation.
+                proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad response");
             }
-
-        } else if (type == LUA_TSTRING) {
-            // response is a raw string from lua.
-            const char *s = lua_tolstring(Lc, 1, &rlen);
-            size_t l = rlen > WRITE_BUFFER_SIZE ? WRITE_BUFFER_SIZE : rlen;
-            memcpy(resp->wbuf, s, l);
-            resp_add_iov(resp, resp->wbuf, l);
-            lua_pop(Lc, 1);
-        } else {
-            proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad response");
         }
 
+        rctx->pending_reqs--;
     } else if (cores == LUA_YIELD) {
-        int coro_ref = 0;
         int yield_type = lua_tointeger(Lc, -1);
         P_DEBUG("%s: coroutine yielded. return type: %d\n", __func__, yield_type);
         assert(yield_type != 0);
         lua_pop(Lc, 1);
 
-        // need to remove and free the io_pending, since c->resp owns it.
-        // so we call mcp_queue_io() again and let it override the
-        // mc_resp's io_pending object.
-        //
-        // p is not null only when being called from proxy_return_cb(),
-        // a pending IO is returning to resume.
-        if (p != NULL) {
-            coro_ref = p->coro_ref;
-            assert((void *)p == (void *)resp->io_pending);
-            resp->io_pending = NULL;
-            c = p->c;
-            // *p is now dead.
-            do_cache_free(c->thread->io_cache, p);
-        } else {
-            // coroutine object sitting on the _main_ VM right now, so we grab
-            // the reference from there, which also pops it.
-            assert(c != NULL);
-            coro_ref = luaL_ref(c->thread->L, LUA_REGISTRYINDEX);
-        }
-
         int res = 0;
+        mcp_request_t *rq = NULL;
+        mcp_backend_t *be = NULL;
+        mcp_resp_t *r = NULL;
         switch (yield_type) {
             case MCP_YIELD_AWAIT:
-                mcplib_await_run(c, resp, Lc, coro_ref);
+                // called with await context on the stack.
+                rctx->first_queue = false; // HACK: ensure awaits are counted.
+                mcplib_await_run_rctx(rctx);
                 break;
             case MCP_YIELD_POOL:
                 // TODO (v2): c only used for cache alloc?
-                mcp_queue_io(c, resp, coro_ref, Lc);
+                // pool_call checks the argument already.
+                be = lua_touserdata(Lc, -1);
+                rq = lua_touserdata(Lc, -2);
+                // not using a pre-made res object from this yield type.
+                r = mcp_prep_resobj(Lc, rq, be, c->thread);
+                rctx->first_queue = false; // HACK: ensure poolreqs are counted.
+                mcp_queue_rctx_io(rctx, rq, be, r);
                 break;
-            case MCP_YIELD_LOCAL:
+            case MCP_YIELD_INTERNAL:
                 // stack should be: rq, res
-                res = mcplib_internal_run(Lc, c, resp, coro_ref);
+                res = mcplib_internal_run(rctx);
                 if (res == 0) {
                     // stack should still be: rq, res
                     // TODO: turn this function into a for loop that re-runs on
                     // certain status codes, to avoid recursive depth here.
-                    //
-                    // FIXME: this dance with the coroutine reference is
-                    // annoying. In this case we immediately resume, so no *io
-                    // was generated, so we won't do the above coro_ref swap, so
-                    // we'll try to take the coro_ref again and fail.
-                    // The ref is only actually used in proxy_await
-                    // It should instead be stashed on the top mc_resp object
-                    // (ideally removing c->proxy_coro_ref at the same time)
-                    // and unref'ed when the resp is cleaned up.
-                    lua_rawgeti(c->thread->L, LUA_REGISTRYINDEX, coro_ref);
-                    luaL_unref(c->thread->L, LUA_REGISTRYINDEX, coro_ref);
-                    proxy_run_coroutine(Lc, resp, NULL, c);
+                    // or maybe... a goto? :P
+                    proxy_run_rcontext(rctx);
                 } else if (res > 0) {
                     // internal run queued for extstore.
                 } else {
@@ -743,18 +765,28 @@ int proxy_run_coroutine(lua_State *Lc, mc_resp *resp, io_pending_proxy_t *p, con
                     proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad request");
                 }
                 break;
+            case MCP_YIELD_WAITFOR:
+            case MCP_YIELD_WAITHANDLE:
+                // Even if we're in WAITHANDLE, we want to dispatch any queued
+                // requests, so we still need to iterate the full set of qslots.
+                _proxy_run_rcontext_queues(rctx);
+                break;
             default:
                 abort();
         }
 
     } else {
-        WSTAT_DECR(c->thread, proxy_req_active, 1);
+        // Log the error where it happens, then the parent will handle a
+        // result object normally.
         P_DEBUG("%s: Failed to run coroutine: %s\n", __func__, lua_tostring(Lc, -1));
         LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, lua_tostring(Lc, -1));
-        proxy_out_errstring(resp, PROXY_SERVER_ERROR, "lua failure");
+        if (!rctx->parent) {
+            WSTAT_DECR(c->thread, proxy_req_active, 1);
+            proxy_out_errstring(resp, PROXY_SERVER_ERROR, "lua failure");
+        }
     }
 
-    return 0;
+    return cores;
 }
 
 // basically any data before the first key.
@@ -792,22 +824,22 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
     }
 
     struct proxy_hook *hook = &hooks[pr.command];
-    int hook_ref = hook->lua_ref;
+    struct proxy_hook_ref hook_ref = hook->ref;
     // if client came from a tagged listener, scan for a more specific hook.
     // TODO: (v2) avoiding a hash table lookup here, but maybe some other
     // datastructure would suffice. for 4-8 tags this is perfectly fast.
     if (c->tag && hook->tagged) {
         struct proxy_hook_tagged *pht = hook->tagged;
-        while (pht->lua_ref) {
+        while (pht->ref.lua_ref) {
             if (c->tag == pht->tag) {
-                hook_ref = pht->lua_ref;
+                hook_ref = pht->ref;
                 break;
             }
             pht++;
         }
     }
 
-    if (!hook_ref) {
+    if (!hook_ref.lua_ref) {
         // need to pass our command string into the internal handler.
         // to minimize the code change, this means allowing it to tokenize the
         // full command. The proxy's indirect parser should be built out to
@@ -821,7 +853,7 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
             command[cmdlen-1] = '\0';
         }
         // lets nread_proxy know we're in ascii mode.
-        c->proxy_coro_ref = 0;
+        c->proxy_rctx = NULL;
         process_command_ascii(c, command);
         return;
     }
@@ -928,21 +960,24 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
         return;
     }
 
-    // start a coroutine.
-    // TODO (v2): This can pull a thread from a cache.
-    lua_newthread(L);
-    lua_State *Lc = lua_tothread(L, -1);
-    // leave the thread first on the stack, so we can reference it if needed.
-    // pull the lua hook function onto the stack.
-    lua_rawgeti(Lc, LUA_REGISTRYINDEX, hook_ref);
+    // hook is owned by a function generator.
+    // FIXME: allow to fail?
+    mcp_rcontext_t *rctx = mcplib_funcgen_get_rctx(L, hook_ref.lua_ref, hook_ref.ctx);
+    mcp_set_request(&pr, rctx->request, command, cmdlen);
+    rctx->request->ascii_multiget = multiget;
+    rctx->c = c;
+    rctx->pending_reqs++; // seed counter with the "main" request
+    // remember the top level mc_resp, because further requests on the
+    // same connection will replace c->resp.
+    rctx->resp = c->resp;
 
-    mcp_request_t *rq = mcp_new_request(Lc, &pr, command, cmdlen);
-    rq->ascii_multiget = multiget;
-    // NOTE: option 1) copy c->tag into rq->tag here.
-    // add req:listen_tag() to retrieve in top level route.
+    // for the very first call we need to place:
+    // - rctx->function_ref + rctx->request_ref
+    // I _think_ here is the right place to do that?
+    lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rctx->function_ref);
+    lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rctx->request_ref);
 
-    // TODO (v2): lift this to a post-processor?
-    if (rq->pr.vlen != 0) {
+    if (pr.vlen != 0) {
         c->item = NULL;
         // Need to add the used memory later due to needing an extra callback
         // handler on error during nread.
@@ -950,53 +985,56 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
 
         // relying on temporary malloc's not having fragmentation
         if (!oom) {
-            c->item = malloc(rq->pr.vlen);
+            c->item = malloc(pr.vlen);
         }
         if (c->item == NULL) {
             lua_settop(L, 0);
             proxy_out_errstring(c->resp, PROXY_SERVER_ERROR, "out of memory");
             WSTAT_DECR(c->thread, proxy_req_active, 1);
-            c->sbytes = rq->pr.vlen;
+            c->sbytes = pr.vlen;
             conn_set_state(c, conn_swallow);
             return;
         }
         c->item_malloced = true;
         c->ritem = c->item;
-        c->rlbytes = rq->pr.vlen;
-        c->proxy_coro_ref = luaL_ref(L, LUA_REGISTRYINDEX); // pops coroutine.
+        c->rlbytes = pr.vlen;
+
+        // remember the request context for later.
+        c->proxy_rctx = rctx;
 
         conn_set_state(c, conn_nread);
         return;
-    } else {
-        conn_set_state(c, conn_new_cmd);
     }
 
-    proxy_run_coroutine(Lc, c->resp, NULL, c);
+    proxy_run_rcontext(rctx);
+    mcp_funcgen_return_rctx(rctx);
 
-    lua_settop(L, 0); // clear anything remaining on the main thread.
+    lua_settop(L, 0); // clear any junk from the main thread.
 }
 
-// analogue for storage_get_item(); add a deferred IO object to the current
-// connection's response object. stack enough information to write to the
-// server on the submit callback, and enough to resume the lua state on the
-// completion callback.
-static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
-    io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_PROXY);
+mcp_resp_t *mcp_prep_bare_resobj(lua_State *L, LIBEVENT_THREAD *t) {
+    mcp_resp_t *r = lua_newuserdatauv(L, sizeof(mcp_resp_t), 0);
+    // FIXME (v2): is this memset still necessary? I was using it for
+    // debugging.
+    memset(r, 0, sizeof(mcp_resp_t));
+    r->thread = t;
+    assert(r->thread != NULL);
+    gettimeofday(&r->start, NULL);
 
-    // stack: request, hash selector. latter just to hold a reference.
+    luaL_getmetatable(L, "mcp.response");
+    lua_setmetatable(L, -2);
 
-    mcp_request_t *rq = luaL_checkudata(Lc, -1, "mcp.request");
-    mcp_backend_t *be = rq->be;
+    return r;
+}
 
-    // Then we push a response object, which we'll re-use later.
-    // reserve one uservalue for a lua-supplied response.
-    mcp_resp_t *r = lua_newuserdatauv(Lc, sizeof(mcp_resp_t), 1);
+mcp_resp_t *mcp_prep_resobj(lua_State *L, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t) {
+    mcp_resp_t *r = lua_newuserdatauv(L, sizeof(mcp_resp_t), 0);
     // FIXME (v2): is this memset still necessary? I was using it for
     // debugging.
     memset(r, 0, sizeof(mcp_resp_t));
     r->buf = NULL;
     r->blen = 0;
-    r->thread = c->thread;
+    r->thread = t;
     assert(r->thread != NULL);
     gettimeofday(&r->start, NULL);
     // Set noreply mode.
@@ -1023,14 +1061,24 @@ static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
 
     r->cmd = rq->pr.command;
 
-    luaL_getmetatable(Lc, "mcp.response");
-    lua_setmetatable(Lc, -2);
+    strncpy(r->be_name, be->name, MAX_NAMELEN+1);
+    strncpy(r->be_port, be->port, MAX_PORTLEN+1);
 
+    luaL_getmetatable(L, "mcp.response");
+    lua_setmetatable(L, -2);
+
+    return r;
+}
+
+// Used for any cases where we're queueing requests to the IO subsystem.
+io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, mcp_backend_t *be, mcp_resp_t *r) {
+    conn *c = rctx->c;
+    io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_PROXY);
     io_pending_proxy_t *p = do_cache_alloc(c->thread->io_cache);
     if (p == NULL) {
         WSTAT_INCR(c->thread, proxy_conn_oom, 1);
-        proxy_lua_error(Lc, "out of memory allocating from IO cache");
-        return;
+        proxy_lua_error(rctx->Lc, "out of memory allocating from IO cache");
+        return NULL;
     }
 
     // this is a re-cast structure, so assert that we never outsize it.
@@ -1040,36 +1088,44 @@ static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
     p->io_queue_type = IO_QUEUE_PROXY;
     p->thread = c->thread;
     p->c = c;
-    p->resp = resp;
+    p->resp = rctx->resp; // FIXME: necessary?
     p->client_resp = r;
     p->flushed = false;
-    p->ascii_multiget = rq->ascii_multiget;
-    p->return_cb = proxy_return_cb;
-    p->finalize_cb = proxy_finalize_cb;
-    resp->io_pending = (io_pending_t *)p;
+    p->return_cb = proxy_return_rctx_cb;
+    p->finalize_cb = proxy_finalize_rctx_cb;
+    // FIXME: Why was I doing this?
+    // - conn cannot resume until all queued requests resolve
+    //rctx->resp->io_pending = (io_pending_t *)p;
 
-    // top of the main thread should be our coroutine.
-    // lets grab a reference to it and pop so it doesn't get gc'ed.
-    p->coro_ref = coro_ref;
+    // pass along the request context for resumption.
+    p->rctx = rctx;
 
-    // we'll drop the pointer to the coro on here to save some CPU
-    // on re-fetching it later. The pointer shouldn't change.
-    p->coro = Lc;
+    if (rq) {
+        p->ascii_multiget = rq->ascii_multiget;
+        // The direct backend object. Lc is holding the reference in the stack
+        p->backend = be;
 
-    // The direct backend object. Lc is holding the reference in the stack
-    p->backend = be;
-    // See #887 for notes.
-    // TODO (v2): hopefully this can be optimized out.
-    strncpy(r->be_name, be->name, MAX_NAMELEN+1);
-    strncpy(r->be_port, be->port, MAX_PORTLEN+1);
+        mcp_request_attach(rctx->Lc, rq, p);
+    }
 
-    mcp_request_attach(Lc, rq, p);
+    // HACK
+    // find the parent rctx
+    while (rctx->parent) {
+        rctx = rctx->parent;
+    }
+    // Hack to enforce the first iop increments client IO queue counter.
+    if (!rctx->first_queue) {
+        rctx->first_queue = true;
+        p->qcount_incr = true;
+    }
+    // END HACK
 
     // link into the batch chain.
     p->next = q->stack_ctx;
     q->stack_ctx = p;
+    P_DEBUG("%s: queued\n", __func__);
 
-    return;
+    return p;
 }
 
 static void *mcp_profile_alloc(void *ud, void *ptr, size_t osize,

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1170,9 +1170,6 @@ io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, m
     p->flushed = false;
     p->return_cb = proxy_return_rctx_cb;
     p->finalize_cb = proxy_finalize_rctx_cb;
-    // FIXME: Why was I doing this?
-    // - conn cannot resume until all queued requests resolve
-    //rctx->resp->io_pending = (io_pending_t *)p;
 
     // pass along the request context for resumption.
     p->rctx = rctx;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -786,6 +786,7 @@ int proxy_run_rcontext(mcp_rcontext_t *rctx) {
             WSTAT_DECR(c->thread, proxy_req_active, 1);
             proxy_out_errstring(resp, PROXY_SERVER_ERROR, "lua failure");
         }
+        rctx->pending_reqs--;
     }
 
     return cores;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1148,6 +1148,9 @@ mcp_resp_t *mcp_prep_resobj(lua_State *L, mcp_request_t *rq, mcp_backend_t *be, 
 }
 
 // Used for any cases where we're queueing requests to the IO subsystem.
+// NOTE: it's not currently possible to limit the memory used by the IO
+// object cache. So this check is redundant, and any callers may proceed
+// as though it is successful.
 io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, mcp_backend_t *be, mcp_resp_t *r) {
     conn *c = rctx->c;
     io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_PROXY);
@@ -1155,6 +1158,8 @@ io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, m
     if (p == NULL) {
         WSTAT_INCR(c->thread, proxy_conn_oom, 1);
         proxy_lua_error(rctx->Lc, "out of memory allocating from IO cache");
+        // NOTE: the error call above jumps to an error handler, so this does
+        // not actually return.
         return NULL;
     }
 

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1182,7 +1182,7 @@ io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, m
         // The direct backend object. Lc is holding the reference in the stack
         p->backend = be;
 
-        mcp_request_attach(rctx->Lc, rq, p);
+        mcp_request_attach(rq, p);
     }
 
     // HACK

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1012,7 +1012,7 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
     }
 
     // hook is owned by a function generator.
-    mcp_rcontext_t *rctx = mcplib_funcgen_get_rctx(L, hook_ref.lua_ref, hook_ref.ctx);
+    mcp_rcontext_t *rctx = mcp_funcgen_start(L, hook_ref.ctx, &pr);
     if (rctx == NULL) {
         proxy_out_errstring(c->resp, PROXY_SERVER_ERROR, "lua failure");
         WSTAT_DECR(c->thread, proxy_req_active, 1);
@@ -1022,6 +1022,7 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
         }
         return;
     }
+    // TODO: move some of this junk into mcp_funcgen_start.
     mcp_set_request(&pr, rctx->request, command, cmdlen);
     rctx->request->ascii_multiget = multiget;
     rctx->c = c;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -283,6 +283,13 @@ void proxy_submit_cb(io_queue_t *q) {
     while (p) {
         mcp_backend_t *be;
         P_DEBUG("%s: queueing req for backend: %p\n", __func__, (void *)p);
+        if (p->qcount_incr) {
+            // funny workaround: awaiting IOP's don't count toward
+            // resuming a connection, only the completion of the await
+            // condition.
+            q->count++;
+        }
+
         if (p->await_background) {
             P_DEBUG("%s: fast-returning await_background object: %p\n", __func__, (void *)p);
             // intercept await backgrounds
@@ -292,11 +299,6 @@ void proxy_submit_cb(io_queue_t *q) {
             return_io_pending((io_pending_t *)p);
             p = p->next;
             continue;
-        } else if (p->qcount_incr) {
-            // funny workaround: awaiting IOP's don't count toward
-            // resuming a connection, only the completion of the await
-            // condition.
-            q->count++;
         }
         be = p->backend;
 

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -19,8 +19,6 @@ void proxy_worker_reload(void *arg, LIBEVENT_THREAD *thr);
 
 void proxy_submit_cb(io_queue_t *q);
 void proxy_complete_cb(io_queue_t *q);
-void proxy_return_cb(io_pending_t *pending);
-void proxy_finalize_cb(io_pending_t *pending);
 
 /* lua */
 int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state);

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -3,6 +3,7 @@
 
 void proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
 void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
+void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c);
 
 /* proxy mode handlers */
 int try_read_command_proxy(conn *c);

--- a/proto_text.c
+++ b/proto_text.c
@@ -804,6 +804,8 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
 #ifdef PROXY
     } else if (strcmp(subcommand, "proxy") == 0) {
         process_proxy_stats(settings.proxy_ctx, &append_stats, c);
+    } else if (strcmp(subcommand, "proxyfuncs") == 0) {
+        process_proxy_funcstats(settings.proxy_ctx, &append_stats, c);
 #endif
     } else {
         /* getting here means that the subcommand is either engine specific or

--- a/proxy.h
+++ b/proxy.h
@@ -704,6 +704,7 @@ int mcplib_rcontext_queue_assign(lua_State *L);
 int mcplib_rcontext_queue(lua_State *L);
 int mcplib_rcontext_wait_for(lua_State *L);
 int mcplib_rcontext_wait_handle(lua_State *L);
+int mcplib_rcontext_queue_and_wait(lua_State *L);
 int mcplib_rcontext_good(lua_State *L);
 int mcplib_rcontext_any(lua_State *L);
 int mcplib_rcontext_ok(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -718,7 +718,7 @@ int mcplib_funcgen_new_handle(lua_State *L);
 int mcplib_funcgen_ready(lua_State *L);
 int mcplib_router_new(lua_State *L);
 mcp_rcontext_t *mcp_funcgen_start(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_t *pr);
-mcp_rcontext_t *mcplib_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen);
+mcp_rcontext_t *mcp_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen);
 void mcp_funcgen_return_rctx(mcp_rcontext_t *rctx);
 int mcplib_funcgen_gc(lua_State *L);
 void mcp_funcgen_reference(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -641,7 +641,9 @@ struct mcp_funcgen_s {
     unsigned int free_max; // size of list below.
     unsigned int routecount; // total routes if this fgen is a router.
     bool closed; // the hook holding this fgen has been replaced
+    bool ready; // if we're locked down or not.
     mcp_rcontext_t **list;
+    struct mcp_rqueue_s *queue_list;
     struct mcp_funcgen_router router;
 };
 
@@ -700,7 +702,7 @@ struct mcp_rcontext_s {
 void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle);
 void mcp_process_rctx_wait(mcp_rcontext_t *rctx, int handle);
 int mcp_process_rqueue_return(mcp_rcontext_t *rctx, int handle, mcp_resp_t *res);
-int mcplib_rcontext_queue_assign(lua_State *L);
+int mcplib_rcontext_queue_set_cb(lua_State *L);
 int mcplib_rcontext_queue(lua_State *L);
 int mcplib_rcontext_wait_for(lua_State *L);
 int mcplib_rcontext_wait_handle(lua_State *L);
@@ -710,6 +712,8 @@ int mcplib_rcontext_any(lua_State *L);
 int mcplib_rcontext_ok(lua_State *L);
 int mcplib_funcgenbare_new(lua_State *L);
 int mcplib_funcgen_new(lua_State *L);
+int mcplib_funcgen_queue_assign(lua_State *L);
+int mcplib_funcgen_ready(lua_State *L);
 int mcplib_router_new(lua_State *L);
 mcp_rcontext_t *mcp_funcgen_start(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_t *pr);
 mcp_rcontext_t *mcplib_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen);

--- a/proxy.h
+++ b/proxy.h
@@ -750,7 +750,7 @@ int mcplib_open_dist_ring_hash(lua_State *L);
 
 int proxy_run_rcontext(mcp_rcontext_t *rctx);
 mcp_backend_t *mcplib_pool_proxy_call_helper(mcp_pool_proxy_t *pp, const char *key, size_t len);
-void mcp_request_attach(lua_State *L, mcp_request_t *rq, io_pending_proxy_t *p);
+void mcp_request_attach(mcp_request_t *rq, io_pending_proxy_t *p);
 int mcp_request_render(mcp_request_t *rq, int idx, const char *tok, size_t len);
 void proxy_lua_error(lua_State *L, const char *s);
 #define proxy_lua_ferror(L, fmt, ...) \

--- a/proxy.h
+++ b/proxy.h
@@ -600,6 +600,7 @@ enum mcp_rqueue_e {
     QWAIT_ANY = 0,
     QWAIT_OK,
     QWAIT_GOOD,
+    QWAIT_FASTGOOD,
     QWAIT_HANDLE
 };
 

--- a/proxy.h
+++ b/proxy.h
@@ -674,6 +674,7 @@ struct mcp_rqueue_s {
     int res_ref; // reference to lua response object.
     void *obj; // direct pointer to the object for fast access.
     mcp_request_t *rq; // request set to this slot
+    mcp_resp_t *res_obj; // pointer to result object
     enum mcp_rqueue_state state; // queued/active/etc
     uint8_t obj_type; // what the obj_ref actually is.
     uint8_t flags; // bit flags for various states
@@ -739,6 +740,10 @@ int mcplib_request_has_flag(lua_State *L);
 int mcplib_request_flag_token(lua_State *L);
 int mcplib_request_gc(lua_State *L);
 void mcp_request_cleanup(LIBEVENT_THREAD *t, mcp_request_t *rq);
+
+// response interface
+void mcp_response_cleanup(LIBEVENT_THREAD *t, mcp_resp_t *r);
+void mcp_set_resobj(mcp_resp_t *r, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t);
 
 int mcplib_open_dist_jump_hash(lua_State *L);
 int mcplib_open_dist_ring_hash(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -652,10 +652,10 @@ struct mcp_funcgen_s {
 #define RQUEUE_TYPE_POOL 1
 #define RQUEUE_TYPE_FGEN 2
 #define RQUEUE_ASSIGNED (1<<0)
+#define RQUEUE_R_RESUME (1<<1)
 #define RQUEUE_R_GOOD (1<<3)
 #define RQUEUE_R_OK (1<<4)
 #define RQUEUE_R_ANY (1<<5)
-#define RQUEUE_R_RESUME (1<<6)
 #define RQUEUE_R_ERROR (1<<7)
 
 enum mcp_rqueue_state {
@@ -710,9 +710,10 @@ int mcplib_rcontext_enqueue(lua_State *L);
 int mcplib_rcontext_wait_cond(lua_State *L);
 int mcplib_rcontext_wait_handle(lua_State *L);
 int mcplib_rcontext_enqueue_and_wait(lua_State *L);
-int mcplib_rcontext_good(lua_State *L);
-int mcplib_rcontext_any(lua_State *L);
-int mcplib_rcontext_ok(lua_State *L);
+int mcplib_rcontext_res_good(lua_State *L);
+int mcplib_rcontext_res_any(lua_State *L);
+int mcplib_rcontext_res_ok(lua_State *L);
+int mcplib_rcontext_result(lua_State *L);
 int mcplib_funcgenbare_new(lua_State *L);
 int mcplib_funcgen_new(lua_State *L);
 int mcplib_funcgen_new_handle(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -666,8 +666,6 @@ enum mcp_rqueue_state {
     RQUEUE_WAITED
 };
 
-// FIXME: obj_ref -> intptr_t and use for both obj_ref and rctx to cut the
-// total size of the slot down?
 struct mcp_rqueue_s {
     int obj_ref; // reference to pool/func/etc object
     int cb_ref; // if a lua callback was specified

--- a/proxy.h
+++ b/proxy.h
@@ -99,7 +99,7 @@ struct mcp_memprofile {
 #define MCP_YIELD_POOL 1
 #define MCP_YIELD_AWAIT 2
 #define MCP_YIELD_INTERNAL 3
-#define MCP_YIELD_WAITFOR 4
+#define MCP_YIELD_WAITCOND 4
 #define MCP_YIELD_WAITHANDLE 5
 
 #define SHAREDVM_FGEN_IDX 1
@@ -705,17 +705,17 @@ struct mcp_rcontext_s {
 void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle);
 void mcp_process_rctx_wait(mcp_rcontext_t *rctx, int handle);
 int mcp_process_rqueue_return(mcp_rcontext_t *rctx, int handle, mcp_resp_t *res);
-int mcplib_rcontext_queue_set_cb(lua_State *L);
-int mcplib_rcontext_queue(lua_State *L);
-int mcplib_rcontext_wait_for(lua_State *L);
+int mcplib_rcontext_handle_set_cb(lua_State *L);
+int mcplib_rcontext_enqueue(lua_State *L);
+int mcplib_rcontext_wait_cond(lua_State *L);
 int mcplib_rcontext_wait_handle(lua_State *L);
-int mcplib_rcontext_queue_and_wait(lua_State *L);
+int mcplib_rcontext_enqueue_and_wait(lua_State *L);
 int mcplib_rcontext_good(lua_State *L);
 int mcplib_rcontext_any(lua_State *L);
 int mcplib_rcontext_ok(lua_State *L);
 int mcplib_funcgenbare_new(lua_State *L);
 int mcplib_funcgen_new(lua_State *L);
-int mcplib_funcgen_queue_assign(lua_State *L);
+int mcplib_funcgen_new_handle(lua_State *L);
 int mcplib_funcgen_ready(lua_State *L);
 int mcplib_router_new(lua_State *L);
 mcp_rcontext_t *mcp_funcgen_start(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_t *pr);

--- a/proxy.h
+++ b/proxy.h
@@ -613,7 +613,7 @@ enum mcp_funcgen_router_e {
 
 struct mcp_router_long_s {
     char start[KEY_HASH_FILTER_MAX+1];
-    char until[KEY_HASH_FILTER_MAX+1];
+    char stop[KEY_HASH_FILTER_MAX+1];
 };
 
 struct mcp_funcgen_router {

--- a/proxy.h
+++ b/proxy.h
@@ -646,7 +646,7 @@ struct mcp_rcontext_s {
     int function_ref; // ref to the created route function.
     int coroutine_ref; // ref to our encompassing coroutine.
     unsigned int async_pending; // legacy async handling
-    unsigned int pending_reqs; // pending requests and sub-requests
+    int pending_reqs; // pending requests and sub-requests
     unsigned int wait_count;
     unsigned int wait_done; // TODO: change these variables to uint8's
     int wait_handle; // waiting on a specific queue slot

--- a/proxy.h
+++ b/proxy.h
@@ -597,7 +597,8 @@ void proxy_return_rctx_cb(io_pending_t *pending);
 void proxy_finalize_rctx_cb(io_pending_t *pending);
 
 enum mcp_rqueue_e {
-    QWAIT_ANY = 0,
+    QWAIT_IDLE = 0,
+    QWAIT_ANY,
     QWAIT_OK,
     QWAIT_GOOD,
     QWAIT_FASTGOOD,

--- a/proxy.h
+++ b/proxy.h
@@ -597,10 +597,10 @@ void proxy_return_rctx_cb(io_pending_t *pending);
 void proxy_finalize_rctx_cb(io_pending_t *pending);
 
 enum mcp_rqueue_e {
-    WAIT_ANY = 0,
-    WAIT_OK,
-    WAIT_GOOD,
-    WAIT_HANDLE
+    QWAIT_ANY = 0,
+    QWAIT_OK,
+    QWAIT_GOOD,
+    QWAIT_HANDLE
 };
 
 enum mcp_funcgen_router_e {

--- a/proxy.h
+++ b/proxy.h
@@ -670,6 +670,7 @@ enum mcp_rqueue_state {
 struct mcp_rqueue_s {
     int obj_ref; // reference to pool/func/etc object
     int cb_ref; // if a lua callback was specified
+    int req_ref; // reference to associated request object.
     int res_ref; // reference to lua response object.
     void *obj; // direct pointer to the object for fast access.
     mcp_request_t *rq; // request set to this slot

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -1701,6 +1701,11 @@ int mcplib_internal_run(mcp_rcontext_t *rctx) {
     // Always return OK from here as this is signalling an internal error.
     r->status = MCMC_OK;
 
+    // resp object is associated with the
+    // response object, which is about a
+    // kilobyte.
+    lua_gc(rctx->Lc, LUA_GCSTEP, 1);
+
     if (resp->io_pending) {
         // TODO (v2): here we move the IO from the temporary resp to the top
         // resp, but this feels kludgy so I'm leaving an explicit note to find
@@ -1724,5 +1729,6 @@ int mcplib_internal_run(mcp_rcontext_t *rctx) {
         r->buf = io->eio.buf;
         return 1;
     }
+
     return 0;
 }

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1311,6 +1311,9 @@ static void proxy_register_defines(lua_State *L) {
 #define X(x) \
     lua_pushinteger(L, x); \
     lua_setfield(L, -2, #x);
+#define Y(x, l) \
+    lua_pushinteger(L, x); \
+    lua_setfield(L, -2, l);
 
     X(MCMC_CODE_STORED);
     X(MCMC_CODE_EXISTS);
@@ -1335,11 +1338,12 @@ static void proxy_register_defines(lua_State *L) {
     X(AWAIT_FIRST);
     X(AWAIT_FASTGOOD);
     X(AWAIT_BACKGROUND);
-    X(WAIT_ANY);
-    X(WAIT_OK);
-    X(WAIT_GOOD);
+    Y(QWAIT_ANY, "WAIT_ANY");
+    Y(QWAIT_OK, "WAIT_OK");
+    Y(QWAIT_GOOD, "WAIT_GOOD");
     CMD_FIELDS
 #undef X
+#undef Y
 
     lua_pushboolean(L, 1);
     lua_setfield(L, -2, "WAIT_RESUME");

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1344,6 +1344,9 @@ static void proxy_register_defines(lua_State *L) {
     Y(QWAIT_OK, "WAIT_OK");
     Y(QWAIT_GOOD, "WAIT_GOOD");
     Y(QWAIT_FASTGOOD, "WAIT_FASTGOOD");
+    Y(RQUEUE_R_GOOD, "RES_GOOD");
+    Y(RQUEUE_R_OK, "RES_OK");
+    Y(RQUEUE_R_ANY, "RES_ANY");
     CMD_FIELDS
 #undef X
 #undef Y
@@ -1413,9 +1416,10 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"wait_cond", mcplib_rcontext_wait_cond},
         {"enqueue_and_wait", mcplib_rcontext_enqueue_and_wait},
         {"wait_handle", mcplib_rcontext_wait_handle},
-        {"good", mcplib_rcontext_good},
-        {"ok", mcplib_rcontext_ok},
-        {"any", mcplib_rcontext_any},
+        {"res_good", mcplib_rcontext_res_good},
+        {"res_ok", mcplib_rcontext_res_ok},
+        {"res_any", mcplib_rcontext_res_any},
+        {"result", mcplib_rcontext_result},
         {NULL, NULL}
     };
 

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -844,7 +844,7 @@ static int mcplib_pool_proxy_gc(lua_State *L) {
     return 0;
 }
 
-mcp_backend_t *mcplib_pool_proxy_call_helper(lua_State *L, mcp_pool_proxy_t *pp, const char *key, size_t len) {
+mcp_backend_t *mcplib_pool_proxy_call_helper(mcp_pool_proxy_t *pp, const char *key, size_t len) {
     mcp_pool_t *p = pp->main;
     if (p->key_filter) {
         key = p->key_filter(p->key_filter_conf, key, len, &len);
@@ -854,22 +854,16 @@ mcp_backend_t *mcplib_pool_proxy_call_helper(lua_State *L, mcp_pool_proxy_t *pp,
     uint32_t lookup = p->phc.selector_func(hash, p->phc.ctx);
 
     assert(p->phc.ctx != NULL);
-    // attach the backend to the request object.
-    // the lua modules should "think" in 1 based indexes, so we need to
-    // subtract one here.
     if (lookup >= p->pool_size) {
-        proxy_lua_error(L, "key dist hasher tried to use out of bounds index");
+        return NULL;
     }
 
     return pp->pool[lookup].be;
 }
 
-// hashfunc(request) -> backend(request)
-// needs key from request object.
+// pool(request) -> yields the pool/request for further processing
 static int mcplib_pool_proxy_call(lua_State *L) {
-    // internal args are the hash selector (self)
     mcp_pool_proxy_t *pp = luaL_checkudata(L, -2, "mcp.pool_proxy");
-    // then request object.
     mcp_request_t *rq = luaL_checkudata(L, -1, "mcp.request");
 
     // we have a fast path to the key/length.
@@ -879,11 +873,16 @@ static int mcplib_pool_proxy_call(lua_State *L) {
     }
     const char *key = MCP_PARSER_KEY(rq->pr);
     size_t len = rq->pr.klen;
-    rq->be = mcplib_pool_proxy_call_helper(L, pp, key, len);
+    mcp_backend_t *be = mcplib_pool_proxy_call_helper(pp, key, len);
+    if (be == NULL) {
+        proxy_lua_error(L, "key dist hasher tried to use out of bounds index");
+        return 0;
+    }
+    lua_pushlightuserdata(L, be);
 
-    // now yield request, pool up.
+    // now yield request, pool, backend, mode up.
     lua_pushinteger(L, MCP_YIELD_POOL);
-    return lua_yield(L, 3);
+    return lua_yield(L, 4);
 }
 
 static int mcplib_tcp_keepalive(lua_State *L) {
@@ -1083,7 +1082,23 @@ static int mcplib_attach(lua_State *L) {
         loop_end = hook + 1;
     }
 
+    void *fgen = NULL;
     if (lua_isfunction(L, 2)) {
+        // create a funcgen with null generator that calls this function
+        lua_pushvalue(L, 2); // copy input function.
+        mcplib_funcgenbare_new(L); // convert it into a function generator.
+        fgen = luaL_checkudata(L, -1, "mcp.funcgen"); // set our pointer ref.
+        lua_replace(L, 2); // move the function generator over the input
+                           // function. necessary for alignment with the rest
+                           // of the code.
+    } else if ((fgen = luaL_testudata(L, 2, "mcp.funcgen")) != NULL) {
+        // good
+    } else {
+        proxy_lua_error(L, "Must pass a function to mcp.attach");
+        return 0;
+    }
+
+    {
         struct proxy_hook *hooks = t->proxy_hooks;
         uint64_t tag = 0; // listener socket tag
 
@@ -1104,7 +1119,8 @@ static int mcplib_attach(lua_State *L) {
                 // need to add flush support before allowing override
                 continue;
             }
-            lua_pushvalue(L, 2); // duplicate the function for the ref.
+            lua_pushvalue(L, 2); // duplicate the ref.
+            struct proxy_hook_ref *href = &h->ref;
 
             if (tag) {
                 // listener was tagged. use the extended hook structure.
@@ -1122,21 +1138,7 @@ static int mcplib_attach(lua_State *L) {
 
                 bool found = false;
                 for (int x = 0; x < h->tagcount; x++) {
-                    if (pht->tag == tag) {
-                        if (pht->lua_ref) {
-                            // Found existing tagged hook.
-                            luaL_unref(L, LUA_REGISTRYINDEX, pht->lua_ref);
-                        }
-
-                        pht->lua_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-                        assert(pht->lua_ref != 0);
-                        found = true;
-                        break;
-                    } else if (pht->tag == 0) {
-                        // no tag in this slot, so we use it.
-                        pht->lua_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-                        pht->tag = tag;
-                        assert(pht->lua_ref != 0);
+                    if (pht->tag == tag || pht->tag == 0) {
                         found = true;
                         break;
                     }
@@ -1145,33 +1147,34 @@ static int mcplib_attach(lua_State *L) {
 
                 // need to resize the array to fit the new tag.
                 if (!found) {
-                    pht = realloc(h->tagged, sizeof(struct proxy_hook_tagged) * (h->tagcount+1));
-                    if (!pht) {
+                    struct proxy_hook_tagged *temp = realloc(h->tagged, sizeof(struct proxy_hook_tagged) * (h->tagcount+1));
+                    if (!temp) {
                         proxy_lua_error(L, "mcp.attach: failure to resize tagged hooks");
                         return 0;
                     }
-
-                    pht[h->tagcount].lua_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-                    pht[h->tagcount].tag = tag;
-
+                    pht = &temp[h->tagcount];
+                    memset(pht, 0, sizeof(*pht));
                     h->tagcount++;
-                    h->tagged = pht;
+                    h->tagged = temp;
                 }
 
-            } else {
-                if (h->lua_ref) {
-                    // remove existing reference.
-                    luaL_unref(L, LUA_REGISTRYINDEX, h->lua_ref);
-                }
-
-                // pops the function from the stack and leaves us a ref. for later.
-                h->lua_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-                assert(h->lua_ref != 0);
+                href = &pht->ref;
+                pht->tag = tag;
             }
+
+            // now assign our hook reference.
+            if (href->lua_ref) {
+                // Found existing tagged hook.
+                luaL_unref(L, LUA_REGISTRYINDEX, href->lua_ref);
+                mcp_funcgen_dereference(L, href->ctx);
+            }
+
+            lua_pushvalue(L, -1); // duplicate the funcgen
+            mcp_funcgen_reference(L);
+            href->lua_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+            href->ctx = fgen;
+            assert(href->lua_ref != 0);
         }
-    } else {
-        proxy_lua_error(L, "Must pass a function to mcp.attach");
-        return 0;
     }
 
     return 0;
@@ -1331,8 +1334,14 @@ static void proxy_register_defines(lua_State *L) {
     X(AWAIT_FIRST);
     X(AWAIT_FASTGOOD);
     X(AWAIT_BACKGROUND);
+    X(WAIT_ANY);
+    X(WAIT_OK);
+    X(WAIT_GOOD);
     CMD_FIELDS
 #undef X
+
+    lua_pushboolean(L, 1);
+    lua_setfield(L, -2, "WAIT_RESUME");
 }
 
 // Creates and returns the top level "mcp" module
@@ -1390,6 +1399,22 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {NULL, NULL}
     };
 
+    const struct luaL_Reg mcplib_rcontext_m[] = {
+        {"queue_assign", mcplib_rcontext_queue_assign},
+        {"queue", mcplib_rcontext_queue},
+        {"wait_for", mcplib_rcontext_wait_for},
+        {"wait_handle", mcplib_rcontext_wait_handle},
+        {"good", mcplib_rcontext_good},
+        {"ok", mcplib_rcontext_ok},
+        {"any", mcplib_rcontext_any},
+        {NULL, NULL}
+    };
+
+    const struct luaL_Reg mcplib_funcgen_m[] = {
+        {"__gc", mcplib_funcgen_gc},
+        {NULL, NULL}
+    };
+
     const struct luaL_Reg mcplib_f_config [] = {
         {"pool", mcplib_pool},
         {"backend", mcplib_backend},
@@ -1412,6 +1437,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
     const struct luaL_Reg mcplib_f_routes [] = {
         {"internal", mcplib_internal},
         {"attach", mcplib_attach},
+        {"funcgen_new", mcplib_funcgen_new},
         {"await", mcplib_await},
         {"await_logerrors", mcplib_await_logerrors},
         {"log", mcplib_log},
@@ -1454,6 +1480,26 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         lua_pushvalue(L, -1); // duplicate metatable.
         lua_setfield(L, -2, "__index"); // mt.__index = mt
         luaL_setfuncs(L, mcplib_ratelim_tbf_m, 0); // register methods
+        lua_pop(L, 1);
+
+        luaL_newmetatable(L, "mcp.rcontext");
+        lua_pushvalue(L, -1); // duplicate metatable.
+        lua_setfield(L, -2, "__index"); // mt.__index = mt
+        luaL_setfuncs(L, mcplib_rcontext_m, 0); // register methods
+        lua_pop(L, 1);
+
+        luaL_newmetatable(L, "mcp.funcgen");
+        lua_pushvalue(L, -1); // duplicate metatable.
+        lua_setfield(L, -2, "__index"); // mt.__index = mt
+        luaL_setfuncs(L, mcplib_funcgen_m, 0); // register methods
+        lua_pop(L, 1);
+
+        // marks a special C-compatible route function.
+        luaL_newmetatable(L, "mcp.rfunc");
+        lua_pop(L, 1);
+
+        // function generator userdata.
+        luaL_newmetatable(L, "mcp.funcgen");
         lua_pop(L, 1);
 
         luaL_newlibtable(L, mcplib_f_routes);

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1085,7 +1085,6 @@ static int mcplib_attach(lua_State *L) {
     void *fgen = NULL;
     if (lua_isfunction(L, 2)) {
         // create a funcgen with null generator that calls this function
-        lua_pushvalue(L, 2); // copy input function.
         mcplib_funcgenbare_new(L); // convert it into a function generator.
         fgen = luaL_checkudata(L, -1, "mcp.funcgen"); // set our pointer ref.
         lua_replace(L, 2); // move the function generator over the input

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1438,6 +1438,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"internal", mcplib_internal},
         {"attach", mcplib_attach},
         {"funcgen_new", mcplib_funcgen_new},
+        {"router_new", mcplib_router_new},
         {"await", mcplib_await},
         {"await_logerrors", mcplib_await_logerrors},
         {"log", mcplib_log},

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1408,10 +1408,10 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
     };
 
     const struct luaL_Reg mcplib_rcontext_m[] = {
-        {"queue_set_cb", mcplib_rcontext_queue_set_cb},
-        {"queue", mcplib_rcontext_queue},
-        {"wait_for", mcplib_rcontext_wait_for},
-        {"queue_and_wait", mcplib_rcontext_queue_and_wait},
+        {"handle_set_cb", mcplib_rcontext_handle_set_cb},
+        {"enqueue", mcplib_rcontext_enqueue},
+        {"wait_cond", mcplib_rcontext_wait_cond},
+        {"enqueue_and_wait", mcplib_rcontext_enqueue_and_wait},
         {"wait_handle", mcplib_rcontext_wait_handle},
         {"good", mcplib_rcontext_good},
         {"ok", mcplib_rcontext_ok},
@@ -1421,7 +1421,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
 
     const struct luaL_Reg mcplib_funcgen_m[] = {
         {"__gc", mcplib_funcgen_gc},
-        {"queue_assign", mcplib_funcgen_queue_assign},
+        {"new_handle", mcplib_funcgen_new_handle},
         {"ready", mcplib_funcgen_ready},
         {NULL, NULL}
     };

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1084,7 +1084,7 @@ static int mcplib_attach(lua_State *L) {
         loop_end = hook + 1;
     }
 
-    void *fgen = NULL;
+    mcp_funcgen_t *fgen = NULL;
     if (lua_isfunction(L, 2)) {
         // create a funcgen with null generator that calls this function
         lua_pushvalue(L, 2); // function must be at top of stack.
@@ -1097,7 +1097,12 @@ static int mcplib_attach(lua_State *L) {
     } else if ((fgen = luaL_testudata(L, 2, "mcp.funcgen")) != NULL) {
         // good
     } else {
-        proxy_lua_error(L, "Must pass a function to mcp.attach");
+        proxy_lua_error(L, "mcp.attach: must pass a function");
+        return 0;
+    }
+
+    if (fgen->closed) {
+        proxy_lua_error(L, "mcp.attach: cannot use a previously replaced function");
         return 0;
     }
 

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1343,6 +1343,7 @@ static void proxy_register_defines(lua_State *L) {
     Y(QWAIT_ANY, "WAIT_ANY");
     Y(QWAIT_OK, "WAIT_OK");
     Y(QWAIT_GOOD, "WAIT_GOOD");
+    Y(QWAIT_FASTGOOD, "WAIT_FASTGOOD");
     CMD_FIELDS
 #undef X
 #undef Y

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1405,7 +1405,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
     };
 
     const struct luaL_Reg mcplib_rcontext_m[] = {
-        {"queue_assign", mcplib_rcontext_queue_assign},
+        {"queue_set_cb", mcplib_rcontext_queue_set_cb},
         {"queue", mcplib_rcontext_queue},
         {"wait_for", mcplib_rcontext_wait_for},
         {"queue_and_wait", mcplib_rcontext_queue_and_wait},
@@ -1418,6 +1418,8 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
 
     const struct luaL_Reg mcplib_funcgen_m[] = {
         {"__gc", mcplib_funcgen_gc},
+        {"queue_assign", mcplib_funcgen_queue_assign},
+        {"ready", mcplib_funcgen_ready},
         {NULL, NULL}
     };
 

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1404,6 +1404,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"queue_assign", mcplib_rcontext_queue_assign},
         {"queue", mcplib_rcontext_queue},
         {"wait_for", mcplib_rcontext_wait_for},
+        {"queue_and_wait", mcplib_rcontext_queue_and_wait},
         {"wait_handle", mcplib_rcontext_wait_handle},
         {"good", mcplib_rcontext_good},
         {"ok", mcplib_rcontext_ok},

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1085,11 +1085,13 @@ static int mcplib_attach(lua_State *L) {
     void *fgen = NULL;
     if (lua_isfunction(L, 2)) {
         // create a funcgen with null generator that calls this function
+        lua_pushvalue(L, 2); // function must be at top of stack.
         mcplib_funcgenbare_new(L); // convert it into a function generator.
         fgen = luaL_checkudata(L, -1, "mcp.funcgen"); // set our pointer ref.
         lua_replace(L, 2); // move the function generator over the input
                            // function. necessary for alignment with the rest
                            // of the code.
+        lua_pop(L, 1); // drop the extra generator function reference.
     } else if ((fgen = luaL_testudata(L, 2, "mcp.funcgen")) != NULL) {
         // good
     } else {

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -304,8 +304,10 @@ static void mcp_funcgen_cleanup(lua_State *L, mcp_funcgen_t *fgen) {
     // decrement the slot tracker. apply full delta at once for efficiency.
     mcp_sharedvm_delta(t->proxy_ctx, SHAREDVM_FGENSLOT_IDX, name, -fgen->total);
 
-    lua_pop(L, 1); // pop the name string.
-    luaL_unref(L, LUA_REGISTRYINDEX, fgen->name_ref);
+    if (fgen->name_ref) {
+        lua_pop(L, 1); // pop the name string.
+        luaL_unref(L, LUA_REGISTRYINDEX, fgen->name_ref);
+    }
 
     // Finally, get the rctx reference table and nil each reference to allow
     // garbage collection to happen sooner on the rctx's

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -973,12 +973,6 @@ static void proxy_return_rqu_cb(io_pending_t *pending) {
     conn *c = rctx->c;
 
     if (p->client_resp) {
-        if (p->client_resp->blen) {
-            // FIXME: workaround for buffer memory being external to objects.
-            // can't run 0 since that means something special (run the GC)
-            unsigned int kb = p->client_resp->blen / 1000;
-            lua_gc(p->rctx->Lc, LUA_GCSTEP, kb > 0 ? kb : 1);
-        }
         mcp_process_rqueue_return(rctx, p->queue_handle, p->client_resp);
     }
     rctx->pending_reqs--;

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -794,8 +794,6 @@ static void mcp_resume_rctx_from_cb(mcp_rcontext_t *rctx) {
         // level resp object and is now complete.
         // HACK
         // see notes in proxy_run_rcontext()
-        // FIXME: this may be incomplete, as mcp.internal() can make
-        // IO_QUEUE_EXTSTORE requests; need to audit the callbacks for that.
         // NOTE: this function is called from rqu_cb(), which pushes the
         // submission loop. This code below can call drive_machine(), which
         // calls submission loop if stuff is queued.

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -890,7 +890,6 @@ void mcp_process_rctx_wait(mcp_rcontext_t *rctx, int handle) {
     }
 
     assert(rctx->pending_reqs != 0);
-    // FIXME: need to only check R_RESUME if NOT QWAIT_HANDLE?
     if ((status & RQUEUE_R_RESUME) || rctx->wait_done == rctx->wait_count || rctx->pending_reqs == 1) {
         // ran out of stuff to wait for. time to resume.
         // TODO: can we do the settop at the yield? nothing we need to

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -951,6 +951,12 @@ static void proxy_return_rqu_cb(io_pending_t *pending) {
     conn *c = rctx->c;
 
     if (p->client_resp) {
+        if (p->client_resp->blen) {
+            // FIXME: workaround for buffer memory being external to objects.
+            // can't run 0 since that means something special (run the GC)
+            unsigned int kb = p->client_resp->blen / 1000;
+            lua_gc(p->rctx->Lc, LUA_GCSTEP, kb > 0 ? kb : 1);
+        }
         mcp_process_rqueue_return(rctx, p->queue_handle, p->client_resp);
     }
     rctx->pending_reqs--;

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -1,0 +1,888 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+
+static void mcp_funcgen_cleanup(lua_State *L, mcp_funcgen_t *fgen);
+
+// If we're GC'ed but not closed, it means it was created but never
+// attached to a function, so ensure everything is closed properly.
+int mcplib_funcgen_gc(lua_State *L) {
+    mcp_funcgen_t *fgen = luaL_checkudata(L, -1, "mcp.funcgen");
+    if (fgen->closed) {
+        return 0;
+    }
+    assert(fgen->self_ref == 0);
+
+    mcp_funcgen_cleanup(L, fgen);
+    return 0;
+}
+
+// For describing functions which generate functions which can execute
+// requests.
+// These "generator functions" handle pre-allocating and creating a memory
+// heirarchy, allowing dynamic runtimes at high speed.
+
+// TODO: switch from an array to a STAILQ so we can avoid the memory
+// management and error handling.
+// Realistically it's impossible for these to error so we're safe for now.
+static void _mcplib_funcgen_cache(mcp_funcgen_t *fgen, mcp_rcontext_t *rctx) {
+    if (fgen->free + 1 >= fgen->free_max) {
+        fgen->free_max *= 2;
+        fgen->list = realloc(fgen->list, fgen->free_max * sizeof(mcp_rcontext_t *));
+    }
+    fgen->list[fgen->free] = rctx;
+    fgen->free++;
+
+    // we're closed and every outstanding request slot has been
+    // returned.
+    if (fgen->closed && fgen->free == fgen->total) {
+        mcp_funcgen_cleanup(fgen->thread->L, fgen);
+    }
+}
+
+// call with stack: mcp.funcgen -2, function -1
+static mcp_rcontext_t *_mcplib_funcgen_gencall(lua_State *L, mcp_funcgen_t *fgen) {
+    // create the ctx object.
+    size_t rctx_len = sizeof(mcp_rcontext_t) + sizeof(struct mcp_rqueue_s) * fgen->max_queues;
+    mcp_rcontext_t *rc = lua_newuserdatauv(L, rctx_len, 0);
+    memset(rc, 0, rctx_len);
+
+    luaL_getmetatable(L, "mcp.rcontext");
+    lua_setmetatable(L, -2);
+
+    // link the rcontext into the function generator.
+    // FIXME: triple check this actually cleans up if we bail.
+    // TODO: copy the func then the rcontext again and do this after the pcall
+    // to avoid having to unwind it post-failure.
+    rc->fgen = fgen;
+    fgen->total++;
+
+    lua_getiuservalue(L, -3, 1); // get the reference table.
+    lua_pushvalue(L, -2); // copy rcontext
+    lua_rawseti(L, -2, fgen->total); // pop rcontext
+    lua_pop(L, 1); // pop ref table.
+
+    // FIXME: move this to the end, so we only cache on success.
+    _mcplib_funcgen_cache(fgen, rc);
+
+    // pre-create a top level request object.
+    mcp_request_t *rq = lua_newuserdatauv(L, sizeof(mcp_request_t) + MCP_REQUEST_MAXLEN + KEY_MAX_LENGTH, 0);
+    memset(rq, 0, sizeof(mcp_request_t));
+    luaL_getmetatable(L, "mcp.request");
+    lua_setmetatable(L, -2);
+
+    rc->request_ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop the request
+    rc->request = rq;
+
+    // current stack should be func, mcp.rcontext.
+    int call_argnum = 1;
+    // stack will be func, rctx, arg if there is an arg.
+    if (fgen->argument_ref) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->argument_ref);
+        call_argnum++;
+    }
+
+    // TODO: lua_call instead of pcall?
+    int res = lua_pcall(L, call_argnum, 1, 0);
+    if (res != LUA_OK) {
+        // TODO: give this a proxy_lua_error.
+        lua_error(L);
+        return 0;
+    }
+
+    // we should have a top level function as a result.
+    if (!lua_isfunction(L, -1)) {
+        proxy_lua_error(L, "function generator didn't return a function");
+        return 0;
+    }
+
+    // TODO: copy the function, return "rcontext, rfunction"
+    // so it can be immediately executed?
+    // pop the returned function.
+    rc->function_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    // associate a coroutine thread with this context.
+    lua_newthread(L);
+    rc->Lc = lua_tothread(L, -1);
+    rc->coroutine_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    // return the rcontext
+    return rc;
+}
+
+static void _mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
+    mcp_funcgen_t *fgen = rctx->fgen;
+    assert(rctx->pending_reqs == 0);
+    // TODO: resetthread instead?
+    lua_settop(rctx->Lc, 0);
+    rctx->resp = NULL;
+    rctx->first_queue = false; // HACK
+    mcp_request_cleanup(fgen->thread, rctx->request);
+
+    // reset each rqu.
+    // TODO: keep the res obj but reset it internally.
+    for (int x = 0; x < fgen->max_queues; x++) {
+        struct mcp_rqueue_s *rqu = &rctx->qslots[x];
+        if (rqu->res_ref) {
+            luaL_unref(rctx->Lc, LUA_REGISTRYINDEX, rqu->res_ref);
+        }
+        assert(rqu->state != RQUEUE_ACTIVE);
+        rqu->state = RQUEUE_IDLE;
+        rqu->res_ref = 0;
+        rqu->flags = 0;
+        rqu->rq = NULL;
+        if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+            _mcp_funcgen_return_rctx(rqu->obj);
+        }
+    }
+}
+
+// TODO: check rctx->awaiting before returning?
+// TODO: separate the "cleanup" portion from the "Return to cache" portion, so
+// we can call that directly for subrctx's
+void mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
+    mcp_funcgen_t *fgen = rctx->fgen;
+    if (rctx->pending_reqs != 0) {
+        // not ready to return to cache yet.
+        return;
+    }
+    if (rctx->parent) {
+        // Important: we need to hold the parent request reference until this
+        // subrctx is fully depleted of outstanding requests itself.
+        rctx->parent->pending_reqs--;
+        if (rctx->parent->pending_reqs == 0) {
+            mcp_funcgen_return_rctx(rctx->parent);
+        }
+        return;
+    }
+    _mcp_funcgen_return_rctx(rctx);
+    _mcplib_funcgen_cache(fgen, rctx);
+}
+
+// FIXME: should be able to avoid the fgen ref, because we only need the fgen lua
+// object if there were no empty slots.
+// FIXME: mcplib -> mcp?
+mcp_rcontext_t *mcplib_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen) {
+    mcp_rcontext_t *rctx = NULL;
+    // nothing left in slot cache, generate a new function.
+    if (fgen->free == 0) {
+        // pull in the funcgen object
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen_ref);
+        // then generator function
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->generator_ref);
+        // then generate a new function slot.
+        // FIXME: do a lua_pcall here so the arguments make sense?
+        _mcplib_funcgen_gencall(L, fgen);
+        lua_pop(L, 1); // drop the extra funcgen ref
+    } else {
+        P_DEBUG("%s: serving from cache\n", __func__);
+    }
+
+    rctx = fgen->list[fgen->free-1];
+    fgen->free--;
+
+    // on non-error, return the response object upward.
+    return rctx;
+}
+
+// calling either with self_ref set, or with fgen in stack -1 (ie; from GC
+// function without ever being attached to anything)
+static void mcp_funcgen_cleanup(lua_State *L, mcp_funcgen_t *fgen) {
+    assert(fgen->closed);
+    // pull the fgen into the stack.
+    if (fgen->self_ref) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->self_ref);
+        // remove the C reference to the fgen
+        luaL_unref(L, LUA_REGISTRYINDEX, fgen->self_ref);
+        fgen->self_ref = 0;
+    }
+
+    // Walk every requets context and issue cleanup.
+    for (int x = 0; x < fgen->total; x++) {
+        mcp_rcontext_t *rctx = fgen->list[x];
+
+        luaL_unref(L, LUA_REGISTRYINDEX, rctx->coroutine_ref);
+        luaL_unref(L, LUA_REGISTRYINDEX, rctx->function_ref);
+        luaL_unref(L, LUA_REGISTRYINDEX, rctx->request_ref);
+        // TODO: cleanup of request queue entries. recurse funcgen cleanup.
+    }
+
+    // Finally, get the rctx reference table and nil each reference to allow
+    // garbage collection to happen sooner on the rctx's
+    lua_getiuservalue(L, -1, 1);
+    for (int x = 0; x < fgen->total; x++) {
+        lua_pushnil(L);
+        lua_rawseti(L, -2, x+1);
+    }
+    // drop the reference table and the funcgen reference.
+    lua_pop(L, 2);
+}
+
+// Must be called with the function generator at on top of stack
+// Pops the value from the stack.
+void mcp_funcgen_reference(lua_State *L) {
+    mcp_funcgen_t *fgen = luaL_checkudata(L, -1, "mcp.funcgen");
+    if (fgen->self_ref) {
+        fgen->refcount++;
+        lua_pop(L, 1); // ensure we drop the extra value.
+    } else {
+        fgen->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        fgen->refcount = 1;
+    }
+    P_DEBUG("%s: funcgen referenced: %d\n", __func__, fgen->refcount);
+}
+
+void mcp_funcgen_dereference(lua_State *L, mcp_funcgen_t *fgen) {
+    assert(fgen->refcount > 0);
+    fgen->refcount--;
+    P_DEBUG("%s: funcgen dereferenced: %d\n", __func__, fgen->refcount);
+    if (fgen->refcount == 0) {
+        fgen->closed = true;
+
+        P_DEBUG("%s: funcgen cleaning up\n", __func__);
+        if (fgen->free == fgen->total) {
+            mcp_funcgen_cleanup(L, fgen);
+        }
+    }
+}
+
+// All we need to do here is copy the function reference we've stashed into
+// the C closure's upvalue and return it.
+static int _mcplib_funcgenbare_generator(lua_State *L) {
+    lua_pushvalue(L, lua_upvalueindex(1));
+    return 1;
+}
+
+// helper function to create a function generator with a "default" function.
+// the function passed in here is a standard 'function(r) etc end' prototype,
+// which we want to always return instead of calling a real generator
+// function.
+int mcplib_funcgenbare_new(lua_State *L) {
+    if (!lua_isfunction(L, -1)) {
+        proxy_lua_error(L, "Must pass a function to mcp.funcgenbare_new");
+        return 0;
+    }
+
+    // Pops the function into the upvalue of this C closure function.
+    lua_pushcclosure(L, _mcplib_funcgenbare_generator, 1);
+
+    // Pass our fakeish generator function down the line.
+    return mcplib_funcgen_new(L);
+}
+
+// TODO: find a better name for this function. _after_ its final placement.
+int mcplib_funcgen_new(lua_State *L) {
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+    int max_queues = 1; // FIXME: define.
+    int tidx = 0;
+
+    if (lua_istable(L, -1)) {
+        tidx = lua_absindex(L, -1);
+        if (lua_getfield(L, -1, "max_queues") != LUA_TNIL) {
+            max_queues = lua_tointeger(L, -1);
+        }
+        lua_pop(L, 1);
+
+        if (lua_getfield(L, -1, "func") != LUA_TFUNCTION) {
+            proxy_lua_error(L, "Must specify generator function ('func') in mcp.funcgen_new");
+            return 0;
+        }
+
+        // now the generator function is at the top of the stack.
+    } else if (!lua_isfunction(L, -1)) {
+        proxy_lua_error(L, "Must pass a function or table to mcp.funcgen_new");
+        return 0;
+    }
+
+    mcp_funcgen_t *fgen = lua_newuserdatauv(L, sizeof(mcp_funcgen_t), 1);
+    memset(fgen, 0, sizeof(mcp_funcgen_t));
+    fgen->thread = t;
+    fgen->max_queues = max_queues;
+    fgen->free_max = 8; // FIXME: define
+    fgen->list = calloc(fgen->free_max, sizeof(mcp_rcontext_t *));
+
+    luaL_getmetatable(L, "mcp.funcgen");
+    lua_setmetatable(L, -2);
+
+    // the table we will use to hold references to rctx's
+    lua_createtable(L, 8, 0);
+    // set our table into the uservalue 1 of fgen (idx -2)
+    // pops the table.
+    lua_setiuservalue(L, -2, 1);
+
+    if (tidx) {
+        // check for a generator argument.
+        if (lua_getfield(L, tidx, "arg") != LUA_TNIL) {
+            fgen->argument_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        } else {
+            lua_pop(L, 1);
+        }
+    }
+
+    // stack should now be: -2: func -1: mcp.funcgen
+
+    // copy the generator function.
+    lua_pushvalue(L, -2);
+    // run the generator function once, which caches a new function call
+    // object.
+    _mcplib_funcgen_gencall(L, fgen);
+
+    // we've survived one call to the function generator, so lets reference it
+    // now.
+    lua_pushvalue(L, -2); // copy the generator again
+    fgen->generator_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    // top of stack is now: gfunc, fgen
+
+    // return the generator for attach() later.
+    return 1;
+}
+
+// Handlers for request contexts
+
+// first arg is rcontext
+// next is either a pool proxy or another function generator
+// TODO LATER: create a static result object
+int mcplib_rcontext_queue_assign(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    mcp_pool_proxy_t *pp = NULL;
+    mcp_funcgen_t *fgen = NULL;
+    // FIXME: ensure only two or three arguments, else the references break.
+    int argc = lua_gettop(L);
+
+    // find the next unused queue slot.
+    struct mcp_rqueue_s *rqu = NULL;
+    int x;
+    for (x = 0; x < rctx->fgen->max_queues; x++) {
+        if (rctx->qslots[x].obj_type == RQUEUE_TYPE_NONE) {
+            rqu = &rctx->qslots[x];
+            break;
+        }
+    }
+    if (!rqu) {
+        proxy_lua_error(L, "ran out of queue slots during queue_assign()");
+        return 0;
+    }
+
+    if (argc == 3) {
+        if (!lua_isfunction(L, 3)) {
+            proxy_lua_error(L, "second argument to queue_assign must be a callback function");
+        }
+
+        // pops top argument.
+        rqu->cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+
+    if ((pp = luaL_testudata(L, 2, "mcp.pool_proxy")) != NULL) {
+        // pops *pp from the stack.
+        rqu->obj_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        rqu->obj_type = RQUEUE_TYPE_POOL;
+        rqu->obj = pp;
+        // TODO: ref incr on the pool proxy.
+    } else if ((fgen = luaL_testudata(L, 2, "mcp.funcgen")) != NULL) {
+        // pops the fgen from the stack.
+        mcp_funcgen_reference(L);
+        // now run the generator once to get an rctx to peg into this slot.
+        // FIXME: fix this self_ref business.
+        // this is okay temporarily since the above reference ensures fgen's
+        // self ref is set.
+        mcp_rcontext_t *subrctx = mcplib_funcgen_get_rctx(L, fgen->self_ref, fgen);
+        // link the new rctx into this chain; we'll hold onto it until the
+        // parent de-allocates.
+        subrctx->parent = rctx;
+        subrctx->parent_handle = x;
+        rqu->obj_type = RQUEUE_TYPE_FGEN;
+        rqu->obj = subrctx;
+    } else {
+        // unwind and throw error
+        if (rqu->cb_ref) {
+            luaL_unref(L, LUA_REGISTRYINDEX, rqu->cb_ref);
+            rqu->cb_ref = 0;
+        }
+        proxy_lua_error(L, "invalid argument to queue_assign");
+        return 0;
+    }
+
+    // return the "handle" of the queue slot.
+    lua_pushinteger(L, x);
+    return 1;
+}
+
+static void _mcplib_rcontext_queue(lua_State *L, mcp_rcontext_t *rctx, mcp_request_t *rq, int handle) {
+    if (handle < 0 || handle > rctx->fgen->max_queues) {
+        proxy_lua_error(L, "invalid handle passed to queue");
+        return;
+    }
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+
+    if (rqu->state != RQUEUE_IDLE) {
+        return;
+    }
+
+    // If we're queueing to an fgen, arm the coroutine while we have the
+    // objects handy. Else this requires roundtripping a luaL_ref/luaL_unref
+    // later.
+    if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+        mcp_rcontext_t *subrctx = rqu->obj;
+        lua_pushvalue(L, 2); // duplicate the request obj
+        lua_rawgeti(subrctx->Lc, LUA_REGISTRYINDEX, subrctx->function_ref);
+        lua_xmove(L, subrctx->Lc, 1); // move the requet object.
+        subrctx->pending_reqs++;
+    }
+
+    rqu->state = RQUEUE_QUEUED;
+    rqu->rq = rq;
+}
+
+// first arg is rcontext
+// then a request object
+// then either a handle (integer) or array style table of handles
+// TODO: block queueing if the rctx is currently waiting
+// TODO: if passing to an fgen:
+// - prep the function reference into its coroutine
+// - lua_xmove the request object into place
+// - but don't execute it yet.
+int mcplib_rcontext_queue(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    mcp_request_t *rq = luaL_checkudata(L, 2, "mcp.request");
+
+    if (!rq->pr.keytoken) {
+        proxy_lua_error(L, "cannot queue requests without a key");
+        return 0;
+    }
+
+    int type = lua_type(L, 3);
+    if (type == LUA_TNUMBER) {
+        int handle = lua_tointeger(L, 3);
+
+        _mcplib_rcontext_queue(L, rctx, rq, handle);
+    } else if (type == LUA_TTABLE) {
+        unsigned int len = lua_rawlen(L, 3);
+        for (int x = 0; x < len; x++) {
+            type = lua_rawgeti(L, 3, x+1);
+            if (type != LUA_TNUMBER) {
+                proxy_lua_error(L, "invalid handle passed to queue via array table");
+                return 0;
+            }
+
+            int handle = lua_tointeger(L, 4);
+            lua_pop(L, 1);
+
+            _mcplib_rcontext_queue(L, rctx, rq, handle);
+        }
+    } else {
+        proxy_lua_error(L, "must pass a handle or a table to queue");
+        return 0;
+    }
+
+    return 0;
+}
+
+// TODO: dedupe the handler code.
+// TODO: rename to mcp_resume_rctx ?
+static void mcp_resume_rctx_from_cb(mcp_rcontext_t *rctx) {
+    int res = proxy_run_rcontext(rctx);
+    if (rctx->parent) {
+        struct mcp_rqueue_s *rqu = &rctx->parent->qslots[rctx->parent_handle];
+        if (res == LUA_OK) {
+            int type = lua_type(rctx->Lc, 1);
+            if (type == LUA_TUSERDATA) {
+                assert(rctx->parent->wait_count > 0);
+                // move stack result object into parent rctx rqu slot.
+                // FIXME: crashes. use testudata and internal error handling.
+                mcp_resp_t *r = luaL_checkudata(rctx->Lc, 1, "mcp.response");
+                rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+                mcp_process_rqueue_return(rctx->parent, rctx->parent_handle, r);
+            } else if (type == LUA_TSTRING) {
+                // TODO: wrap with a resobj and parse it.
+                // for now we bypass the rqueue process handling
+                // meaning no callbacks/etc.
+                rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+                rqu->flags |= RQUEUE_R_ANY;
+                rqu->state = RQUEUE_COMPLETE;
+            } else {
+                // FIXME: generate a generic object with an error.
+                assert(1 == 0);
+            }
+            if (rctx->parent->wait_count) {
+                mcp_process_rctx_wait(rctx->parent, rctx->parent_handle);
+            }
+            mcp_funcgen_return_rctx(rctx);
+        } else if (res == LUA_YIELD) {
+            // normal.
+        } else {
+            // we have an error. need to mark the error into the parent rqu
+            // slot.
+            rqu->flags |= RQUEUE_R_ERROR|RQUEUE_R_ANY;
+            lua_pop(rctx->Lc, 1); // drop the error message.
+            mcp_resp_t *r = mcp_prep_bare_resobj(rctx->Lc, rctx->fgen->thread);
+            r->status = MCMC_ERR;
+            r->resp.code = MCMC_CODE_SERVER_ERROR;
+            rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+            mcp_process_rqueue_return(rctx->parent, rctx->parent_handle, r);
+            if (rctx->parent->wait_count) {
+                mcp_process_rctx_wait(rctx->parent, rctx->parent_handle);
+            }
+            mcp_funcgen_return_rctx(rctx);
+        }
+    } else {
+        // Parent rctx has returned either a response or error to its top
+        // level resp object and is now complete.
+        // HACK
+        // see notes in proxy_run_rcontext()
+        // FIXME: this may be incomplete, as mcp.internal() can make
+        // IO_QUEUE_EXTSTORE requests; need to audit the callbacks for that.
+        // NOTE: this function is called from rqu_cb(), which pushes the
+        // submission loop. This code below can call drive_machine(), which
+        // calls submission loop if stuff is queued.
+        // Would remove redundancy if we can signal up to rqu_cb() and either
+        // q->count-- or do the inline submission at that level.
+        if (res != LUA_YIELD) {
+            mcp_funcgen_return_rctx(rctx);
+            io_queue_t *q = conn_io_queue_get(rctx->c, IO_QUEUE_PROXY);
+            q->count--;
+            if (q->count == 0) {
+                // call re-add directly since we're already in the worker thread.
+                conn_worker_readd(rctx->c);
+            }
+        }
+    }
+}
+
+// This "Dummy" IO immediately resumes the yielded function, without a result
+// attached.
+static void proxy_return_rqu_dummy_cb(io_pending_t *pending) {
+    io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
+    mcp_rcontext_t *rctx = p->rctx;
+    conn *c = rctx->c;
+
+    rctx->pending_reqs--;
+
+    lua_settop(rctx->Lc, 0);
+    lua_pushinteger(rctx->Lc, 0); // return a "0" done count to the function.
+    mcp_resume_rctx_from_cb(rctx);
+
+    do_cache_free(p->thread->io_cache, p);
+    // We always need a C object right now, but just in case.
+    if (c) {
+        // HACK
+        // see notes above proxy_run_rcontext.
+        // in case the above resume calls queued new work, we have to submit
+        // it to the backend handling system here.
+        for (io_queue_t *q = c->io_queues; q->type != IO_QUEUE_NONE; q++) {
+            if (q->stack_ctx != NULL) {
+                io_queue_cb_t *qcb = thread_io_queue_get(c->thread, q->type);
+                qcb->submit_cb(q);
+            }
+        }
+    }
+}
+
+void mcp_process_rctx_wait(mcp_rcontext_t *rctx, int handle) {
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    int status = rqu->flags;
+    assert(rqu->state == RQUEUE_COMPLETE);
+    // waiting for some IO's to complete before continuing.
+    // meaning if we "match good" here, we can resume.
+    // we can also resume if we are in wait mode but pending_reqs is down
+    // to 1.
+    switch (rctx->wait_mode) {
+        case WAIT_GOOD:
+            if (status & RQUEUE_R_GOOD) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+        case WAIT_OK:
+            if (status & (RQUEUE_R_GOOD|RQUEUE_R_OK)) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+        case WAIT_ANY:
+            rctx->wait_done++;
+            rqu->state = RQUEUE_WAITED;
+            break;
+        case WAIT_HANDLE:
+            // waiting for a specific handle to return
+            if (handle == rctx->wait_handle) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+    }
+
+    assert(rctx->pending_reqs != 0);
+    // FIXME: need to only check R_RESUME if NOT WAIT_HANDLE?
+    if ((status & RQUEUE_R_RESUME) || rctx->wait_done == rctx->wait_count || rctx->pending_reqs == 1) {
+        // ran out of stuff to wait for. time to resume.
+        // TODO: can we do the settop at the yield? nothing we need to
+        // keep in the stack in this mode.
+        lua_settop(rctx->Lc, 0);
+        rctx->wait_count = 0;
+        if (rctx->wait_mode == WAIT_HANDLE) {
+            mcp_rcontext_push_rqu_res(rctx->Lc, rctx, handle);
+        } else {
+            lua_pushinteger(rctx->Lc, rctx->wait_done);
+        }
+        rctx->wait_mode = WAIT_ANY;
+
+        mcp_resume_rctx_from_cb(rctx);
+    }
+}
+
+// sets the slot's return status code, to be used for filtering responses
+// later.
+// if a callback was set, execute it now.
+int mcp_process_rqueue_return(mcp_rcontext_t *rctx, int handle, mcp_resp_t *res) {
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    uint8_t flag = RQUEUE_R_ANY;
+
+    assert(rqu->state == RQUEUE_ACTIVE);
+    rqu->state = RQUEUE_COMPLETE;
+    if (!rqu->cb_ref) {
+        if (res->status == MCMC_OK) {
+            if (res->resp.code != MCMC_CODE_END) {
+                flag = RQUEUE_R_GOOD;
+            } else {
+                flag = RQUEUE_R_OK;
+            }
+        }
+        rqu->flags |= flag;
+        return flag;
+    } else {
+        lua_settop(rctx->Lc, 0);
+        lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rqu->cb_ref);
+        lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rqu->res_ref);
+        if (lua_pcall(rctx->Lc, 1, 2, 0) != LUA_OK) {
+            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, lua_tostring(rctx->Lc, -1));
+            flag = RQUEUE_R_ANY;
+        } else {
+            enum mcp_rqueue_e mode = lua_tointeger(rctx->Lc, 1);
+            switch (mode) {
+                case WAIT_GOOD:
+                    flag = RQUEUE_R_GOOD;
+                    break;
+                case WAIT_OK:
+                    flag = RQUEUE_R_OK;
+                    break;
+                case WAIT_ANY:
+                    break;
+                default:
+                    fprintf(stderr, "BAD RESULT!!!\n");
+                    // FIXME:
+                    break;
+            }
+
+            // if second result return shortcut status code
+            if (lua_toboolean(rctx->Lc, 2)) {
+                flag |= RQUEUE_R_RESUME;
+            }
+        }
+        rqu->flags |= flag;
+        lua_settop(rctx->Lc, 0); // FIXME: This might not be necessary.
+                                 // we settop _before_ calling cb's and
+                                 // _before_ setting up for a coro resume.
+        return rqu->flags;
+    }
+}
+
+// specific function for queue-based returns.
+static void proxy_return_rqu_cb(io_pending_t *pending) {
+    io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
+    mcp_rcontext_t *rctx = p->rctx;
+    // Hold the client object before we potentially return the rctx below.
+    conn *c = rctx->c;
+
+    mcp_process_rqueue_return(rctx, p->queue_handle, p->client_resp);
+    rctx->pending_reqs--;
+
+    if (rctx->wait_count) {
+        mcp_process_rctx_wait(rctx, p->queue_handle);
+    } else {
+        mcp_funcgen_return_rctx(rctx);
+    }
+
+    do_cache_free(p->thread->io_cache, p);
+
+    // We always need a C object right now, but just in case.
+    if (c) {
+        // HACK
+        // see notes above proxy_run_rcontext.
+        // in case the above resume calls queued new work, we have to submit
+        // it to the backend handling system here.
+        for (io_queue_t *q = c->io_queues; q->type != IO_QUEUE_NONE; q++) {
+            if (q->stack_ctx != NULL) {
+                io_queue_cb_t *qcb = thread_io_queue_get(c->thread, q->type);
+                qcb->submit_cb(q);
+            }
+        }
+    }
+}
+
+void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle) {
+    struct mcp_rqueue_s *rqu = NULL;
+    rqu = &rctx->qslots[handle];
+
+    if (rqu->state == RQUEUE_QUEUED) {
+        rqu->state = RQUEUE_ACTIVE;
+        if (rqu->obj_type == RQUEUE_TYPE_POOL) {
+            mcp_request_t *rq = rqu->rq;
+            mcp_backend_t *be = mcplib_pool_proxy_call_helper(rqu->obj, MCP_PARSER_KEY(rq->pr), rq->pr.klen);
+            // FIXME: queue requires conn because we're stacking objects
+            // into the connection for later submission, which means we
+            // absolutely cannot queue things once *c becomes invalid.
+            // need to assert/block this from happening.
+            mcp_resp_t *r = mcp_prep_resobj(rctx->Lc, rq, be, rctx->fgen->thread);
+            // FIXME: check for NULL on the IO object and handle.
+            io_pending_proxy_t *p = mcp_queue_rctx_io(rctx, rq, be, r);
+            p->return_cb = proxy_return_rqu_cb;
+            p->queue_handle = handle;
+            // need to reference the res object into the queue slot.
+            rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+            rctx->pending_reqs++;
+        } else if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+            // TODO: NULL the ->c post-return?
+            mcp_rcontext_t *subrctx = rqu->obj;
+            subrctx->c = rctx->c;
+            rctx->pending_reqs++;
+            mcp_resume_rctx_from_cb(subrctx);
+        } else {
+            assert(1==0);
+        }
+    } else if (rqu->state == RQUEUE_COMPLETE && rctx->wait_count) {
+        // The slot was previously completed from an earlier dispatch, but we
+        // haven't "waited" on it yet.
+        mcp_process_rctx_wait(rctx, handle);
+    }
+}
+
+// TODO: one more function to wait on a list of handles? to queue and wait on
+// a list of handles? expand wait_for()
+
+// takes num, filter mode
+// TODO: if count is zero, queue dummy IO to force submission.
+int mcplib_rcontext_wait_for(lua_State *L) {
+    // TODO: protect against double waitfor?
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    int mode = WAIT_ANY;
+    int wait = 0;
+
+    if (!lua_isnumber(L, 2)) {
+        proxy_lua_error(L, "must pass number to wait_for");
+        return 0;
+    } else {
+        wait = lua_tointeger(L, 2);
+        if (wait < 0) {
+            proxy_lua_error(L, "wait count for wait_for must be positive");
+            return 0;
+        }
+        rctx->wait_count = wait;
+    }
+
+    if (lua_isnumber(L, 3)) {
+        mode = lua_tointeger(L, 3);
+    }
+
+    switch (mode) {
+        case WAIT_ANY:
+        case WAIT_OK:
+        case WAIT_GOOD:
+            break;
+        default:
+            proxy_lua_error(L, "invalid mode sent to wait_for");
+            return 0;
+    }
+    rctx->wait_done = 0;
+    rctx->wait_mode = mode;
+
+    // waiting for none, meaning just execute the queues.
+    if (wait == 0) {
+        // FIXME: error handling for p == NULL
+        io_pending_proxy_t *p = mcp_queue_rctx_io(rctx, NULL, NULL, NULL);
+        p->return_cb = proxy_return_rqu_dummy_cb;
+        p->await_background = true;
+        rctx->pending_reqs++;
+    }
+
+    lua_pushinteger(L, MCP_YIELD_WAITFOR);
+    return lua_yield(L, 1);
+}
+
+int mcplib_rcontext_wait_handle(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    mcp_request_t *rq = luaL_checkudata(L, 2, "mcp.request");
+    int isnum = 0;
+    int handle = lua_tointegerx(L, 3, &isnum);
+
+    if (!rq->pr.keytoken) {
+        proxy_lua_error(L, "cannot queue requests without a key");
+        return 0;
+    }
+
+    if (!isnum) {
+        proxy_lua_error(L, "invalid handle passed to wait_handle");
+        return 0;
+    }
+
+    // queue up this handle and yield for the direct wait.
+    _mcplib_rcontext_queue(L, rctx, rq, handle);
+    rctx->wait_done = 0;
+    rctx->wait_count = 1;
+    rctx->wait_mode = WAIT_HANDLE;
+    rctx->wait_handle = handle;
+
+    lua_pushinteger(L, MCP_YIELD_WAITHANDLE);
+    return lua_yield(L, 1);
+}
+
+static inline struct mcp_rqueue_s *_mcplib_rcontext_checkhandle(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    int isnum = 0;
+    int handle = lua_tointegerx(L, 2, &isnum);
+    if (!isnum || handle < 0 || handle > rctx->fgen->max_queues) {
+        proxy_lua_error(L, "invalid queue handle passed to :good/:ok:/:any");
+        return NULL;
+    }
+
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    return rqu;
+}
+
+int mcplib_rcontext_good(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & RQUEUE_R_GOOD) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+int mcplib_rcontext_ok(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & (RQUEUE_R_OK|RQUEUE_R_GOOD)) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+int mcplib_rcontext_any(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD)) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+    } else {
+        // Shouldn't be possible to get here, unless you're asking about a
+        // queue that was never armed or hasn't completed yet.
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+// the supplied handle must be valid.
+void mcp_rcontext_push_rqu_res(lua_State *L, mcp_rcontext_t *rctx, int handle) {
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+}

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -1161,7 +1161,7 @@ static inline struct mcp_rqueue_s *_mcplib_rcontext_checkhandle(lua_State *L) {
     return rqu;
 }
 
-int mcplib_rcontext_good(lua_State *L) {
+int mcplib_rcontext_res_good(lua_State *L) {
     struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
     if (rqu->flags & RQUEUE_R_GOOD) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
@@ -1171,7 +1171,7 @@ int mcplib_rcontext_good(lua_State *L) {
     return 1;
 }
 
-int mcplib_rcontext_ok(lua_State *L) {
+int mcplib_rcontext_res_ok(lua_State *L) {
     struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
     if (rqu->flags & (RQUEUE_R_OK|RQUEUE_R_GOOD)) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
@@ -1181,7 +1181,7 @@ int mcplib_rcontext_ok(lua_State *L) {
     return 1;
 }
 
-int mcplib_rcontext_any(lua_State *L) {
+int mcplib_rcontext_res_any(lua_State *L) {
     struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
     if (rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD)) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
@@ -1191,6 +1191,21 @@ int mcplib_rcontext_any(lua_State *L) {
         lua_pushnil(L);
     }
     return 1;
+}
+
+// returns res, RES_GOOD|OK|ANY
+int mcplib_rcontext_result(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD)) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+        // mask away any other queue flags.
+        lua_pushinteger(L, rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD));
+    } else {
+        lua_pushnil(L);
+        lua_pushnil(L);
+    }
+
+    return 2;
 }
 
 // the supplied handle must be valid.

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -1035,7 +1035,6 @@ void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle) {
 // a list of handles? expand wait_cond()
 
 // takes num, filter mode
-// TODO: if count is zero, queue dummy IO to force submission.
 int mcplib_rcontext_wait_cond(lua_State *L) {
     // TODO: protect against double waitfor?
     mcp_rcontext_t *rctx = lua_touserdata(L, 1);

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -497,9 +497,12 @@ int mcplib_funcgen_new_handle(lua_State *L) {
     if ((pp = luaL_testudata(L, 2, "mcp.pool_proxy")) != NULL) {
         // good.
     } else if ((fg = luaL_testudata(L, 2, "mcp.funcgen")) != NULL) {
-        // good
+        if (fg->router.type != FGEN_ROUTER_NONE) {
+            proxy_lua_error(L, "cannot assign a router to a handle in new_handle");
+            return 0;
+        }
     } else {
-        proxy_lua_error(L, "invalid argument to queue_assign");
+        proxy_lua_error(L, "invalid argument to new_handle");
         return 0;
     }
 
@@ -510,7 +513,7 @@ int mcplib_funcgen_new_handle(lua_State *L) {
         fgen->queue_list = realloc(fgen->queue_list, fgen->max_queues * sizeof(struct mcp_rqueue_s));
     }
     if (fgen->queue_list == NULL) {
-        proxy_lua_error(L, "failed to realloc queue list during queue_assign()");
+        proxy_lua_error(L, "failed to realloc queue list during new_handle()");
         return 0;
     }
 

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -271,9 +271,8 @@ mcp_rcontext_t *mcp_funcgen_start(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_
             return NULL;
         }
     }
-    // FIXME: check on the fgen->self_ref usage here. I'm 99% sure it's
-    // impossible to get here without self_ref set because attach would
-    // have to be overridden already, so the fgen is inaccessible.
+    // fgen->self_ref must be valid because we cannot start a function that
+    // hasn't been referenced anywhere.
     mcp_rcontext_t *rctx = mcp_funcgen_get_rctx(L, fgen->self_ref, fgen);
 
     if (rctx == NULL) {

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -501,6 +501,10 @@ int mcplib_funcgen_new_handle(lua_State *L) {
             proxy_lua_error(L, "cannot assign a router to a handle in new_handle");
             return 0;
         }
+        if (fg->closed) {
+            proxy_lua_error(L, "cannot use a replaced function in new_handle");
+            return 0;
+        }
     } else {
         proxy_lua_error(L, "invalid argument to new_handle");
         return 0;

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -1015,7 +1015,6 @@ void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle) {
             // absolutely cannot queue things once *c becomes invalid.
             // need to assert/block this from happening.
             mcp_set_resobj(rqu->res_obj, rq, be, rctx->fgen->thread);
-            // FIXME: check for NULL on the IO object and handle.
             io_pending_proxy_t *p = mcp_queue_rctx_io(rctx, rq, be, rqu->res_obj);
             p->return_cb = proxy_return_rqu_cb;
             p->queue_handle = handle;
@@ -1078,7 +1077,6 @@ int mcplib_rcontext_wait_cond(lua_State *L) {
 
     // waiting for none, meaning just execute the queues.
     if (wait == 0) {
-        // FIXME: error handling for p == NULL
         io_pending_proxy_t *p = mcp_queue_rctx_io(rctx, NULL, NULL, NULL);
         p->return_cb = proxy_return_rqu_dummy_cb;
         p->await_background = true;

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -72,7 +72,7 @@ static int _mcplib_funcgen_gencall(lua_State *L) {
             // owner funcgen already holds the subfgen reference, so here we're just
             // grabbing a subrctx to pin into the slot.
             mcp_funcgen_t *fg = frqu->obj;
-            mcp_rcontext_t *subrctx = mcplib_funcgen_get_rctx(L, fg->self_ref, fg);
+            mcp_rcontext_t *subrctx = mcp_funcgen_get_rctx(L, fg->self_ref, fg);
             if (subrctx == NULL) {
                 proxy_lua_error(L, "failed to generate request slot during queue_assign()");
             }
@@ -235,8 +235,7 @@ void mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
     _mcplib_funcgen_cache(fgen, rctx);
 }
 
-// FIXME: mcplib -> mcp?
-mcp_rcontext_t *mcplib_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen) {
+mcp_rcontext_t *mcp_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen) {
     mcp_rcontext_t *rctx = NULL;
     // nothing left in slot cache, generate a new function.
     if (fgen->free == 0) {
@@ -275,7 +274,7 @@ mcp_rcontext_t *mcp_funcgen_start(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_
     // FIXME: check on the fgen->self_ref usage here. I'm 99% sure it's
     // impossible to get here without self_ref set because attach would
     // have to be overridden already, so the fgen is inaccessible.
-    mcp_rcontext_t *rctx = mcplib_funcgen_get_rctx(L, fgen->self_ref, fgen);
+    mcp_rcontext_t *rctx = mcp_funcgen_get_rctx(L, fgen->self_ref, fgen);
 
     if (rctx == NULL) {
         return NULL;

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -541,7 +541,7 @@ int mcp_request_render(mcp_request_t *rq, int idx, const char *tok, size_t len) 
 }
 
 // FIXME: remove lua_state from arguments.
-void mcp_request_attach(lua_State *L, mcp_request_t *rq, io_pending_proxy_t *p) {
+void mcp_request_attach(mcp_request_t *rq, io_pending_proxy_t *p) {
     mcp_parser_t *pr = &rq->pr;
     char *r = (char *) pr->request;
     size_t len = pr->reqlen;

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -807,6 +807,9 @@ void mcp_request_cleanup(LIBEVENT_THREAD *t, mcp_request_t *rq) {
         t->proxy_buffer_memory_used -= rq->pr.vlen;
         pthread_mutex_unlock(&t->proxy_limit_lock);
         free(rq->pr.vbuf);
+        // need to ensure we NULL this out now, since we can call the cleanup
+        // routine independent of GC, and a later GC would double-free.
+        rq->pr.vbuf = NULL;
     }
 }
 

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -380,9 +380,10 @@ function logall_factory_gen(rctx, arg)
     say("generating logall factory function")
     local t = arg.t
 
-    local cb = function(res)
+    local cb = function(res, req)
         say("received a response, logging...")
         mcp.log("received a response: " .. tostring(res:ok()))
+        mcp.log_req(req, res, "even more logs")
         return mcp.WAIT_ANY
     end
 

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -130,6 +130,18 @@ function direct_factory(rctx, arg)
     end
 end
 
+-- factory for proving slots have unique environmental memory.
+function locality_factory(rctx, arg)
+    say("generating locality factory function")
+    local x = 0
+
+    return function(r)
+        say("returning from locality")
+        x = x + 1
+        return "HD t" .. x .. "\r\n"
+    end
+end
+
 -- waits for only the _first_ queued handle to return.
 -- ie; position 1 in the table.
 -- we do a numeric for loop in the returned function to avoid allocations done
@@ -538,6 +550,7 @@ function mcp_config_routes(p)
     local waitfor = mcp.funcgen_new({ func = waitfor_factory, arg = { list = p }, max_queues = 3, name = "waitfor"})
     local failover = mcp.funcgen_new({ func = failover_factory, arg = { list = p }, max_queues = 3, name = "failover"})
     local suberrors = mcp.funcgen_new({ func = suberrors_factory, max_queues = 3, name = "suberrors"})
+    local locality = mcp.funcgen_new({ func = locality_factory, max_queues = 1, name = "locality"})
 
     -- for testing traffic splitting.
     local split = mcp.funcgen_new({ func = split_factory, arg = { a = single, b = singletwo }, max_queues = 2, name = "split"})
@@ -557,6 +570,7 @@ function mcp_config_routes(p)
         ["suberrors"] = suberrors,
         ["split"] = split,
         ["splitfailover"] = splitfailover,
+        ["locality"] = locality,
     }
 
     local parg = {

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -633,6 +633,14 @@ function failgenret_factory_gen(rctx)
     end
 end
 
+function badreturn_gen(rctx)
+    -- returning a userdata that isn't the correct kind of userdata.
+    -- shouldn't crash the daemon!
+    return function(r)
+        return rctx
+    end
+end
+
 -- TODO: this might be supported only in a later update.
 -- new queue after parent return
 -- - do an immediate return + cb queue, queue from that callback
@@ -668,6 +676,7 @@ function mcp_config_routes(p)
     local errors = new_error_factory(errors_factory_gen, "errors")
     local suberrors = new_error_factory(suberrors_factory_gen, "suberrors")
     local suberr_wrap = new_direct_factory({ p = suberrors, name = "suberrwrap" })
+    local badreturn = new_error_factory(badreturn_gen, "badreturn")
 
     -- for testing traffic splitting.
     local split = new_split_factory({ a = single, b = singletwo, name = "split" })
@@ -690,6 +699,7 @@ function mcp_config_routes(p)
         ["split"] = split,
         ["splitfailover"] = splitfailover,
         ["locality"] = locality,
+        ["badreturn"] = badreturn,
     }
 
     local parg = {

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -56,12 +56,12 @@
 --  queued handles. Takes a mode to filter for valid responses to count:
 --  - mcp.WAIT_OK, WAIT_GOOD, WAIT_ANY
 --
--- rctx:good(handle)
+-- rctx:res_good(handle)
 --  - returns result object if the queue response was considered "Good", else
 --  nil.
--- rctx:any(handle)
+-- rctx:res_any(handle)
 --  - same but "WAIT_ANY"
--- rctx:ok(handle)
+-- rctx:res_ok(handle)
 --  - same but "WAIT_OK"
 
 verbose = true
@@ -220,7 +220,7 @@ function partial_factory_gen(rctx, arg)
         for x=1, count do
             -- :good will only return the result object if the handle's
             -- response was considered "good"
-            local res = rctx:good(t[x])
+            local res = rctx:res_good(t[x])
             if res ~= nil then
                 say("found a result")
                 return res
@@ -230,7 +230,7 @@ function partial_factory_gen(rctx, arg)
         say("found nothing")
         -- didn't return anything good, so return one at random.
         for x=1, count do
-            local res = rctx:any(t[x])
+            local res = rctx:res_any(t[x])
             if res ~= nil then
                 return res
             end
@@ -253,7 +253,7 @@ function all_factory_gen(rctx, arg)
         local done = rctx:wait_cond(count, mode)
         -- :any will give us the result object for that handle, regardless
         -- of return code/status.
-        local res = rctx:any(t[1])
+        local res = rctx:res_any(t[1])
 
         -- TODO: tally up the responses and return summary for test.
         return res
@@ -292,7 +292,7 @@ function fastgood_factory_gen(rctx, arg)
             -- if we just got one "good", we're probably happy.
             for x=1, count do
                 -- loop to find the good handle.
-                local res = rctx:good(t[x])
+                local res = rctx:res_good(t[x])
                 if res ~= nil then
                     return res
                 end
@@ -302,7 +302,7 @@ function fastgood_factory_gen(rctx, arg)
             -- network error.
             -- but for this test we'll just return the first result.
             for x=1, count do
-                local res = rctx:any(t[x])
+                local res = rctx:res_any(t[x])
                 if res ~= nil then
                     return res
                 end
@@ -359,14 +359,14 @@ function blocker_factory_gen(rctx, arg)
         local bres = rctx:enqueue_and_wait(r, blocker)
 
         -- another way of doing this is to ask:
-        -- local res = rctx:good(blocker)
+        -- local res = rctx:res_good(blocker)
         -- if a result was returned, the callback had returned WAIT_GOOD
         if was_blocked == false then
             -- our blocker is happy...
             -- wait for the rest of the handles to come in and make a decision
             -- on what to return to the client.
             local done = rctx:wait_cond(count, mcp.WAIT_ANY)
-            return rctx:any(t[1])
+            return rctx:res_any(t[1])
         else
             return "SERVER_ERROR blocked\r\n"
         end
@@ -449,7 +449,7 @@ function waitfor_factory_gen(rctx, arg)
             -- TODO: bonus points, count the goods or check that everyone's t
             -- flag is right.
             for x=1, count do
-                local res = rctx:good(x)
+                local res = rctx:res_good(x)
                 if res ~= nil then
                     return res
                 end
@@ -496,14 +496,14 @@ function failover_factory_gen(rctx, arg)
             local done = rctx:wait_cond(1, mcp.WAIT_GOOD)
             -- find the good from the second set.
             for x=1, count-1 do
-                local res = rctx:good(t[x])
+                local res = rctx:res_good(t[x])
                 if res ~= nil then
                     say("found a result")
                     return res
                 end
             end
             -- got nothing from second set, just return anything.
-            return rctx:any(first)
+            return rctx:res_any(first)
         else
             return fres
         end

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -524,24 +524,24 @@ end
 function mcp_config_routes(p)
     local b_pool = p.b
     p = p.p
-    local single = mcp.funcgen_new({ func = direct_factory, arg = p[1], max_queues = 1 })
+    local single = mcp.funcgen_new({ func = direct_factory, arg = p[1], max_queues = 1, name = "single" })
     -- use the typically unused backend.
-    local singletwo = mcp.funcgen_new({ func = direct_factory, arg = b_pool, max_queues = 1 })
+    local singletwo = mcp.funcgen_new({ func = direct_factory, arg = b_pool, max_queues = 1, name = "singletwo" })
 
-    local first = mcp.funcgen_new({ func = first_factory, arg = p, max_queues = 3 })
-    local partial = mcp.funcgen_new({ func = partial_factory, arg = { list = p, wait = 2 }, max_queues = 3 })
-    local all = mcp.funcgen_new({ func = all_factory, arg = { list = p }, max_queues = 3})
-    local fastgood = mcp.funcgen_new({ func = fastgood_factory, arg = { list = p, wait = 2 }, max_queues = 3})
-    local blocker = mcp.funcgen_new({ func = blocker_factory, arg = { blocker = b_pool, list = p }, max_queues = 4})
-    local logall = mcp.funcgen_new({ func = logall_factory, arg = { list = p }, max_queues = 3})
-    local summary = mcp.funcgen_new({ func = summary_factory, arg = { list = p }, max_queues = 3})
-    local waitfor = mcp.funcgen_new({ func = waitfor_factory, arg = { list = p }, max_queues = 3})
-    local failover = mcp.funcgen_new({ func = failover_factory, arg = { list = p }, max_queues = 3})
-    local suberrors = mcp.funcgen_new({ func = suberrors_factory, max_queues = 3})
+    local first = mcp.funcgen_new({ func = first_factory, arg = p, max_queues = 3, name = "first" })
+    local partial = mcp.funcgen_new({ func = partial_factory, arg = { list = p, wait = 2 }, max_queues = 3, name = "partial" })
+    local all = mcp.funcgen_new({ func = all_factory, arg = { list = p }, max_queues = 3, name = "all"})
+    local fastgood = mcp.funcgen_new({ func = fastgood_factory, arg = { list = p, wait = 2 }, max_queues = 3, name = "fastgood"})
+    local blocker = mcp.funcgen_new({ func = blocker_factory, arg = { blocker = b_pool, list = p }, max_queues = 4, name = "blocker"})
+    local logall = mcp.funcgen_new({ func = logall_factory, arg = { list = p }, max_queues = 3, name = "logall"})
+    local summary = mcp.funcgen_new({ func = summary_factory, arg = { list = p }, max_queues = 3, name = "summary"})
+    local waitfor = mcp.funcgen_new({ func = waitfor_factory, arg = { list = p }, max_queues = 3, name = "waitfor"})
+    local failover = mcp.funcgen_new({ func = failover_factory, arg = { list = p }, max_queues = 3, name = "failover"})
+    local suberrors = mcp.funcgen_new({ func = suberrors_factory, max_queues = 3, name = "suberrors"})
 
     -- for testing traffic splitting.
-    local split = mcp.funcgen_new({ func = split_factory, arg = { a = single, b = singletwo }, max_queues = 2})
-    local splitfailover = mcp.funcgen_new({ func = split_factory, arg = { a = failover, b = singletwo }, max_queues = 2})
+    local split = mcp.funcgen_new({ func = split_factory, arg = { a = single, b = singletwo }, max_queues = 2, name = "split"})
+    local splitfailover = mcp.funcgen_new({ func = split_factory, arg = { a = failover, b = singletwo }, max_queues = 2, name = "splitfailover"})
 
     local map = {
         ["single"] = single,
@@ -564,7 +564,7 @@ function mcp_config_routes(p)
         list = map,
         pattern = "^/(%a+)/"
     }
-    local pfx = mcp.funcgen_new({ func = prefix_factory, arg = parg, max_queues = 16 })
+    local pfx = mcp.funcgen_new({ func = prefix_factory, arg = parg, max_queues = 16, name = "prefix" })
 
     mcp.attach(mcp.CMD_ANY_STORAGE, pfx)
 end

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -1,0 +1,462 @@
+-- New style request factories and backend request handling.
+-- WARNING: UNDER DEVELOPMENT. MAY STILL CHANGE.
+-- (though hopefully only subtly)
+--
+-- Please look at the examples below, and refer to the API notes here if
+-- necessary.
+--
+-- First, this API adds a "request func generation" step when a new request
+-- starts: if there is not already a cached function to use, call the
+-- "generator" function, then use the response to run the request. This generated
+-- function is reused until the parent generator is swapped out during reload.
+-- This allows the user to pre-allocate and pre-calculate objects and data,
+-- offering both safety and performance.
+-- Future API revisions (such as stats) will rely on this generation step to
+-- be more user friendly while retaining performance.
+--
+-- For backend IO's this unifies what was once two API's:
+--  - result = pool(request): the non-async API
+--  - table = mcp.await(etc)
+--
+-- It is now a single system governeed by a request context object (rctx).
+-- This new system allows queueing a nearly arbitrary set of requests,
+-- "blocking" a client on any individual response, and using callbacks to
+-- make decisions on if a response is "good", to resume processing early, or
+-- post-process once all responses are received.
+--
+-- The queueing system is now recursive: a fgen can queue_assign() another fgen.
+-- Meaning configurations can be assembled as call graphs. IE: If you have a
+-- route function A and want to "shadow" some of its requests onto route
+-- function B, instead of making A more complex you can create a third
+-- function C which splits the traffic.
+--
+-- This is demonstrated below with the prefix factory.
+--
+-- API:
+-- fgen = mcp.funcgen_new({ func = generator, arg = a, max_queues = n})
+--  - creates a new factory object. pass this object as the function argument
+--  to mcp.attach() or rctx:queue_assign.
+--
+-- handle = rctx:queue_assign(pool||funcgen, [cb])
+--  - to be called from the factory generator function, pre-assigns a pool or
+--  child fgen and optional callback function. returns a handle.
+--
+-- rctx:queue(r, handle || table)
+--  - to be called from the request function, queues up a request against the
+--  designated slot handle, or an array style table of N handles
+--
+-- res = rctx:wait_handle(r, h)
+--  - Directly returns a single result object after asynchronously waiting on
+--  a specified queued handle.
+--
+-- num_good = rctx:wait_for(count, mode)
+--  - Asynchronously waits for up to "count" results out of all currently
+--  queued handles. Takes a mode to filter for valid responses to count:
+--  - mcp.WAIT_OK, WAIT_GOOD, WAIT_ANY
+--
+-- rctx:good(handle)
+--  - returns result object if the queue response was considered "Good", else
+--  nil.
+-- rctx:any(handle)
+--  - same but "WAIT_ANY"
+-- rctx:ok(handle)
+--  - same but "WAIT_OK"
+
+verbose = true
+
+function say(...)
+    if verbose then
+        print(...)
+    end
+end
+
+function mcp_config_pools()
+    local srv = mcp.backend
+
+    local b1 = srv('b1', '127.0.0.1', 12011)
+    local b2 = srv('b2', '127.0.0.1', 12012)
+    local b3 = srv('b3', '127.0.0.1', 12013)
+    local b4 = srv('b4', '127.0.0.1', 12014)
+    local b1z = mcp.pool({b1})
+    local b2z = mcp.pool({b2})
+    local b3z = mcp.pool({b3})
+    local b4z = mcp.pool({b4})
+    local p = {p = {b1z, b2z, b3z}, b = b4z}
+
+    --return mcp.pool(b1z, { iothread = false })
+    return p
+end
+
+function prefix_factory(rctx, arg)
+    local p = arg.pattern
+    local d = rctx:queue_assign(arg.default)
+    local map = {}
+
+    say("generating a prefix factory function")
+    -- get handler ids for each sub-route value
+    -- convert the map.
+    for k, v in pairs(arg.list) do
+        map[k] = rctx:queue_assign(v)
+    end
+
+    return function(r)
+        local handle = map[string.match(r:key(), p)]
+        if handle == nil then
+            return rctx:wait_handle(r, d)
+        end
+        return rctx:wait_handle(r, handle)
+    end
+end
+
+function direct_factory(rctx, arg)
+    say("generating direct factory function")
+    local h = rctx:queue_assign(arg)
+
+    return function(r)
+        say("waiting on a single pool")
+        return rctx:wait_handle(r, h)
+    end
+end
+
+-- waits for only the _first_ queued handle to return.
+-- ie; position 1 in the table.
+-- we do a numeric for loop in the returned function to avoid allocations done
+-- by a call to pairs()
+function first_factory(rctx, arg)
+    say("generating first factory function")
+    local t = {}
+    local count = 0
+
+    for _, v in pairs(arg) do
+        table.insert(t, rctx:queue_assign(v))
+        count = count + 1
+    end
+
+    return function(r)
+        say("waiting on first of " .. count .. " pools")
+        for x=1, count do
+            rctx:queue(r, t[x])
+        end
+
+        return rctx:wait_handle(r, t[1])
+    end
+end
+
+-- wait on x out of y
+function partial_factory(rctx, arg)
+    say("generating partial factory function")
+    local t = {}
+    local count = 0
+    local wait = arg.wait
+
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v))
+        count = count + 1
+    end
+
+    return function(r)
+        say("waiting on first " .. wait .. " out of " .. count)
+        for x=1, count do
+            rctx:queue(r, t[x])
+        end
+
+        local done = rctx:wait_for(wait)
+        for x=1, count do
+            -- :good will only return the result object if the handle's
+            -- response was considered "good"
+            local res = rctx:good(t[x])
+            if res ~= nil then
+                say("found a result")
+                return res
+            end
+            -- TODO: tally up responses and send summary for test.
+        end
+        say("found nothing")
+        -- didn't return anything good, so return one at random.
+        for x=1, count do
+            local res = rctx:any(t[x])
+            if res ~= nil then
+                return res
+            end
+        end
+    end
+end
+
+-- wait on all pool arguments
+function all_factory(rctx, arg)
+    say("generating all factory function")
+    local t = {}
+    local count = 0
+    -- should be a minor speedup avoiding the table lookup.
+    local mode = mcp.WAIT_ANY
+
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v))
+        count = count + 1
+    end
+
+    return function(r)
+        say("waiting on " .. count)
+
+        rctx:queue(r, t)
+        local done = rctx:wait_for(count, mode)
+        -- :any will give us the result object for that handle, regardless
+        -- of return code/status.
+        local res = rctx:any(t[1])
+
+        -- TODO: tally up the responses and return summary for test.
+        return res
+    end
+end
+
+-- wait on the first good or N of total
+function fastgood_factory(rctx, arg)
+    say("generating fastgood factory function")
+    local t = {}
+    local count = 0
+    local wait = arg.wait
+
+    local cb = function(res)
+        say("running in a callback!")
+        if res:hit() then
+            say("was a hit!")
+            -- return an extra arg telling us to shortcut the wait count
+            return mcp.WAIT_GOOD, mcp.WAIT_RESUME
+        end
+        -- default return code is mcp.WAIT_ANY
+    end
+
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v, cb))
+        count = count + 1
+    end
+
+    return function(r)
+        say("first good or wait for N")
+
+        rctx:queue(r, t)
+        local done = rctx:wait_for(wait, mcp.WAIT_GOOD)
+        say("fastgood done:", done)
+
+        if done == 1 then
+            -- if we just got one "good", we're probably happy.
+            for x=1, count do
+                -- loop to find the good handle.
+                local res = rctx:good(t[x])
+                if res ~= nil then
+                    return res
+                end
+            end
+        else
+            -- else we had to wait and now need to decide if it was a miss or
+            -- network error.
+            -- but for this test we'll just return the first result.
+            for x=1, count do
+                local res = rctx:any(t[x])
+                if res ~= nil then
+                    return res
+                end
+            end
+        end
+    end
+end
+
+-- queue a bunch, but shortcut if a special auxiliary handle fails
+function blocker_factory(rctx, arg)
+    say("generating blocker factory function")
+    local t = {}
+    local count = 0
+    local was_blocked = false
+
+    local cb = function(res)
+        -- check the response or tokens or anything special to indicate
+        -- success.
+        -- for this test we just check if it was a hit.
+        if res:hit() then
+            was_blocked = false
+            return mcp.WAIT_GOOD
+        else
+            was_blocked = true
+            return mcp.WAIT_ANY
+        end
+    end
+
+    local blocker = rctx:queue_assign(arg.blocker, cb)
+
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v))
+        count = count + 1
+    end
+
+    return function(r)
+        say("function blocker test")
+
+        -- queue up the real queries we wanted to run.
+        rctx:queue(r, t)
+
+        -- any wait command will execute all queued queries at once, but here
+        -- we only wait for the blocker to complete.
+        -- we also use wait_handle() to implicitly queue the blocker handle.
+        local bres = rctx:wait_handle(r, blocker)
+
+        -- another way of doing this is to ask:
+        -- local res = rctx:good(blocker)
+        -- if a result was returned, the callback had returned WAIT_GOOD
+        if was_blocked == false then
+            -- our blocker is happy...
+            -- wait for the rest of the handles to come in and make a decision
+            -- on what to return to the client.
+            local done = rctx:wait_for(count, mcp.WAIT_ANY)
+            return rctx:any(t[1])
+        else
+            return "SERVER_ERROR blocked\r\n"
+        end
+    end
+end
+
+-- log on all callbacks, even if waiting for 1
+function logall_factory(rctx, arg)
+    say("generating logall factory function")
+    local t = {}
+
+    local cb = function(res)
+        say("received a response, logging...")
+        mcp.log("received a response: " .. tostring(res:ok()))
+        return mcp.WAIT_ANY
+    end
+
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v, cb))
+    end
+
+    return function(r)
+        rctx:queue(r, t)
+        return rctx:wait_handle(r, t[1])
+    end
+end
+
+-- log a summary after all callbacks run
+function summary_factory(rctx, arg)
+    say("generating summary factory function")
+    local t = {}
+    local count = 0
+
+    local todo = 0
+    local cb = function(res)
+        say("responses TODO: " .. todo)
+        todo = todo - 1
+        if todo == 0 then
+            mcp.log("received all responses")
+        end
+    end
+
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v, cb))
+        count = count + 1
+    end
+
+    return function(r)
+        -- re-seed the todo value that the callback uses
+        todo = count
+
+        rctx:queue(r, t)
+        -- we're just waiting for a single response, but we queue all of the
+        -- handles. the callback uses data from the shared environment and a
+        -- summary is logged.
+        return rctx:wait_handle(r, t[1])
+    end
+end
+
+-- testing various waitfor conditions.
+function waitfor_factory(rctx, arg)
+    say("generating background factory function")
+    local t = {}
+    local count = 0
+    for _, v in pairs(arg.list) do
+        table.insert(t, rctx:queue_assign(v))
+        count = count + 1
+    end
+
+    return function(r)
+        local key = r:key()
+        if key == "/waitfor/a" then
+            rctx:queue(r, t)
+            rctx:wait_for(0) -- issue the requests in the background
+            return "HD t1\r\n" -- return whatever to the client
+        elseif key == "/waitfor/b" then
+            rctx:queue(r, t)
+            rctx:wait_for(0) -- issue requests and resume
+            -- now go back into wait mode, but we've already dispatched
+            local done = rctx:wait_for(2)
+            if done ~= 2 then
+                return "SERVER_ERROR invalid wait"
+            end
+            -- TODO: bonus points, count the goods or check that everyone's t
+            -- flag is right.
+            for x=1, count do
+                local res = rctx:good(x)
+                if res ~= nil then
+                    return res
+                end
+                return "SERVER_ERROR no good response"
+            end
+        elseif key == "/waitfor/c" then
+            rctx:queue(r, t[1])
+            rctx:wait_for(0) -- issue the first queued request
+            -- queue two more
+            rctx:queue(r, t[2])
+            rctx:queue(r, t[3])
+            -- wait explicitly for the first queued one.
+            return rctx:wait_handle(r, t[1])
+        end
+    end
+end
+
+-- TODO: this might be supported only in a later update.
+-- new queue after parent return
+-- - do an immediate return + cb queue, queue from that callback
+-- - should still work but requires worker lua vm
+-- requires removing the need of having an active client socket object to
+-- queue new requests for processing.
+function postreturn_factory(rctx, arg)
+
+end
+
+-- TODO: demonstrate a split call graph
+-- ie; an all split into two single
+
+function mcp_config_routes(p)
+    local b_pool = p.b
+    p = p.p
+    local single = mcp.funcgen_new({ func = direct_factory, arg = p[1], max_queues = 1 })
+
+    local first = mcp.funcgen_new({ func = first_factory, arg = p, max_queues = 3 })
+    local partial = mcp.funcgen_new({ func = partial_factory, arg = { list = p, wait = 2 }, max_queues = 3 })
+    local all = mcp.funcgen_new({ func = all_factory, arg = { list = p }, max_queues = 3})
+    local fastgood = mcp.funcgen_new({ func = fastgood_factory, arg = { list = p, wait = 2 }, max_queues = 3})
+    local blocker = mcp.funcgen_new({ func = blocker_factory, arg = { blocker = b_pool, list = p }, max_queues = 4})
+    local logall = mcp.funcgen_new({ func = logall_factory, arg = { list = p }, max_queues = 3})
+    local summary = mcp.funcgen_new({ func = summary_factory, arg = { list = p }, max_queues = 3})
+    local waitfor = mcp.funcgen_new({ func = waitfor_factory, arg = { list = p }, max_queues = 3})
+
+    local map = {
+        ["single"] = single,
+        ["first"] = first,
+        ["partial"] = partial,
+        ["all"] = all,
+        ["fastgood"] = fastgood,
+        ["blocker"] = blocker,
+        ["logall"] = logall,
+        ["summary"] = summary,
+        ["waitfor"] = waitfor,
+    }
+
+    local parg = {
+        default = single,
+        list = map,
+        pattern = "^/(%a+)/"
+    }
+    local pfx = mcp.funcgen_new({ func = prefix_factory, arg = parg, max_queues = 16 })
+
+    mcp.attach(mcp.CMD_ANY_STORAGE, pfx)
+end

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -197,10 +197,10 @@ sub test_returns {
 }
 
 sub test_waitfor {
-    note 'stress testing rctx:wait_for scenarios';
+    note 'stress testing rctx:wait_cond scenarios';
 
     my $func_before = mem_stats($ps, "proxyfuncs");
-    subtest 'wait_for(0)' => sub {
+    subtest 'wait_cond(0)' => sub {
         $t->c_send("mg waitfor/a\r\n");
         $t->c_recv("HD t1\r\n", 'client response before backends receive cmd');
         $t->be_recv_c([0, 1, 2]);
@@ -208,7 +208,7 @@ sub test_waitfor {
         $t->clear();
     };
 
-    subtest 'wait_for(0) then wait_for(2)' => sub {
+    subtest 'wait_cond(0) then wait_cond(2)' => sub {
         $t->c_send("mg waitfor/b t\r\n");
         $t->be_recv_c([0, 1, 2]);
         $t->be_send([0, 1, 2], "HD t13\r\n");
@@ -216,7 +216,7 @@ sub test_waitfor {
         $t->clear();
     };
 
-    subtest 'wait_for(0) then queue then wait_for(1)' => sub {
+    subtest 'wait_cond(0) then queue then wait_cond(1)' => sub {
         $t->c_send("mg waitfor/c t\r\n");
         $t->be_recv_c([0, 1, 2]);
         $t->be_send([0, 1, 2], "HD t11\r\n");

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -68,6 +68,13 @@ sub test_errors {
         $t->c_send("$cmd$cmd");
         $t->c_recv("NF\r\n");
         $t->c_recv("SERVER_ERROR lua failure\r\n");
+        $t->clear();
+    };
+
+    subtest 'wrong return object' => sub {
+        $t->c_send("mg badreturn/a\r\n");
+        $t->c_recv("SERVER_ERROR bad response\r\n");
+        $t->clear();
     };
 }
 

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -67,7 +67,7 @@ sub test_errors {
         my $cmd = "md failgen/a\r\n";
         $t->c_send("$cmd$cmd");
         $t->c_recv("NF\r\n");
-        $t->c_recv("SERVER_ERROR lua failure\r\n");
+        $t->c_recv("SERVER_ERROR lua start failure\r\n");
         $t->clear();
     };
 

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -330,7 +330,7 @@ sub test_basic {
         # The third backend is our blocker, first test that normal backends return
         # but we don't return to client.
         $t->c_send("mg blocker/a t Ltest\r\n");
-        $t->be_recv_c([0, 1, 2, 3]);
+        $t->be_recv_c([0, 1, 2, 3], 'received blocker requests');
         $t->be_send([0, 1, 2], "HD t10\r\n");
         ok(!$t->wait_c(0.2), 'client doesnt become readable');
         $t->be_send(3, "HD t15\r\n");

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -80,6 +80,20 @@ sub test_pipeline {
             }
         }
     };
+
+    subtest 'ensuring unique slot environments' => sub {
+        # In each loop we send the command three times pipelined, but we
+        # should get three unique lua environments.
+        # In subsequent loops, the numbers will increment in lockstep.
+        for my $x (1 .. 5) {
+            # key doesn't matter; function isn't looking at it.
+            my $cmd = "mg /locality/a\r\n";
+            $t->c_send("$cmd$cmd$cmd");
+            for (1 .. 3) {
+                $t->c_recv("HD t$x\r\n", "client got return sequence $x");
+            }
+        }
+    };
 }
 
 sub test_split {

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -351,7 +351,7 @@ sub test_basic {
 
     subtest 'logall route' => sub {
         my $w = $p_srv->new_sock;
-        print $w "watch proxyuser\n";
+        print $w "watch proxyuser proxyreqs\n";
         is(<$w>, "OK\r\n", 'watcher enabled');
 
         $t->c_send("mg logall/a t\r\n");
@@ -360,6 +360,7 @@ sub test_basic {
         $t->c_recv_be();
         for (0 .. 2) {
             like(<$w>, qr/received a response: /, 'got a log line');
+            like(<$w>, qr/even more logs/, 'got logreq line');
         }
         $t->clear();
     };

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -1,0 +1,173 @@
+#!/usr/bin/env perl
+# Was wondering why we didn't use subtest more.
+# Turns out it's "relatively new", so it wasn't included in CentOS 5. which we
+# had to support until a few years ago. So most of the tests had been written
+# beforehand.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up the listeners _before_ starting the proxy.
+# the fourth listener is only occasionally used.
+my $t = Memcached::ProxyTest->new(servers => [12011, 12012, 12013, 12014]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyfuncgen.lua');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+# Comment out unused sections when debugging.
+test_basic();
+test_waitfor();
+
+done_testing();
+
+sub test_waitfor {
+    note 'stress testing rctx:wait_for scenarios';
+
+    subtest 'wait_for(0)' => sub {
+        $t->c_send("mg /waitfor/a\r\n");
+        $t->c_recv("HD t1\r\n", 'client response before backends receive cmd');
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t9\r\n");
+        $t->clear();
+    };
+
+    subtest 'wait_for(0) then wait_for(2)' => sub {
+        $t->c_send("mg /waitfor/b t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t13\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'wait_for(0) then queue then wait_for(1)' => sub {
+        $t->c_send("mg /waitfor/c t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t11\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+}
+
+sub test_basic {
+    note 'basic functionality tests';
+
+    subtest 'single backend route' => sub {
+        $t->c_send("mg /single/a\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'first route' => sub {
+        $t->c_send("mg /first/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        # respond from the other two backends first.
+        $t->be_send([1, 2], "HD t5\r\n");
+        $t->be_send(0, "HD t1\r\n");
+        # receive just the last command.
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'partial route' => sub {
+        $t->c_send("mg /partial/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send(0, "HD t4\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(1, "HD t4\r\n");
+        $t->c_recv_be('response received after 2/3 returned');
+        $t->be_send(2, "HD t5\r\n");
+        $t->clear();
+    };
+
+    subtest 'all route' => sub {
+        $t->c_send("mg /all/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1], "HD t1\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(2, "HD t1\r\n");
+        $t->c_recv_be('response received after 3/3 returned');
+        $t->clear();
+    };
+
+    subtest 'fastgood route' => sub {
+        $t->c_send("mg /fastgood/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        # Send one valid but not a hit.
+        $t->be_send(0, "EN\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(1, "HD t5\r\n");
+        $t->c_recv_be('response received after first good');
+        $t->be_send(2, "EN\r\n");
+        $t->clear();
+    };
+
+    subtest 'blocker route' => sub {
+        # The third backend is our blocker, first test that normal backends return
+        # but we don't return to client.
+        $t->c_send("mg /blocker/a t Ltest\r\n");
+        $t->be_recv_c([0, 1, 2, 3]);
+        $t->be_send([0, 1, 2], "HD t10\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(3, "HD t15\r\n");
+        # Now, be sure we didn't receive the blocker response
+        $t->c_recv("HD t10\r\n");
+        $t->clear();
+
+        note '... failed blocker';
+        $t->c_send("mg /blocker/b t Ltest\r\n");
+        $t->be_recv_c([0, 1, 2, 3]);
+        $t->be_send([0, 1, 2], "HD t10\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(3, "EN\r\n");
+        # Should get the blocker failed response.
+        $t->c_recv("SERVER_ERROR blocked\r\n");
+        $t->clear();
+    };
+
+    subtest 'logall route' => sub {
+        my $w = $p_srv->new_sock;
+        print $w "watch proxyuser\n";
+        is(<$w>, "OK\r\n", 'watcher enabled');
+
+        $t->c_send("mg /logall/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t3\r\n");
+        $t->c_recv_be();
+        for (0 .. 2) {
+            like(<$w>, qr/received a response: /, 'got a log line');
+        }
+        $t->clear();
+    };
+
+    subtest 'summary_factory' => sub {
+        my $w = $p_srv->new_sock;
+        print $w "watch proxyuser\n";
+        is(<$w>, "OK\r\n", 'watcher enabled');
+
+        $t->c_send("mg /summary/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t8\r\n");
+        $t->c_recv_be();
+        like(<$w>, qr/received all responses/, 'got a log summary line');
+        $t->clear();
+    };
+}
+

--- a/t/proxyintext.lua
+++ b/t/proxyintext.lua
@@ -1,0 +1,44 @@
+-- using mcp.internal() with extstore
+
+function new_splitter(afg, bfg)
+    local fg = mcp.funcgen_new()
+    local h_a = fg:new_handle(afg)
+    local h_b = fg:new_handle(bfg)
+
+    fg:ready({ f = function(rctx)
+        return function(r)
+            rctx:enqueue(r, h_a)
+            rctx:enqueue(r, h_b)
+            rctx:wait_cond(2, mcp.WAIT_ANY)
+            return rctx:res_any(h_a)
+        end
+    end
+    })
+
+    return fg
+end
+
+function mcp_config_pools()
+end
+
+function mcp_config_routes()
+    local mfg = mcp.funcgen_new()
+    mfg:ready({ f = function(rctx)
+            return function(r)
+                return mcp.internal(r)
+            end
+        end
+    })
+
+    -- test running internal from subrctx's
+    local split = new_splitter(mfg, mfg)
+
+    local map = {
+        ["top"] = mfg,
+        ["split"] = split,
+    }
+
+    local router = mcp.router_new({ map = map })
+
+    mcp.attach(mcp.CMD_ANY_STORAGE, router)
+end

--- a/t/proxyintext.t
+++ b/t/proxyintext.t
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+#
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $ext_path;
+
+if (!supports_extstore()) {
+    plan skip_all => 'extstore not enabled';
+    exit 0;
+}
+
+$ext_path = "/tmp/extstore.$$";
+
+my $value;
+{
+    my @chars = ("C".."Z");
+    for (1 .. 20000) {
+        $value .= $chars[rand @chars];
+    }
+}
+
+my $t = Memcached::ProxyTest->new(servers => [12081]);
+
+my $p_srv = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_item_size=512,ext_item_age=2,ext_path=$ext_path:64m,ext_max_sleep=100000,proxy_config=./t/proxyintext.lua");
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+#$t->accept_backends();
+
+{
+    test_basic();
+    subtest 'extstore tests', \&test_ext;
+}
+
+done_testing();
+
+sub test_basic {
+    subtest 'top level in memory mcp.internal() values' => sub {
+        $t->c_send("ms top/a 2 F1 Oa1\r\nhi\r\n");
+        $t->c_recv("HD Oa1\r\n", "set small value");
+        
+        $t->c_send("mg top/a v f Oa2\r\n");
+        $t->c_recv("VA 2 f1 Oa2\r\n", "header received");
+        $t->c_recv("hi\r\n", "payload received");
+        $t->clear();
+    };
+
+    subtest 'sub level in memory mcp.internal() values' => sub {
+        plan skip_all => 'sub-rctx internal calls do not work';
+        $t->c_send("ms split/b 2 F2 Ob1\r\nho\r\n");
+        $t->c_recv("HD Ob1\r\n", "set small to subrctx");
+
+        $t->c_send("mg split/b v f Ob2\r\n");
+        $t->c_recv("VA 2 f2 Ob2\r\n", "header received");
+        $t->c_recv("ho\r\n", "payload received");
+        $t->clear();
+    };
+}
+
+# don't need tons of keys for this test as we're focusing on fetch/return
+# functionality.
+sub test_ext {
+    my $count = 20;
+    for my $c (1 .. $count) {
+        $t->c_send("ms top/$c 20000 F$c\r\n$value\r\n");
+        $t->c_recv("HD\r\n");
+
+        # sub-rctx internal calls do not work.
+        #$t->c_send("ms split/$c 20000 F$c\r\n$value\r\n");
+        #$t->c_recv("HD\r\n");
+    }
+    $t->clear();
+
+    wait_ext_flush($ps);
+
+    $t->c_send("mg top/1 f v\r\n");
+    $t->c_recv("VA 20000 f1\r\n", "header received");
+    $t->c_recv("$value\r\n", "value received");
+
+    #$t->c_send("mg split/2 f v\r\n");
+    #$t->c_recv("VA 20000 F2\r\n", "header received");
+    #$t->c_recv("$value\r\n", "value received");
+    $t->clear();
+}
+
+END {
+    unlink $ext_path if $ext_path;
+}

--- a/t/proxyintext.t
+++ b/t/proxyintext.t
@@ -52,7 +52,7 @@ sub test_basic {
     subtest 'top level in memory mcp.internal() values' => sub {
         $t->c_send("ms top/a 2 F1 Oa1\r\nhi\r\n");
         $t->c_recv("HD Oa1\r\n", "set small value");
-        
+
         $t->c_send("mg top/a v f Oa2\r\n");
         $t->c_recv("VA 2 f1 Oa2\r\n", "header received");
         $t->c_recv("hi\r\n", "payload received");

--- a/t/proxylimits.t
+++ b/t/proxylimits.t
@@ -253,7 +253,7 @@ check_version($ps);
 
     $stats = mem_stats($ps, 'proxy');
     $used = $stats->{buffer_memory_used};
-    cmp_ok($used, '<', 2000, 'multiget: buffer memory usage not inflated');
+    cmp_ok($used, '<', 1000, 'multiget: buffer memory usage not inflated');
 
     $cmd = "get foo\r\n";
     for (1 .. 200) {

--- a/t/proxylimits.t
+++ b/t/proxylimits.t
@@ -253,7 +253,7 @@ check_version($ps);
 
     $stats = mem_stats($ps, 'proxy');
     $used = $stats->{buffer_memory_used};
-    cmp_ok($used, '<', 1000, 'multiget: buffer memory usage not inflated');
+    cmp_ok($used, '<', 2000, 'multiget: buffer memory usage not inflated');
 
     $cmd = "get foo\r\n";
     for (1 .. 200) {

--- a/t/proxyrouter.lua
+++ b/t/proxyrouter.lua
@@ -15,7 +15,7 @@ end
 
 function factory(rctx, h)
     return function(r)
-        return rctx:queue_and_wait(r, h)
+        return rctx:enqueue_and_wait(r, h)
     end
 end
 
@@ -28,7 +28,7 @@ end
 -- TODO: make default path and some other paths that return static data
 function mcp_config_routes(p)
     local fg = mcp.funcgen_new()
-    local fgh = fg:queue_assign(p)
+    local fgh = fg:new_handle(p)
     fg:ready({ f = factory, a = fgh })
 
     local def_fg = mcp.funcgen_new()

--- a/t/proxyrouter.lua
+++ b/t/proxyrouter.lua
@@ -25,6 +25,16 @@ function d_factory(rctx)
     end
 end
 
+function string_fgen(msg)
+    local fg = mcp.funcgen_new()
+    fg:ready({ f = function(rctx)
+        return function(r)
+            return msg
+        end
+    end})
+    return fg
+end
+
 -- TODO: make default path and some other paths that return static data
 function mcp_config_routes(p)
     local fg = mcp.funcgen_new()
@@ -37,6 +47,8 @@ function mcp_config_routes(p)
     local map = {
         ["one"] = fg,
         ["two"] = fg,
+        ["cmd"] = { [mcp.CMD_MG] = string_fgen("SERVER_ERROR cmd_mg\r\n"),
+            [mcp.CMD_MS] = string_fgen("SERVER_ERROR cmd_ms\r\n") },
     }
 
     local rpfx_short = mcp.router_new({ map = map, mode = "prefix", stop = "|", default = def_fg })

--- a/t/proxyrouter.lua
+++ b/t/proxyrouter.lua
@@ -1,0 +1,51 @@
+
+verbose = true
+
+function say(...)
+    if verbose then
+        print(...)
+    end
+end
+
+function mcp_config_pools()
+    local srv = mcp.backend
+    local b1 = srv('b1', '127.0.0.1', 12021)
+    return mcp.pool({b1})
+end
+
+function factory(rctx, h)
+    return function(r)
+        return rctx:queue_and_wait(r, h)
+    end
+end
+
+function d_factory(rctx)
+    return function(r)
+        return "SERVER_ERROR default route\r\n"
+    end
+end
+
+-- TODO: make default path and some other paths that return static data
+function mcp_config_routes(p)
+    local fg = mcp.funcgen_new()
+    local fgh = fg:queue_assign(p)
+    fg:ready({ f = factory, a = fgh })
+
+    local def_fg = mcp.funcgen_new()
+    def_fg:ready({ f = d_factory })
+
+    local map = {
+        ["one"] = fg,
+        ["two"] = fg,
+    }
+
+    local rpfx_short = mcp.router_new({ map = map, mode = "prefix", stop = "|", default = def_fg })
+    local rpfx_long = mcp.router_new({ map = map, mode = "prefix", stop = "+#+", default = def_fg })
+    local ranc_short = mcp.router_new({ map = map, mode = "anchor", start = "_", stop = ",", default = def_fg })
+    local ranc_long = mcp.router_new({ map = map, mode = "anchor", start = "=?=", stop = "__", default = def_fg })
+
+    mcp.attach(mcp.CMD_MG, rpfx_short)
+    mcp.attach(mcp.CMD_MS, rpfx_long)
+    mcp.attach(mcp.CMD_MD, ranc_short)
+    mcp.attach(mcp.CMD_MA, ranc_long)
+end

--- a/t/proxyrouter.t
+++ b/t/proxyrouter.t
@@ -31,11 +31,22 @@ $t->set_c($ps);
 $t->accept_backends();
 
 {
+    test_submap();
     test_basic();
     test_separators();
 }
 
 done_testing();
+
+sub test_submap {
+    subtest 'check sub map routing' => sub {
+        $t->c_send("mg cmd|test t3\r\n");
+        $t->c_recv("SERVER_ERROR cmd_mg\r\n", "routed to sub-mg function");
+        $t->c_send("ms cmd+#+test 2 T3\r\nhi\r\n");
+        $t->c_recv("SERVER_ERROR cmd_ms\r\n", "routed to sub-ms function");
+        $t->clear();
+    };
+}
 
 sub test_basic {
     # If there's a lua stack leak somewhere running the query a few hundred

--- a/t/proxyrouter.t
+++ b/t/proxyrouter.t
@@ -1,0 +1,117 @@
+#!/usr/bin/env perl
+# Was wondering why we didn't use subtest more.
+# Turns out it's "relatively new", so it wasn't included in CentOS 5. which we
+# had to support until a few years ago. So most of the tests had been written
+# beforehand.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up the listeners _before_ starting the proxy.
+# the fourth listener is only occasionally used.
+my $t = Memcached::ProxyTest->new(servers => [12021]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyrouter.lua');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+{
+    test_basic();
+    test_separators();
+}
+
+done_testing();
+
+sub test_basic {
+    # If there's a lua stack leak somewhere running the query a few hundred
+    # times will cause a crash.
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    subtest 'loop checking for lua leak' => sub {
+        for (1 .. 500) {
+            $t->c_send("mg one|key t$_\r\n");
+            $t->be_recv_c(0);
+            $t->be_send(0, "EN\r\n");
+            $t->c_recv_be();
+        }
+    };
+    check_func_counts($ps, $func_before);
+}
+
+# Router has short and long prefix and anchored prefix modes
+sub test_separators {
+    subtest 'short separator' => sub {
+        $t->c_send("mg one|key t3\r\n");
+        $t->be_recv_c(0, 'backend received mg');
+        $t->be_send(0, "EN\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("mg one/found\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+
+    subtest 'long separator' => sub {
+        $t->c_send("ms one+#+foo 2\r\nhi\r\n");
+        $t->be_recv(0, "ms one+#+foo 2\r\n", 'backend received ms');
+        $t->be_recv(0, "hi\r\n", 'backend received data');
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("ms one+#found 2\r\nhi\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+
+    subtest 'short anchor' => sub {
+        $t->c_send("md _one,bar\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("md _one+nothing\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+
+    subtest 'long anchor' => sub {
+        $t->c_send("ma =?=one__key\r\n");
+        $t->be_recv_c(0, 'backend received ma');
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("ma =?=one_nothing\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+}
+
+sub check_func_counts {
+    my $c = shift;
+    my $a = shift;
+    my $b = mem_stats($c, "proxyfuncs");
+    for my $key (keys %$a) {
+        # Don't want to pollute/slow down the output with tons of ok's here,
+        # so only fail on the fail conditions.
+        if (! exists $b->{$key}) {
+            fail("func stat gone missing: $key");
+        }
+        if ($a->{$key} != $b->{$key}) {
+            cmp_ok($b->{$key}, '==', $a->{$key}, "func stat for $key");
+        }
+    }
+}

--- a/t/proxytags.lua
+++ b/t/proxytags.lua
@@ -1,0 +1,28 @@
+-- get some information about the test being run from an external file
+-- so we can modify ourselves.
+local mode = dofile("/tmp/proxytagmode.lua")
+
+function mcp_config_pools()
+    -- we only ever need the one backend for this test.
+    -- we're explicitly not testing for changes in the backend, but that
+    -- routes are overwritten properly.
+    local be = mcp.backend('be', '127.0.0.1', 12050)
+    local p = mcp.pool({ be })
+    return p
+end
+
+function mcp_config_routes(p)
+    if mode == "start" then
+        -- one without tag
+        mcp.attach(mcp.CMD_MG, function(r) return p(r) end)
+        -- no listener on a
+        mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR tag A\r\n" end, "a")
+        -- listener on b
+        mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR tag B\r\n" end, "b")
+        -- extra listener.
+        mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR tag CCCC\r\n" end, "cccc")
+    end
+    -- TODO: reload to replace functions, ensure change.
+    -- TODO: mcp.CMD_ANY_STORAGE on reload
+    -- TODO: mcp.CMD_ANY_STORAGE and then replace a single CMD_MG
+end

--- a/t/proxytags.t
+++ b/t/proxytags.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $modefile = "/tmp/proxytagmode.lua";
+my $t = Memcached::ProxyTest->new(servers => [12050]);
+
+write_modefile('return "start"');
+my $p_srv = new_memcached('-l 127.0.0.1:12051 -l tag_b_:127.0.0.1:12052 -l tag_cccc_:127.0.0.1:12053 -o proxy_config=./t/proxytags.lua', 12051);
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+my $tagpsb = IO::Socket::INET->new(PeerAddr => "127.0.0.1:12052");
+my $tagpsc = IO::Socket::INET->new(PeerAddr => "127.0.0.1:12053");
+
+$t->set_c($ps);
+$t->accept_backends();
+
+{
+    test_basic();
+}
+
+done_testing();
+
+sub test_basic {
+    subtest 'untagged pass-thru' => sub {
+        $t->set_c($ps);
+        $t->c_send("mg foo t\r\n");
+        $t->be_recv_c(0, 'backend received pass-thru cmd');
+        $t->be_send(0, "HD t97\r\n");
+        $t->c_recv_be('client received pass-thru response');
+    };
+
+    subtest 'tag B works' => sub {
+        $t->set_c($tagpsb);
+        $t->c_send("mg bar t\r\n");
+        # No backend, looking for string response.
+        $t->c_recv("SERVER_ERROR tag B\r\n", 'received resp from tagged handler');
+    };
+
+    subtest 'tag CCCC works' => sub {
+        $t->set_c($tagpsc);
+        $t->c_send("mg baz t\r\n");
+        # No backend, looking for string response.
+        $t->c_recv("SERVER_ERROR tag CCCC\r\n", 'received resp from tagged handler');
+    };
+}
+
+sub write_modefile {
+    my $cmd = shift;
+    open(my $fh, "> $modefile") or die "Couldn't overwrite $modefile: $!";
+    print $fh $cmd;
+    close($fh);
+}
+
+sub wait_reload {
+    my $w = shift;
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=start/, "reload started");
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=done/, "reload completed");
+}
+
+END {
+    unlink $modefile;
+}


### PR DESCRIPTION
See #1098 for merge details. I've decided to keep this PR around for now as development history instead of just squashing this particular branch.

See t/proxyfuncgen.lua for documentation on API changes.

Depresses me greatly to post this still early. I am in a bug squashing and
testing phase.

This change is fully backwards compatible with the old API. If you are using
the old API, some of the C changes around execution of the lua code. All
parsing code (client or backend handling) is unchanged.

Motivation
---
This change revolves around holding context during request execution.
Previously the lua context simply "floated", being carried with a backend IO
request when necessary and resumed during a later callback. It was not
possible to know things for the full duration of a request. It was also not
possible to hold references for the full duration of a request.

For example, previously when lua executes a request against a single pool
(`pool(req)` syntax), the pool and request objects are held in the coroutine's
execution stack, then the coroutine is suspended. This prevents the pool from
being garbage collected while the request executes. Nothing else explicitly
prevents this from happening.

Nor can we pre-allocate memory and request objects. In a typical request, at
minimum:
- a coroutine thread is allocated
- a request object is allocated
- response objects are allocated
- any strings are allocated
- all of the above must later be garbage collected.

This can add up to a lot of CPU. Object creation is especially slow (setting
metatables) and argument checking can get expensive. This puts a high floor on
the CPU usage of a request. With pre-allocation it should be possible to run a
request from start to finish with zero allocations (and thus zero garbage
collection).

Further, the "async API" available via `mcp.await` was supposed to be a
temporary workaround before making the API change available in this pull
request. `mcp.await` is implemented by bolting itself over the existing
system, with hacks to know when to resume the coroutine. Further, it creates
even more allocations:

- the await tracking object
- a table to hold the response objects to be returned to lua

... and itself is limited. There is no way to execute callbacks, to execute
different requests against different pools, to wait on specific pools, and so
on.

Further, there is no way to compose a configuration as a directed graph, as
was done with mcrouter and similar systems. Without this configurations are
less composible, requiring significant code changes to do things like shadow
traffic, pre-warm pools, and so on.

The change
---

We now use a request context to track an incoming request until the response 
has been sent to the client. We use a pre-generation stage to allow
pre-allocating objects, caching lookups, creating callback contexts, and so
on. These pre-allocted request contexts and their associated functions are
re-used until the configuration is reloaded and overwritten.

See `t/proxyfuncgen.lua` for a description of the API and examples for how to
use it. Easier than describing it more here.

TODO
--

The remaining TODO items are split into "potential testing/merge blockers" and
"blocking usage of the new API"

Full blockers:
- [x] handle "TODO: return rctx" in `proto_proxy.c`
- [x] handle "FIXME: allow to fail" in `proto_proxy.c`
- [x] trace usage of `finalize_rctx_cb` and ensure nothing is missed
- [x] counters for how many funcgens exist and slots are in use (cannot trace
  on a per-funtion basis, just global)
- [x] The basic test work noted below.

Completion work:
- [x] Replace fgen free list with STAILQ linked list to remove error handling
  around allocation [not doing for now, low/no risk]
- [x] See if `max_queues` argument can be removed by executing a "learning run"
  with the function generator.
~~Argument for setting the size limit of a request object (might be global)~~ (change too big for this pr)
- [x] Cleanup code for funcgens being replaced (will expand this into sub-items)
- [x] Various cleanups around the funcgen code (TODO/FIXME's in the code)
~~Disallow further queuing from callbacks~~ (delaying; need to advise users to not do this for now)
- [x] Disallow calling wait funcs while waiting.
- [x] Don't allocate a request if a request context is a subcontext
- [x] Pre-allocate IO objects into queue slots to avoid runtime memory error handling
- [x] Pre-allocate result objects into queue slots where possible
- [x] Cleanups around non-result-object result handling (strings, nil, etc)
- [x] `rctx:wait_handle()` - accept just the handle if a queue slot already
  activated with a request

Test work:
- [ ] See `t/luafuncgen.t` - fill out tests until I run out of ideas.
- [ ] Separate test file for funcgen reload tests
- [x] Separate test file for testing the builtin router
- [ ] Specific funcgen tests added to the shredders test suite.
- [x] Executing the shredders stabilization and performance suites for the
  original API.

Maybe work:
- [x] A builtin prefix router, which avoids pulling the key into lua and
  executing a slow regular expression check. This adds up to a lot of CPU
usage...
- [x] extend router to accept command maps. ie: prefix -> mg -> func.
- [ ] "Max slots" argument to cap how many parallel requests of a particular function are allowed.