### PR TITLE
Add global pages stat

### DIFF
--- a/slabs.c
+++ b/slabs.c
@@ -603,6 +603,7 @@ static void do_slabs_stats(ADD_STAT add_stats, void *c) {
     /* add overall slab stats and append terminator */
 
     APPEND_STAT("active_slabs", "%d", total);
+    APPEND_STAT("global_pool_pages", "%u", slabclass[SLAB_GLOBAL_PAGE_POOL].slabs);
     APPEND_STAT("total_malloced", "%llu", (unsigned long long)mem_malloced);
     add_stats(NULL, 0, NULL, 0, c);
 }


### PR DESCRIPTION
Memcached's memory is managed by `slab classes`. Each slab class has many `pages`. When one page is not used by slab, it will be moved to the `global page pool` (i.e., slab class 0) for later use.

The `stats slabs` command shows page count of active slab classes, and the total_malloced memory size.
And if we add global pool pages count, it will be more helpful for users to understand memory information, i.e.,`pages of all active slab classes` + `pages of global pool` = `total malloced pages`

e.g.,
```
stats slabs
STAT 20:chunk_size 7104
STAT 20:chunks_per_page 147
STAT 20:total_pages 40              ## active pages
STAT 20:total_chunks 5880
STAT 20:used_chunks 5826
STAT 20:free_chunks 54
STAT 20:free_chunks_end 0
STAT 20:get_hits 0
STAT 20:cmd_set 5826
STAT 20:delete_hits 0
STAT 20:incr_hits 0
STAT 20:decr_hits 0
STAT 20:cas_hits 0
STAT 20:cas_badval 0
STAT 20:touch_hits 0
STAT 24:chunk_size 17352
STAT 24:chunks_per_page 60
STAT 24:total_pages 15              ## active pages
STAT 24:total_chunks 900
STAT 24:used_chunks 869
STAT 24:free_chunks 31
STAT 24:free_chunks_end 0
STAT 24:get_hits 0
STAT 24:cmd_set 55874
STAT 24:delete_hits 0
STAT 24:incr_hits 0
STAT 24:decr_hits 0
STAT 24:cas_hits 0
STAT 24:cas_badval 0
STAT 24:touch_hits 0
STAT active_slabs 2
STAT global_pool_pages 45           ## unused pages
STAT total_malloced 104857600       ## total memory
END
```
`STAT 20:total_pages 40` + `STAT 24:total_pages 15` + `STAT global_pool_pages 45` = total_malloced 100 pages