### PR TITLE
Use malloc_trim to return memory to OS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -694,6 +694,7 @@ AC_CHECK_FUNCS(clock_gettime)
 AC_CHECK_FUNCS(preadv)
 AC_CHECK_FUNCS(pread)
 AC_CHECK_FUNCS(eventfd)
+AC_CHECK_FUNCS(malloc_trim)
 AC_CHECK_FUNCS([accept4], [AC_DEFINE(HAVE_ACCEPT4, 1, [Define to 1 if support accept4])])
 AC_CHECK_FUNCS([getopt_long], [AC_DEFINE(HAVE_GETOPT_LONG, 1, [Define to 1 if support getopt_long])])
 

--- a/slabs.c
+++ b/slabs.c
@@ -22,6 +22,9 @@
 #include <signal.h>
 #include <assert.h>
 #include <pthread.h>
+#ifdef HAVE_MALLOC_TRIM
+#include <malloc.h>
+#endif
 
 //#define DEBUG_SLAB_MOVER
 /* powers-of-N allocation structures */
@@ -691,6 +694,9 @@ bool slabs_adjust_mem_limit(size_t new_mem_limit) {
     pthread_mutex_lock(&slabs_lock);
     ret = do_slabs_adjust_mem_limit(new_mem_limit);
     pthread_mutex_unlock(&slabs_lock);
+#ifdef HAVE_MALLOC_TRIM
+    malloc_trim(0); /* force return memory to OS */
+#endif
     return ret;
 }
 


### PR DESCRIPTION
One `page` is freed by `slabs.c:memory_release` when `cache_memlimit` command adjust memory limitation. But sometimes `glibc` do not return the freed memory to operating system, which make users confusing with memcached's memory `Resident Size`. The following example shows that about 25GB memory is not return to OS.

![image](https://github.com/memcached/memcached/assets/4401756/6d581676-a4c0-42e4-b38c-23bdcdb54daf)

[malloc_trim](https://man7.org/linux/man-pages/man3/malloc_trim.3.html) can release memory back to the system. 