### PR TITLE
docs: use spaces instead of tab character

### DIFF
--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -4,7 +4,6 @@ use FindBin qw($Bin);
 chdir "$Bin/.." or die;
 
 my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md md5.c md5.h);
-push(@exempted, glob("doc/*.xml"));
 push(@exempted, glob("doc/*.full"));
 push(@exempted, glob("doc/xml2rfc/*.xsl"));
 push(@exempted, glob("m4/*backport*m4"));

--- a/doc/protocol-binary-range.xml
+++ b/doc/protocol-binary-range.xml
@@ -144,10 +144,10 @@
 
       <section anchor="command-getr-request" title="Get Range Request">
         <t>
-	  The Get Range request is primarily intended for use over a UDP transport
-	  to request byte ranges of the value for a key. In the event that the Data version
-	  check fails to match that of the key, an error MUST be returned.
-	</t>
+        The Get Range request is primarily intended for use over a UDP transport
+        to request byte ranges of the value for a key. In the event that the Data version
+        check fails to match that of the key, an error MUST be returned.
+        </t>
         <t>
       <figure>
         <preamble>Extra data for get range request:</preamble>
@@ -172,12 +172,12 @@ Total 20 bytes
 
       <section anchor="command-getr-response" title="Get Range Response">
         <t>
-	  The Get Range request is primarily intended for use over a UDP transport
-	  to indicate the location of the bytes of the value for a key contained in
-	  a given packet. A client receives enough information in each Get Range
-	  extras to construct an appropriately sized buffer in its own memory and
-	  blindly insert the contents of the packet at the given byte offset.
-	</t>
+        The Get Range request is primarily intended for use over a UDP transport
+        to indicate the location of the bytes of the value for a key contained in
+        a given packet. A client receives enough information in each Get Range
+        extras to construct an appropriately sized buffer in its own memory and
+        blindly insert the contents of the packet at the given byte offset.
+        </t>
         <t>
       <figure>
         <preamble>Extra data for get range response:</preamble>

--- a/doc/protocol-binary.xml
+++ b/doc/protocol-binary.xml
@@ -180,8 +180,8 @@
           different request/response value pair. This is useful for protocol
           analyzers to distinguish the nature of the packet from the direction
           which it is moving. Note, it is common to run a memcached instance on
-	  a host that also runs an application server. Such a host will both
-	  send and receive memcache packets.
+          a host that also runs an application server. Such a host will both
+          send and receive memcache packets.
         </t>
 
         <t>
@@ -237,7 +237,7 @@
           <t hangText="0x0D">GetKQ</t>
           <t hangText="0x0E">Append</t>
           <t hangText="0x0F">Prepend</t>
-	  <t hangText="0x10">Stat</t>
+          <t hangText="0x10">Stat</t>
           <t hangText="0x11">SetQ</t>
           <t hangText="0x12">AddQ</t>
           <t hangText="0x13">ReplaceQ</t>
@@ -250,16 +250,16 @@
           <t hangText="0x1A">PrependQ</t>
         </list>
         </t>
-	      <t>
-	        As a convention all of the commands ending with "Q" for
-	        Quiet.  A quiet version of a command will omit responses
-	        that are considered uninteresting.  Whether a given response
-	        is interesting is dependent upon the command.  See the
-	        descriptions of the
-	        <xref target="command-get">set commands</xref>
-	        and <xref target="command-set">set commands</xref> for
-	        examples of commands that include quiet variants.
-	      </t>
+        <t>
+        As a convention all of the commands ending with "Q" for
+        Quiet.  A quiet version of a command will omit responses
+        that are considered uninteresting.  Whether a given response
+        is interesting is dependent upon the command.  See the
+        descriptions of the
+        <xref target="command-get">set commands</xref>
+        and <xref target="command-set">set commands</xref> for
+        examples of commands that include quiet variants.
+        </t>
       </section>
 
       <section anchor="value-types" title="Data Types">
@@ -277,10 +277,10 @@
         <t>
         All communication is initiated by a request from the client,
         and the server will respond to each request with zero or
-	multiple packets for each request. If the status code of a response
-	packet is non-nil, the body of the packet will contain a textual error
-	message. If the status code is nil, the command opcode will define the
-	layout of the body of the message.
+        multiple packets for each request. If the status code of a response
+        packet is non-nil, the body of the packet will contain a textual error
+        message. If the status code is nil, the command opcode will define the
+        layout of the body of the message.
         </t>
         <section anchor="command-introduction-example" title="Example">
             <t>
@@ -723,7 +723,7 @@ Value               : None
         </t>
 
         <t>
-	  Delete the item with the specific key.
+        Delete the item with the specific key.
         </t>
 
         <section anchor="command-delete-example" title="Example">
@@ -1163,8 +1163,8 @@ Value               : None
           Request the server version.
         </t>
         <t>
-	  The server responds with a packet containing the version string
-	  in the body with the following format: "x.y.z"
+          The server responds with a packet containing the version string
+          in the body with the following format: "x.y.z"
         </t>
         <section anchor="command-version-example" title="Example">
           <figure>
@@ -1317,7 +1317,7 @@ Value        (29)   : "!"
         </t>
 
         <t>
-	  Request server statistics. Without a key specified the server will
+          Request server statistics. Without a key specified the server will
           respond with a "default" set of statistics information. Each piece
           of statistical information is returned in its own packet (key
           contains the name of the statistical item and the body contains the

--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -12,7 +12,6 @@ BEGIN {
     }
 
     my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md compile_commands.json md5.c md5.h);
-    push(@exempted, glob("doc/*.xml"));
     push(@exempted, glob("doc/*.full"));
     push(@exempted, glob("doc/xml2rfc/*.xsl"));
     push(@exempted, glob("doc/xml2rfc/*.dtd"));


### PR DESCRIPTION
Currently doc directory subfiles have inconsistent indentation.
Change the tab characters in the doc/*.xml files to spaces and include them in the whitespace test.

I think the same change could be applied to some other files(`*.xsl`, `*.full`, ...).

Are these files excluded from testing because they are immutable?
(Does a license that does not allow modifications apply?)