### PR TITLE
proxy: lua API version 2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,7 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_ratelim.c \
 					 proxy_jump_hash.c proxy_request.c \
 					 proxy_network.c proxy_lua.c \
+					 proxy_luafgen.c \
 					 proxy_config.c proxy_ring_hash.c \
 					 proxy_internal.c \
 					 md5.c md5.h

--- a/memcached.h
+++ b/memcached.h
@@ -780,6 +780,9 @@ typedef struct _mc_resp {
      */
     bool skip;
     bool free; // double free detection.
+#ifdef PROXY
+    bool proxy_res; // we're handling a proxied response buffer.
+#endif
     // UDP bits. Copied in from the client.
     uint16_t    request_id; /* Incoming UDP request ID, if this is a UDP "connection" */
     uint16_t    udp_sequence; /* packet counter when transmitting result */
@@ -794,6 +797,7 @@ typedef struct _mc_resp {
 struct _mc_resp_bundle {
     uint8_t refcount;
     uint8_t next_check; // next object to check on assignment.
+    LIBEVENT_THREAD *thread;
     struct _mc_resp_bundle *next;
     struct _mc_resp_bundle *prev;
     mc_resp r[];
@@ -861,7 +865,7 @@ struct conn {
     int io_queues_submitted; /* see notes on io_queue_t */
     io_queue_t io_queues[IO_QUEUE_COUNT]; /* set of deferred IO queues. */
 #ifdef PROXY
-    unsigned int proxy_coro_ref; /* lua reference for active coroutine */
+    void *proxy_rctx; /* pointer to active request context */
 #endif
 #ifdef EXTSTORE
     unsigned int recache_counter;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -14,7 +14,6 @@
 #define PROCESS_NORMAL false
 #define PROXY_GC_BACKGROUND_SECONDS 2
 static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool multiget);
-static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc);
 static void *mcp_profile_alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 
 /******** EXTERNAL FUNCTIONS ******/
@@ -150,6 +149,43 @@ void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c) {
     APPEND_STAT("cmd_replace", "%llu", (unsigned long long)istats.counters[CMD_REPLACE]);
 }
 
+void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c) {
+    char key_str[STAT_KEY_LEN];
+    if (!arg) {
+        return;
+    }
+    proxy_ctx_t *ctx = arg;
+    lua_State *L = ctx->proxy_sharedvm;
+    pthread_mutex_lock(&ctx->sharedvm_lock);
+
+    // iterate all of the named function slots
+    lua_pushnil(L);
+    while (lua_next(L, SHAREDVM_FGEN_IDX) != 0) {
+        int n = lua_tointeger(L, -1);
+        lua_pop(L, 1); // drop the value, leave the key.
+        if (n != 0) {
+            // reuse the key. make a copy since rawget will pop it.
+            lua_pushvalue(L, -1);
+            lua_rawget(L, SHAREDVM_FGENSLOT_IDX);
+            int slots = lua_tointeger(L, -1);
+            lua_pop(L, 1); // drop the slot count.
+
+            // now grab the name key.
+            const char *name = lua_tostring(L, -1);
+            snprintf(key_str, STAT_KEY_LEN-1, "funcs_%s", name);
+            APPEND_STAT(key_str, "%d", n);
+            snprintf(key_str, STAT_KEY_LEN-1, "slots_%s", name);
+            APPEND_STAT(key_str, "%d", slots);
+        } else {
+            // TODO: Is it safe to delete keys in the middle here?
+            // not worried at all about just leaking memory here.
+            lua_pop(L, 1); // drop value, keep key, loop.
+        }
+    }
+
+    pthread_mutex_unlock(&ctx->sharedvm_lock);
+}
+
 // start the centralized lua state and config thread.
 void *proxy_init(bool use_uring, bool proxy_memprofile) {
     proxy_ctx_t *ctx = calloc(1, sizeof(proxy_ctx_t));
@@ -190,6 +226,16 @@ void *proxy_init(bool use_uring, bool proxy_memprofile) {
     luaL_openlibs(L);
     // NOTE: might need to differentiate the libs yes?
     proxy_register_libs(ctx, NULL, L);
+
+    // set up the shared state VM. Used by short-lock events (counters/state)
+    // for global visibility.
+    pthread_mutex_init(&ctx->sharedvm_lock, NULL);
+    ctx->proxy_sharedvm = luaL_newstate();
+    luaL_openlibs(ctx->proxy_sharedvm);
+    // we keep info tables in the top level stack so we don't have to
+    // constantly fetch them from registry.
+    lua_newtable(ctx->proxy_sharedvm); // fgen count
+    lua_newtable(ctx->proxy_sharedvm); // fgen slot count
 
     // Create/start the IO thread, which we need before servers
     // start getting created.
@@ -233,6 +279,14 @@ void proxy_thread_init(void *ctx, LIBEVENT_THREAD *thr) {
     } else {
         L = luaL_newstate();
     }
+
+    // With smaller requests the default incremental collector appears to
+    // never complete. With this simple tuning (def-1, def, def) it seems
+    // fine.
+    // We can't use GCGEN until we manage pools with reference counting, as
+    // they may never hit GC and thus never release their connection
+    // resources.
+    lua_gc(L, LUA_GCINC, 199, 100, 13);
     thr->L = L;
     luaL_openlibs(L);
     proxy_register_libs(ctx, thr, L);
@@ -276,26 +330,22 @@ void proxy_submit_cb(io_queue_t *q) {
     while (p) {
         mcp_backend_t *be;
         P_DEBUG("%s: queueing req for backend: %p\n", __func__, (void *)p);
-        if (p->is_await) {
-            // need to not count await objects multiple times.
-            if (p->await_background) {
-                P_DEBUG("%s: fast-returning await_background object: %p\n", __func__, (void *)p);
-                // intercept await backgrounds
-                // this call cannot recurse if we're on the worker thread,
-                // since the worker thread has to finish executing this
-                // function in order to pick up the returned IO.
-                q->count++;
-                return_io_pending((io_pending_t *)p);
-                p = p->next;
-                continue;
-            } else if (p->await_first) {
-                q->count++;
-            }
+        if (p->qcount_incr) {
             // funny workaround: awaiting IOP's don't count toward
             // resuming a connection, only the completion of the await
             // condition.
-        } else {
             q->count++;
+        }
+
+        if (p->await_background) {
+            P_DEBUG("%s: fast-returning await_background object: %p\n", __func__, (void *)p);
+            // intercept await backgrounds
+            // this call cannot recurse if we're on the worker thread,
+            // since the worker thread has to finish executing this
+            // function in order to pick up the returned IO.
+            return_io_pending((io_pending_t *)p);
+            p = p->next;
+            continue;
         }
         be = p->backend;
 
@@ -354,40 +404,60 @@ void proxy_submit_cb(io_queue_t *q) {
     return;
 }
 
-// called from worker thread after an individual IO has been returned back to
-// the worker thread. Do post-IO run and cleanup work.
-void proxy_return_cb(io_pending_t *pending) {
+// This function handles return processing for the "old style" API: direct
+// pool calls and mcp.await()
+void proxy_return_rctx_cb(io_pending_t *pending) {
     io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
+    if (p->client_resp && p->client_resp->blen) {
+        // FIXME: workaround for buffer memory being external to objects.
+        // can't run 0 since that means something special (run the GC)
+        unsigned int kb = p->client_resp->blen / 1000;
+        lua_gc(p->rctx->Lc, LUA_GCSTEP, kb > 0 ? kb : 1);
+    }
+
     if (p->is_await) {
+        p->rctx->async_pending--;
         mcplib_await_return(p);
-    } else {
-        lua_State *Lc = p->coro;
-
-        // in order to resume we need to remove the objects that were
-        // originally returned
-        // what's currently on the top of the stack is what we want to keep.
-        lua_rotate(Lc, 1, 1);
-        // We kept the original results from the yield so lua would not
-        // collect them in the meantime. We can drop those now.
-        lua_settop(Lc, 1);
-
-        // p can be freed/changed from the call below, so fetch the queue now.
-        io_queue_t *q = conn_io_queue_get(p->c, p->io_queue_type);
-        conn *c = p->c;
-        proxy_run_coroutine(Lc, p->resp, p, c);
-
-        q->count--;
-        if (q->count == 0) {
-            // call re-add directly since we're already in the worker thread.
-            conn_worker_readd(c);
+        // need to directly attempt to return the context,
+        // we may or may not be hitting proxy_run_rcontext from await_return.
+        if (p->rctx->async_pending == 0) {
+            mcp_funcgen_return_rctx(p->rctx);
         }
+        return;
+    }
+
+    mcp_rcontext_t *rctx = p->rctx;
+    lua_rotate(rctx->Lc, 1, 1);
+    lua_settop(rctx->Lc, 1);
+    // hold the resp for a minute.
+    mc_resp *resp = rctx->resp;
+
+    proxy_run_rcontext(rctx);
+    mcp_funcgen_return_rctx(rctx);
+
+    io_queue_t *q = conn_io_queue_get(p->c, p->io_queue_type);
+    // Detatch the iop from the mc_resp and free it here.
+    conn *c = p->c;
+    if (p->io_type != IO_PENDING_TYPE_EXTSTORE) {
+        // if we're doing an extstore subrequest, the iop needs to live until
+        // resp's ->finish_cb is called.
+        resp->io_pending = NULL;
+        do_cache_free(p->thread->io_cache, p);
+    }
+
+    q->count--;
+    if (q->count == 0) {
+        // call re-add directly since we're already in the worker thread.
+        conn_worker_readd(c);
     }
 }
 
-// called from the worker thread as an mc_resp is being freed.
-// must let go of the coroutine reference if there is one.
-// caller frees the pending IO.
-void proxy_finalize_cb(io_pending_t *pending) {
+// This is called if resp_finish is called while an iop exists on the
+// resp.
+// so we need to release our iop and rctx.
+// - This can't happen unless we're doing extstore fetches.
+// - the request context is freed before connection processing resumes.
+void proxy_finalize_rctx_cb(io_pending_t *pending) {
     io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
 
     if (p->io_type == IO_PENDING_TYPE_EXTSTORE) {
@@ -399,16 +469,6 @@ void proxy_finalize_cb(io_pending_t *pending) {
             item_remove(p->hdr_it);
         }
     }
-
-    // release our coroutine reference.
-    // TODO (v2): coroutines are reusable in lua 5.4. we can stack this onto a freelist
-    // after a lua_resetthread(Lc) call.
-    if (p->coro_ref) {
-        // Note: lua registry is the same for main thread or a coroutine.
-        luaL_unref(p->coro, LUA_REGISTRYINDEX, p->coro_ref);
-    }
-
-    return;
 }
 
 int try_read_command_proxy(conn *c) {
@@ -468,11 +528,14 @@ int try_read_command_proxy(conn *c) {
 // Called when a connection is closed while in nread state reading a set
 // Must only be called with an active coroutine.
 void proxy_cleanup_conn(conn *c) {
-    assert(c->proxy_coro_ref != 0);
+    assert(c->proxy_rctx);
     LIBEVENT_THREAD *thr = c->thread;
-    lua_State *L = thr->L;
-    luaL_unref(L, LUA_REGISTRYINDEX, c->proxy_coro_ref);
-    c->proxy_coro_ref = 0;
+    mcp_rcontext_t *rctx = c->proxy_rctx;
+    assert(rctx->pending_reqs == 1);
+    rctx->pending_reqs = 0;
+
+    mcp_funcgen_return_rctx(rctx);
+    c->proxy_rctx = NULL;
     WSTAT_DECR(thr, proxy_req_active, 1);
 }
 
@@ -483,26 +546,24 @@ void complete_nread_proxy(conn *c) {
     LIBEVENT_THREAD *thr = c->thread;
     lua_State *L = thr->L;
 
-    if (c->proxy_coro_ref == 0) {
+    if (c->proxy_rctx == NULL) {
         complete_nread_ascii(c);
         return;
     }
 
     conn_set_state(c, conn_new_cmd);
 
-    // Grab our coroutine.
-    // Leave the reference alone in case we error out, so the conn cleanup
-    // routine can handle it properly.
-    lua_rawgeti(L, LUA_REGISTRYINDEX, c->proxy_coro_ref);
-    lua_State *Lc = lua_tothread(L, -1);
-    mcp_request_t *rq = luaL_checkudata(Lc, -1, "mcp.request");
+    assert(c->proxy_rctx);
+    mcp_rcontext_t *rctx = c->proxy_rctx;
+    mcp_request_t *rq = rctx->request;
 
-    // validate the data chunk.
     if (strncmp((char *)c->item + rq->pr.vlen - 2, "\r\n", 2) != 0) {
         lua_settop(L, 0); // clear anything remaining on the main thread.
         // FIXME (v2): need to set noreply false if mset_res, but that's kind
         // of a weird hack to begin with. Evaluate how to best do that here.
         out_string(c, "CLIENT_ERROR bad data chunk");
+        rctx->pending_reqs--;
+        mcp_funcgen_return_rctx(rctx);
         return;
     }
 
@@ -512,13 +573,13 @@ void complete_nread_proxy(conn *c) {
     rq->pr.vbuf = c->item;
     c->item = NULL;
     c->item_malloced = false;
-    luaL_unref(L, LUA_REGISTRYINDEX, c->proxy_coro_ref);
-    c->proxy_coro_ref = 0;
+    c->proxy_rctx = NULL;
     pthread_mutex_lock(&thr->proxy_limit_lock);
     thr->proxy_buffer_memory_used += rq->pr.vlen;
     pthread_mutex_unlock(&thr->proxy_limit_lock);
 
-    proxy_run_coroutine(Lc, c->resp, NULL, c);
+    proxy_run_rcontext(rctx);
+    mcp_funcgen_return_rctx(rctx);
 
     lua_settop(L, 0); // clear anything remaining on the main thread.
 
@@ -593,168 +654,205 @@ static void _set_noreply_mode(mc_resp *resp, mcp_resp_t *r) {
     }
 }
 
-// this resumes every yielded coroutine (and re-resumes if necessary).
-// called from the worker thread after responses have been pulled from the
-// network.
-// Flow:
-// - the response object should already be on the coroutine stack.
-// - fix up the stack.
-// - run coroutine.
-// - if LUA_YIELD, we need to swap out the pending IO from its mc_resp then call for a queue
-// again.
-// - if LUA_OK finalize the response and return
-// - else set error into mc_resp.
-int proxy_run_coroutine(lua_State *Lc, mc_resp *resp, io_pending_proxy_t *p, conn *c) {
+static void _proxy_run_rcontext_queues(mcp_rcontext_t *rctx) {
+    for (int x = 0; x < rctx->fgen->max_queues; x++) {
+        mcp_run_rcontext_handle(rctx, x);
+    }
+}
+
+static void _proxy_run_tresp_to_resp(mc_resp *tresp, mc_resp *resp) {
+    // The internal cache handler has created a resp we want to swap in
+    // here. It would be fastest to swap *resp's position in the
+    // link but if the set is deep this would instead be slow, so
+    // we copy over details from this temporary resp instead.
+
+    // So far all we fill is the wbuf and some iov's? so just copy
+    // that + the UDP info?
+    memcpy(resp->wbuf, tresp->wbuf, tresp->iov[0].iov_len);
+    for (int x = 0; x < tresp->iovcnt; x++) {
+        resp->iov[x] = tresp->iov[x];
+    }
+    // resp->iov[x].iov_base needs to be updated if it's
+    // pointing within its wbuf.
+    // FIXME: This is too fragile. we need to be able to
+    // inherit details and swap resp objects around.
+    if (tresp->iov[0].iov_base == tresp->wbuf) {
+        resp->iov[0].iov_base = resp->wbuf;
+    }
+    resp->iovcnt = tresp->iovcnt;
+    resp->chunked_total = tresp->chunked_total;
+    resp->chunked_data_iov = tresp->chunked_data_iov;
+    // copy UDP headers...
+    resp->request_id = tresp->request_id;
+    resp->udp_sequence = tresp->udp_sequence;
+    resp->udp_total = tresp->udp_total;
+    resp->request_addr = tresp->request_addr;
+    resp->request_addr_size = tresp->request_addr_size;
+    resp->item = tresp->item; // will be populated if not extstore fetch
+    resp->skip = tresp->skip;
+}
+
+// HACK NOTES:
+// These are self-notes for dormando mostly.
+// The IO queue system does not work well with the proxy, as we need to:
+// - only increment q->count during the submit phase
+//   - .. because a resumed coroutine can queue more data.
+//   - and we will never hit q->count == 0
+//   - .. and then never resume the main connection. (conn_worker_readd)
+//   - which will never submit the new sub-requests
+// - need to only increment q->count once per stack of requests coming from a
+//   resp.
+//
+// There are workarounds for this all over. In the await code, we test for
+// "the first await object" or "is an await background object", for
+// incrementing the q->count
+// For pool-backed requests we always increment in submit
+// For RQU backed requests (new API) there isn't an easy place to test for
+// "the first request", because:
+// - The connection queue is a stack of _all_ requests pending on this
+// connection, and many requests can arrive in one batch.
+//   - Thus we cannot simply check if there are items in the queue
+// - RQU's can be recursive, so we have to loop back to the parent to check to
+//   see if we're the first queue or not.
+//
+// This hack workaround exists so I can fix the IO queue subsystem as a change
+// independent of the RCTX change, as the IO queue touches everything and
+// scares the shit out of me. It's much easier to make changes to it in
+// isolation, when all existing systems are currently working and testable.
+//
+// Description of the hack:
+// - in mcp_queue_io: roll up rctx to parent, and if we are the first IO to queue
+// since the rcontext started, set p->qcounr_incr = true
+// Later in submit_cb:
+// - q->count++ if p->qcount_incr.
+//
+// Finally, in proxy_return_rqu_cb:
+// - If parent completed non-yielded work, q->count-- to allow conn
+// resumption.
+// - At bottom of rqu_cb(), flush any IO queues for the connection in case we
+// re-queued work.
+int proxy_run_rcontext(mcp_rcontext_t *rctx) {
     int nresults = 0;
+    lua_State *Lc = rctx->Lc;
     int cores = lua_resume(Lc, NULL, 1, &nresults);
     size_t rlen = 0;
+    conn *c = rctx->c;
+    mc_resp *resp = rctx->resp;
 
     if (cores == LUA_OK) {
-        WSTAT_DECR(c->thread, proxy_req_active, 1);
-        int type = lua_type(Lc, 1);
-        P_DEBUG("%s: coroutine completed. return type: %d\n", __func__, type);
-        if (type == LUA_TUSERDATA) {
-            mcp_resp_t *r = luaL_checkudata(Lc, 1, "mcp.response");
-            _set_noreply_mode(resp, r);
-            if (r->status != MCMC_OK && r->resp.type != MCMC_RESP_ERRMSG) {
-                proxy_out_errstring(resp, PROXY_SERVER_ERROR, "backend failure");
-            } else if (r->cresp) {
-                mc_resp *tresp = r->cresp;
-                // The internal cache handler has created a resp we want to swap in
-                // here. It would be fastest to swap *resp's position in the
-                // link but if the set is deep this would instead be slow, so
-                // we copy over details from this temporary resp instead.
-                assert(c != NULL);
+        // don't touch the result object if we were a sub-context.
+        if (!rctx->parent) {
+            WSTAT_DECR(c->thread, proxy_req_active, 1);
+            int type = lua_type(Lc, 1);
+            mcp_resp_t *r = NULL;
+            P_DEBUG("%s: coroutine completed. return type: %d\n", __func__, type);
+            if (type == LUA_TUSERDATA && (r = luaL_testudata(Lc, 1, "mcp.response")) != NULL) {
+                _set_noreply_mode(resp, r);
+                if (r->status != MCMC_OK && r->resp.type != MCMC_RESP_ERRMSG) {
+                    proxy_out_errstring(resp, PROXY_SERVER_ERROR, "backend failure");
+                } else if (r->cresp) {
+                    mc_resp *tresp = r->cresp;
+                    assert(c != NULL);
 
-                // So far all we fill is the wbuf and some iov's? so just copy
-                // that + the UDP info?
-                memcpy(resp->wbuf, tresp->wbuf, tresp->iov[0].iov_len);
-                for (int x = 0; x < tresp->iovcnt; x++) {
-                    resp->iov[x] = tresp->iov[x];
+                    _proxy_run_tresp_to_resp(tresp, resp);
+                    // we let the mcp_resp gc handler free up tresp and any
+                    // associated io_pending's of its own later.
+                } else if (r->buf) {
+                    // response set from C.
+                    resp->write_and_free = r->buf;
+                    resp_add_iov(resp, r->buf, r->blen);
+                    // stash the length to later remove from memory tracking
+                    resp->wbytes = r->blen + r->extra;
+                    resp->proxy_res = true;
+                    r->buf = NULL;
+                } else {
+                    // Empty response: used for ascii multiget emulation.
                 }
-                // resp->iov[x].iov_base needs to be updated if it's
-                // pointing within its wbuf.
-                // FIXME: This is too fragile. we need to be able to
-                // inherit details and swap resp objects around.
-                if (tresp->iov[0].iov_base == tresp->wbuf) {
-                    resp->iov[0].iov_base = resp->wbuf;
-                }
-                resp->iovcnt = tresp->iovcnt;
-                resp->chunked_total = tresp->chunked_total;
-                resp->chunked_data_iov = tresp->chunked_data_iov;
-                // copy UDP headers...
-                resp->request_id = tresp->request_id;
-                resp->udp_sequence = tresp->udp_sequence;
-                resp->udp_total = tresp->udp_total;
-                resp->request_addr = tresp->request_addr;
-                resp->request_addr_size = tresp->request_addr_size;
-                resp->item = tresp->item; // will be populated if not extstore fetch
-                resp->skip = tresp->skip;
 
-                // we let the mcp_resp gc handler free up tresp and any
-                // associated io_pending's of its own later.
-            } else if (r->buf) {
-                // response set from C.
-                resp->write_and_free = r->buf;
-                resp_add_iov(resp, r->buf, r->blen);
-                r->buf = NULL;
-            } else if (lua_getiuservalue(Lc, 1, 1) != LUA_TNIL) {
-                // uservalue slot 1 is pre-created, so we get TNIL instead of
-                // TNONE when nothing was set into it.
-                const char *s = lua_tolstring(Lc, -1, &rlen);
+            } else if (type == LUA_TSTRING) {
+                // response is a raw string from lua.
+                const char *s = lua_tolstring(Lc, 1, &rlen);
                 size_t l = rlen > WRITE_BUFFER_SIZE ? WRITE_BUFFER_SIZE : rlen;
                 memcpy(resp->wbuf, s, l);
                 resp_add_iov(resp, resp->wbuf, l);
                 lua_pop(Lc, 1);
             } else {
-                // Empty response: used for ascii multiget emulation.
+                proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad response");
             }
-
-        } else if (type == LUA_TSTRING) {
-            // response is a raw string from lua.
-            const char *s = lua_tolstring(Lc, 1, &rlen);
-            size_t l = rlen > WRITE_BUFFER_SIZE ? WRITE_BUFFER_SIZE : rlen;
-            memcpy(resp->wbuf, s, l);
-            resp_add_iov(resp, resp->wbuf, l);
-            lua_pop(Lc, 1);
-        } else {
-            proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad response");
         }
 
+        rctx->pending_reqs--;
     } else if (cores == LUA_YIELD) {
-        int coro_ref = 0;
         int yield_type = lua_tointeger(Lc, -1);
         P_DEBUG("%s: coroutine yielded. return type: %d\n", __func__, yield_type);
         assert(yield_type != 0);
         lua_pop(Lc, 1);
 
-        // need to remove and free the io_pending, since c->resp owns it.
-        // so we call mcp_queue_io() again and let it override the
-        // mc_resp's io_pending object.
-        //
-        // p is not null only when being called from proxy_return_cb(),
-        // a pending IO is returning to resume.
-        if (p != NULL) {
-            coro_ref = p->coro_ref;
-            assert((void *)p == (void *)resp->io_pending);
-            resp->io_pending = NULL;
-            c = p->c;
-            // *p is now dead.
-            do_cache_free(c->thread->io_cache, p);
-        } else {
-            // coroutine object sitting on the _main_ VM right now, so we grab
-            // the reference from there, which also pops it.
-            assert(c != NULL);
-            coro_ref = luaL_ref(c->thread->L, LUA_REGISTRYINDEX);
-        }
-
         int res = 0;
+        mcp_request_t *rq = NULL;
+        mcp_backend_t *be = NULL;
+        mcp_resp_t *r = NULL;
         switch (yield_type) {
             case MCP_YIELD_AWAIT:
-                mcplib_await_run(c, resp, Lc, coro_ref);
+                // called with await context on the stack.
+                rctx->first_queue = false; // HACK: ensure awaits are counted.
+                mcplib_await_run_rctx(rctx);
                 break;
             case MCP_YIELD_POOL:
                 // TODO (v2): c only used for cache alloc?
-                mcp_queue_io(c, resp, coro_ref, Lc);
+                // pool_call checks the argument already.
+                be = lua_touserdata(Lc, -1);
+                rq = lua_touserdata(Lc, -2);
+                // not using a pre-made res object from this yield type.
+                r = mcp_prep_resobj(Lc, rq, be, c->thread);
+                rctx->first_queue = false; // HACK: ensure poolreqs are counted.
+                mcp_queue_rctx_io(rctx, rq, be, r);
                 break;
-            case MCP_YIELD_LOCAL:
+            case MCP_YIELD_INTERNAL:
                 // stack should be: rq, res
-                res = mcplib_internal_run(Lc, c, resp, coro_ref);
-                if (res == 0) {
-                    // stack should still be: rq, res
-                    // TODO: turn this function into a for loop that re-runs on
-                    // certain status codes, to avoid recursive depth here.
-                    //
-                    // FIXME: this dance with the coroutine reference is
-                    // annoying. In this case we immediately resume, so no *io
-                    // was generated, so we won't do the above coro_ref swap, so
-                    // we'll try to take the coro_ref again and fail.
-                    // The ref is only actually used in proxy_await
-                    // It should instead be stashed on the top mc_resp object
-                    // (ideally removing c->proxy_coro_ref at the same time)
-                    // and unref'ed when the resp is cleaned up.
-                    lua_rawgeti(c->thread->L, LUA_REGISTRYINDEX, coro_ref);
-                    luaL_unref(c->thread->L, LUA_REGISTRYINDEX, coro_ref);
-                    proxy_run_coroutine(Lc, resp, NULL, c);
-                } else if (res > 0) {
-                    // internal run queued for extstore.
+                if (rctx->parent) {
+                    LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, "cannot run mcp.internal from a sub request");
+                    rctx->pending_reqs--;
+                    return LUA_ERRRUN;
                 } else {
-                    assert(res < 0);
-                    proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad request");
+                    res = mcplib_internal_run(rctx);
+                    if (res == 0) {
+                        // stack should still be: rq, res
+                        // TODO: turn this function into a for loop that re-runs on
+                        // certain status codes, to avoid recursive depth here.
+                        // or maybe... a goto? :P
+                        proxy_run_rcontext(rctx);
+                    } else if (res > 0) {
+                        // internal run queued for extstore.
+                    } else {
+                        assert(res < 0);
+                        proxy_out_errstring(resp, PROXY_SERVER_ERROR, "bad request");
+                    }
                 }
+                break;
+            case MCP_YIELD_WAITCOND:
+            case MCP_YIELD_WAITHANDLE:
+                // Even if we're in WAITHANDLE, we want to dispatch any queued
+                // requests, so we still need to iterate the full set of qslots.
+                _proxy_run_rcontext_queues(rctx);
                 break;
             default:
                 abort();
         }
 
     } else {
-        WSTAT_DECR(c->thread, proxy_req_active, 1);
+        // Log the error where it happens, then the parent will handle a
+        // result object normally.
         P_DEBUG("%s: Failed to run coroutine: %s\n", __func__, lua_tostring(Lc, -1));
         LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, lua_tostring(Lc, -1));
-        proxy_out_errstring(resp, PROXY_SERVER_ERROR, "lua failure");
+        if (!rctx->parent) {
+            WSTAT_DECR(c->thread, proxy_req_active, 1);
+            proxy_out_errstring(resp, PROXY_SERVER_ERROR, "lua failure");
+        }
+        rctx->pending_reqs--;
     }
 
-    return 0;
+    return cores;
 }
 
 // basically any data before the first key.
@@ -792,22 +890,22 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
     }
 
     struct proxy_hook *hook = &hooks[pr.command];
-    int hook_ref = hook->lua_ref;
+    struct proxy_hook_ref hook_ref = hook->ref;
     // if client came from a tagged listener, scan for a more specific hook.
     // TODO: (v2) avoiding a hash table lookup here, but maybe some other
     // datastructure would suffice. for 4-8 tags this is perfectly fast.
     if (c->tag && hook->tagged) {
         struct proxy_hook_tagged *pht = hook->tagged;
-        while (pht->lua_ref) {
+        while (pht->ref.lua_ref) {
             if (c->tag == pht->tag) {
-                hook_ref = pht->lua_ref;
+                hook_ref = pht->ref;
                 break;
             }
             pht++;
         }
     }
 
-    if (!hook_ref) {
+    if (!hook_ref.lua_ref) {
         // need to pass our command string into the internal handler.
         // to minimize the code change, this means allowing it to tokenize the
         // full command. The proxy's indirect parser should be built out to
@@ -821,7 +919,7 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
             command[cmdlen-1] = '\0';
         }
         // lets nread_proxy know we're in ascii mode.
-        c->proxy_coro_ref = 0;
+        c->proxy_rctx = NULL;
         process_command_ascii(c, command);
         return;
     }
@@ -928,21 +1026,33 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
         return;
     }
 
-    // start a coroutine.
-    // TODO (v2): This can pull a thread from a cache.
-    lua_newthread(L);
-    lua_State *Lc = lua_tothread(L, -1);
-    // leave the thread first on the stack, so we can reference it if needed.
-    // pull the lua hook function onto the stack.
-    lua_rawgeti(Lc, LUA_REGISTRYINDEX, hook_ref);
+    // hook is owned by a function generator.
+    mcp_rcontext_t *rctx = mcp_funcgen_start(L, hook_ref.ctx, &pr);
+    if (rctx == NULL) {
+        proxy_out_errstring(c->resp, PROXY_SERVER_ERROR, "lua start failure");
+        WSTAT_DECR(c->thread, proxy_req_active, 1);
+        if (pr.vlen != 0) {
+            c->sbytes = pr.vlen;
+            conn_set_state(c, conn_swallow);
+        }
+        return;
+    }
 
-    mcp_request_t *rq = mcp_new_request(Lc, &pr, command, cmdlen);
-    rq->ascii_multiget = multiget;
-    // NOTE: option 1) copy c->tag into rq->tag here.
-    // add req:listen_tag() to retrieve in top level route.
+    mcp_set_request(&pr, rctx->request, command, cmdlen);
+    rctx->request->ascii_multiget = multiget;
+    rctx->c = c;
+    rctx->pending_reqs++; // seed counter with the "main" request
+    // remember the top level mc_resp, because further requests on the
+    // same connection will replace c->resp.
+    rctx->resp = c->resp;
 
-    // TODO (v2): lift this to a post-processor?
-    if (rq->pr.vlen != 0) {
+    // for the very first call we need to place:
+    // - rctx->function_ref + rctx->request_ref
+    // I _think_ here is the right place to do that?
+    lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rctx->function_ref);
+    lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rctx->request_ref);
+
+    if (pr.vlen != 0) {
         c->item = NULL;
         // Need to add the used memory later due to needing an extra callback
         // handler on error during nread.
@@ -950,53 +1060,57 @@ static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool mu
 
         // relying on temporary malloc's not having fragmentation
         if (!oom) {
-            c->item = malloc(rq->pr.vlen);
+            c->item = malloc(pr.vlen);
         }
         if (c->item == NULL) {
+            // return the RCTX
+            rctx->pending_reqs--;
+            mcp_funcgen_return_rctx(rctx);
+            // normal cleanup
             lua_settop(L, 0);
             proxy_out_errstring(c->resp, PROXY_SERVER_ERROR, "out of memory");
             WSTAT_DECR(c->thread, proxy_req_active, 1);
-            c->sbytes = rq->pr.vlen;
+            c->sbytes = pr.vlen;
             conn_set_state(c, conn_swallow);
             return;
         }
         c->item_malloced = true;
         c->ritem = c->item;
-        c->rlbytes = rq->pr.vlen;
-        c->proxy_coro_ref = luaL_ref(L, LUA_REGISTRYINDEX); // pops coroutine.
+        c->rlbytes = pr.vlen;
+
+        // remember the request context for later.
+        c->proxy_rctx = rctx;
 
         conn_set_state(c, conn_nread);
         return;
-    } else {
-        conn_set_state(c, conn_new_cmd);
     }
 
-    proxy_run_coroutine(Lc, c->resp, NULL, c);
+    proxy_run_rcontext(rctx);
+    mcp_funcgen_return_rctx(rctx);
 
-    lua_settop(L, 0); // clear anything remaining on the main thread.
+    lua_settop(L, 0); // clear any junk from the main thread.
 }
 
-// analogue for storage_get_item(); add a deferred IO object to the current
-// connection's response object. stack enough information to write to the
-// server on the submit callback, and enough to resume the lua state on the
-// completion callback.
-static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
-    io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_PROXY);
-
-    // stack: request, hash selector. latter just to hold a reference.
-
-    mcp_request_t *rq = luaL_checkudata(Lc, -1, "mcp.request");
-    mcp_backend_t *be = rq->be;
-
-    // Then we push a response object, which we'll re-use later.
-    // reserve one uservalue for a lua-supplied response.
-    mcp_resp_t *r = lua_newuserdatauv(Lc, sizeof(mcp_resp_t), 1);
+mcp_resp_t *mcp_prep_bare_resobj(lua_State *L, LIBEVENT_THREAD *t) {
+    mcp_resp_t *r = lua_newuserdatauv(L, sizeof(mcp_resp_t), 0);
     // FIXME (v2): is this memset still necessary? I was using it for
     // debugging.
     memset(r, 0, sizeof(mcp_resp_t));
+    r->thread = t;
+    assert(r->thread != NULL);
+    gettimeofday(&r->start, NULL);
+
+    luaL_getmetatable(L, "mcp.response");
+    lua_setmetatable(L, -2);
+
+    return r;
+}
+
+void mcp_set_resobj(mcp_resp_t *r, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t) {
+    memset(r, 0, sizeof(mcp_resp_t));
     r->buf = NULL;
     r->blen = 0;
-    r->thread = c->thread;
+    r->thread = t;
     assert(r->thread != NULL);
     gettimeofday(&r->start, NULL);
     // Set noreply mode.
@@ -1023,14 +1137,35 @@ static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
 
     r->cmd = rq->pr.command;
 
-    luaL_getmetatable(Lc, "mcp.response");
-    lua_setmetatable(Lc, -2);
+    strncpy(r->be_name, be->name, MAX_NAMELEN+1);
+    strncpy(r->be_port, be->port, MAX_PORTLEN+1);
 
+}
+
+mcp_resp_t *mcp_prep_resobj(lua_State *L, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t) {
+    mcp_resp_t *r = lua_newuserdatauv(L, sizeof(mcp_resp_t), 0);
+    mcp_set_resobj(r, rq, be, t);
+
+    luaL_getmetatable(L, "mcp.response");
+    lua_setmetatable(L, -2);
+
+    return r;
+}
+
+// Used for any cases where we're queueing requests to the IO subsystem.
+// NOTE: it's not currently possible to limit the memory used by the IO
+// object cache. So this check is redundant, and any callers may proceed
+// as though it is successful.
+io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, mcp_backend_t *be, mcp_resp_t *r) {
+    conn *c = rctx->c;
+    io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_PROXY);
     io_pending_proxy_t *p = do_cache_alloc(c->thread->io_cache);
     if (p == NULL) {
         WSTAT_INCR(c->thread, proxy_conn_oom, 1);
-        proxy_lua_error(Lc, "out of memory allocating from IO cache");
-        return;
+        proxy_lua_error(rctx->Lc, "out of memory allocating from IO cache");
+        // NOTE: the error call above jumps to an error handler, so this does
+        // not actually return.
+        return NULL;
     }
 
     // this is a re-cast structure, so assert that we never outsize it.
@@ -1040,36 +1175,58 @@ static void mcp_queue_io(conn *c, mc_resp *resp, int coro_ref, lua_State *Lc) {
     p->io_queue_type = IO_QUEUE_PROXY;
     p->thread = c->thread;
     p->c = c;
-    p->resp = resp;
     p->client_resp = r;
     p->flushed = false;
-    p->ascii_multiget = rq->ascii_multiget;
-    p->return_cb = proxy_return_cb;
-    p->finalize_cb = proxy_finalize_cb;
-    resp->io_pending = (io_pending_t *)p;
+    p->return_cb = proxy_return_rctx_cb;
+    p->finalize_cb = proxy_finalize_rctx_cb;
 
-    // top of the main thread should be our coroutine.
-    // lets grab a reference to it and pop so it doesn't get gc'ed.
-    p->coro_ref = coro_ref;
+    // pass along the request context for resumption.
+    p->rctx = rctx;
 
-    // we'll drop the pointer to the coro on here to save some CPU
-    // on re-fetching it later. The pointer shouldn't change.
-    p->coro = Lc;
+    if (rq) {
+        p->ascii_multiget = rq->ascii_multiget;
+        // The direct backend object. Lc is holding the reference in the stack
+        p->backend = be;
 
-    // The direct backend object. Lc is holding the reference in the stack
-    p->backend = be;
-    // See #887 for notes.
-    // TODO (v2): hopefully this can be optimized out.
-    strncpy(r->be_name, be->name, MAX_NAMELEN+1);
-    strncpy(r->be_port, be->port, MAX_PORTLEN+1);
+        mcp_request_attach(rq, p);
+    }
 
-    mcp_request_attach(Lc, rq, p);
+    // HACK
+    // find the parent rctx
+    while (rctx->parent) {
+        rctx = rctx->parent;
+    }
+    // Hack to enforce the first iop increments client IO queue counter.
+    if (!rctx->first_queue) {
+        rctx->first_queue = true;
+        p->qcount_incr = true;
+    }
+    // END HACK
 
     // link into the batch chain.
     p->next = q->stack_ctx;
     q->stack_ctx = p;
+    P_DEBUG("%s: queued\n", __func__);
 
-    return;
+    return p;
+}
+
+// DO NOT call this method frequently! globally locked!
+void mcp_sharedvm_delta(proxy_ctx_t *ctx, int tidx, const char *name, int delta) {
+    lua_State *L = ctx->proxy_sharedvm;
+    pthread_mutex_lock(&ctx->sharedvm_lock);
+
+    if (lua_getfield(L, tidx, name) == LUA_TNIL) {
+        lua_pop(L, 1);
+        lua_pushinteger(L, delta);
+        lua_setfield(L, tidx, name);
+    } else {
+        lua_pushinteger(L, delta);
+        lua_arith(L, LUA_OPADD);
+        lua_setfield(L, tidx, name);
+    }
+
+    pthread_mutex_unlock(&ctx->sharedvm_lock);
 }
 
 static void *mcp_profile_alloc(void *ud, void *ptr, size_t osize,

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -3,6 +3,7 @@
 
 void proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
 void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
+void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c);
 
 /* proxy mode handlers */
 int try_read_command_proxy(conn *c);
@@ -19,8 +20,6 @@ void proxy_worker_reload(void *arg, LIBEVENT_THREAD *thr);
 
 void proxy_submit_cb(io_queue_t *q);
 void proxy_complete_cb(io_queue_t *q);
-void proxy_return_cb(io_pending_t *pending);
-void proxy_finalize_cb(io_pending_t *pending);
 
 /* lua */
 int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state);

--- a/proto_text.c
+++ b/proto_text.c
@@ -804,6 +804,8 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
 #ifdef PROXY
     } else if (strcmp(subcommand, "proxy") == 0) {
         process_proxy_stats(settings.proxy_ctx, &append_stats, c);
+    } else if (strcmp(subcommand, "proxyfuncs") == 0) {
+        process_proxy_funcstats(settings.proxy_ctx, &append_stats, c);
 #endif
     } else {
         /* getting here means that the subcommand is either engine specific or

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -159,8 +159,8 @@ static int proxy_storage_get(LIBEVENT_THREAD *t, item *it, mc_resp *resp,
     io->io_type = IO_PENDING_TYPE_EXTSTORE; // proxy specific sub-type.
     io->gettype = type;
     io->thread = t;
-    io->return_cb = proxy_return_cb;
-    io->finalize_cb = proxy_finalize_cb;
+    io->return_cb = proxy_return_rctx_cb;
+    io->finalize_cb = proxy_finalize_rctx_cb;
     obj_io *eio = &io->eio;
 
     eio->buf = malloc(ntotal);
@@ -1594,18 +1594,19 @@ int mcplib_internal(lua_State *L) {
     luaL_getmetatable(L, "mcp.response");
     lua_setmetatable(L, -2);
 
-    lua_pushinteger(L, MCP_YIELD_LOCAL);
+    lua_pushinteger(L, MCP_YIELD_INTERNAL);
     return lua_yield(L, 2);
 }
 
 // we're pretending to be p_c_ascii(), but reusing our already tokenized code.
 // the text parser should eventually move to the new tokenizer and we can
 // merge all of this code together.
-int mcplib_internal_run(lua_State *L, conn *c, mc_resp *top_resp, int coro_ref) {
+int mcplib_internal_run(mcp_rcontext_t *rctx) {
+    lua_State *L = rctx->Lc;
     mcp_request_t *rq = luaL_checkudata(L, 1, "mcp.request");
     mcp_resp_t *r = luaL_checkudata(L, 2, "mcp.response");
-    mc_resp *resp = resp_start_unlinked(c);
-    LIBEVENT_THREAD *t = c->thread;
+    mc_resp *resp = resp_start_unlinked(rctx->c);
+    LIBEVENT_THREAD *t = rctx->c->thread;
     mcp_parser_t *pr = &rq->pr;
     if (resp == NULL) {
         return -1;
@@ -1695,37 +1696,39 @@ int mcplib_internal_run(lua_State *L, conn *c, mc_resp *top_resp, int coro_ref) 
 
     // TODO: r-> will need status/code/mode copied from resp.
     r->cresp = resp;
-    r->thread = c->thread;
+    r->thread = t;
     r->cmd = rq->pr.command;
     // Always return OK from here as this is signalling an internal error.
     r->status = MCMC_OK;
+
+    // resp object is associated with the
+    // response object, which is about a
+    // kilobyte.
+    lua_gc(rctx->Lc, LUA_GCSTEP, 1);
 
     if (resp->io_pending) {
         // TODO (v2): here we move the IO from the temporary resp to the top
         // resp, but this feels kludgy so I'm leaving an explicit note to find
         // a better way to do this.
-        top_resp->io_pending = resp->io_pending;
+        rctx->resp->io_pending = resp->io_pending;
         resp->io_pending = NULL;
 
         // Add io object to extstore submission queue.
-        io_queue_t *q = conn_io_queue_get(c, IO_QUEUE_EXTSTORE);
-        io_pending_proxy_t *io = (io_pending_proxy_t *)top_resp->io_pending;
+        io_queue_t *q = conn_io_queue_get(rctx->c, IO_QUEUE_EXTSTORE);
+        io_pending_proxy_t *io = (io_pending_proxy_t *)rctx->resp->io_pending;
 
         io->eio.next = q->stack_ctx;
         q->stack_ctx = &io->eio;
         assert(q->count >= 0);
         q->count++;
 
-        io->coro_ref = coro_ref;
-        io->coro = L;
-        io->c  = c;
+        io->rctx = rctx;
+        io->c = rctx->c;
         io->ascii_multiget = rq->ascii_multiget;
-        // we need to associate the top level mc_resp here so the run routine
-        // can fill it in later.
-        io->resp = top_resp;
         // mark the buffer into the mcp_resp for freeing later.
         r->buf = io->eio.buf;
         return 1;
     }
+
     return 0;
 }

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -1,0 +1,1610 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+
+static mcp_funcgen_t *mcp_funcgen_route(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_t *pr);
+static int mcp_funcgen_router_cleanup(lua_State *L, mcp_funcgen_t *fgen);
+static void mcp_funcgen_cleanup(lua_State *L, mcp_funcgen_t *fgen);
+static void proxy_return_rqu_cb(io_pending_t *pending);
+
+// If we're GC'ed but not closed, it means it was created but never
+// attached to a function, so ensure everything is closed properly.
+int mcplib_funcgen_gc(lua_State *L) {
+    mcp_funcgen_t *fgen = luaL_checkudata(L, -1, "mcp.funcgen");
+    if (fgen->closed) {
+        return 0;
+    }
+    assert(fgen->self_ref == 0);
+
+    mcp_funcgen_cleanup(L, fgen);
+    return 0;
+}
+
+// For describing functions which generate functions which can execute
+// requests.
+// These "generator functions" handle pre-allocating and creating a memory
+// heirarchy, allowing dynamic runtimes at high speed.
+
+// TODO: switch from an array to a STAILQ so we can avoid the memory
+// management and error handling.
+// Realistically it's impossible for these to error so we're safe for now.
+static void _mcplib_funcgen_cache(mcp_funcgen_t *fgen, mcp_rcontext_t *rctx) {
+    if (fgen->free + 1 >= fgen->free_max) {
+        fgen->free_max *= 2;
+        fgen->list = realloc(fgen->list, fgen->free_max * sizeof(mcp_rcontext_t *));
+    }
+    fgen->list[fgen->free] = rctx;
+    fgen->free++;
+
+    // we're closed and every outstanding request slot has been
+    // returned.
+    if (fgen->closed && fgen->free == fgen->total) {
+        mcp_funcgen_cleanup(fgen->thread->L, fgen);
+    }
+}
+
+// call with stack: mcp.funcgen -2, function -1
+static int _mcplib_funcgen_gencall(lua_State *L) {
+    mcp_funcgen_t *fgen = luaL_checkudata(L, -2, "mcp.funcgen");
+    int fgen_idx = lua_absindex(L, -2);
+    // create the ctx object.
+    size_t rctx_len = sizeof(mcp_rcontext_t) + sizeof(struct mcp_rqueue_s) * fgen->max_queues;
+    mcp_rcontext_t *rc = lua_newuserdatauv(L, rctx_len, 0);
+    memset(rc, 0, rctx_len);
+
+    luaL_getmetatable(L, "mcp.rcontext");
+    lua_setmetatable(L, -2);
+    // allow the rctx to reference the function generator.
+    rc->fgen = fgen;
+
+    // initialize the queue slots based on the fgen parent
+    for (int x = 0; x < fgen->max_queues; x++) {
+        struct mcp_rqueue_s *frqu = &fgen->queue_list[x];
+        struct mcp_rqueue_s *rqu = &rc->qslots[x];
+        rqu->obj_type = frqu->obj_type;
+        if (frqu->obj_type == RQUEUE_TYPE_POOL) {
+            rqu->obj_ref = 0;
+            rqu->obj = frqu->obj;
+            mcp_resp_t *r = mcp_prep_bare_resobj(L, fgen->thread);
+            rqu->res_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+            rqu->res_obj = r;
+        } else if (frqu->obj_type == RQUEUE_TYPE_FGEN) {
+            // owner funcgen already holds the subfgen reference, so here we're just
+            // grabbing a subrctx to pin into the slot.
+            mcp_funcgen_t *fg = frqu->obj;
+            mcp_rcontext_t *subrctx = mcp_funcgen_get_rctx(L, fg->self_ref, fg);
+            if (subrctx == NULL) {
+                proxy_lua_error(L, "failed to generate request slot during queue_assign()");
+            }
+
+            // if this rctx ever had a request object assigned to it, we can get
+            // rid of it. we're pinning the subrctx in here and don't want
+            // to waste memory.
+            if (subrctx->request_ref) {
+                luaL_unref(L, LUA_REGISTRYINDEX, subrctx->request_ref);
+                subrctx->request_ref = 0;
+                subrctx->request = NULL;
+            }
+
+            // link the new rctx into this chain; we'll hold onto it until the
+            // parent de-allocates.
+            subrctx->parent = rc;
+            subrctx->parent_handle = x;
+            rqu->obj = subrctx;
+        }
+    }
+
+    // copy the rcontext reference
+    lua_pushvalue(L, -1);
+
+    // issue a rotation so one rcontext is now below genfunc, and one rcontext
+    // is on the top.
+    // right shift: gf, rc1, rc2 -> rc2, gf, rc1
+    lua_rotate(L, -3, 1);
+
+    // current stack should be func, mcp.rcontext.
+    int call_argnum = 1;
+    // stack will be func, rctx, arg if there is an arg.
+    if (fgen->argument_ref) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->argument_ref);
+        call_argnum++;
+    }
+
+    // can throw an error upstream.
+    lua_call(L, call_argnum, 1);
+
+    // we should have a top level function as a result.
+    if (!lua_isfunction(L, -1)) {
+        proxy_lua_error(L, "function generator didn't return a function");
+        return 0;
+    }
+    // can't fail past this point.
+
+    // pop the returned function.
+    rc->function_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    // link the rcontext into the function generator.
+    fgen->total++;
+
+    lua_getiuservalue(L, fgen_idx, 1); // get the reference table.
+    // rc, t -> t, rc
+    lua_rotate(L, -2, 1);
+    lua_rawseti(L, -2, fgen->total); // pop rcontext
+    lua_pop(L, 1); // pop ref table.
+
+    _mcplib_funcgen_cache(fgen, rc);
+
+    // associate a coroutine thread with this context.
+    rc->Lc = lua_newthread(L);
+    assert(rc->Lc);
+    rc->coroutine_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    // increment the slot counter
+    const char *name = NULL;
+    if (fgen->name_ref) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->name_ref);
+        name = lua_tostring(L, -1);
+        // popping early: string stays referenced in name_ref and no other lua
+        // code executing on this VM, so it's safe to reference immediately.
+        lua_pop(L, 1);
+    } else {
+        name = "anonymous";
+    }
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+    mcp_sharedvm_delta(t->proxy_ctx, SHAREDVM_FGENSLOT_IDX, name, 1);
+
+    // return the fgen.
+    // FIXME: just return 0? need to adjust caller to not mis-ref the
+    // generator function.
+    return 1;
+}
+
+static void _mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
+    mcp_funcgen_t *fgen = rctx->fgen;
+    assert(rctx->pending_reqs == 0);
+    int res = lua_resetthread(rctx->Lc);
+    if (res != LUA_OK) {
+        // TODO: I was under the impression it was possible to reuse a
+        // coroutine from an error state, but it seems like this only works if
+        // the routine landed in LUA_YIELD or LUA_OK
+        // Leaving a note here to triple check this or if my memory was wrong.
+        // Instead for now we throw away the coroutine if it was involved in
+        // an error. Realistically this shouldn't be normal so it might not
+        // matter anyway.
+        lua_State *L = fgen->thread->L;
+        luaL_unref(L, LUA_REGISTRYINDEX, rctx->coroutine_ref);
+        rctx->Lc = lua_newthread(L);
+        assert(rctx->Lc);
+        rctx->coroutine_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    } else {
+        lua_settop(rctx->Lc, 0);
+    }
+    rctx->wait_mode = QWAIT_IDLE;
+    rctx->resp = NULL;
+    rctx->first_queue = false; // HACK
+    if (rctx->request) {
+        mcp_request_cleanup(fgen->thread, rctx->request);
+    }
+
+    // reset each rqu.
+    for (int x = 0; x < fgen->max_queues; x++) {
+        struct mcp_rqueue_s *rqu = &rctx->qslots[x];
+        if (rqu->res_ref) {
+            if (rqu->res_obj) {
+                // using a persistent object.
+                mcp_response_cleanup(fgen->thread, rqu->res_obj);
+            } else {
+                // temporary error object
+                luaL_unref(rctx->Lc, LUA_REGISTRYINDEX, rqu->res_ref);
+                rqu->res_ref = 0;
+            }
+        }
+        if (rqu->req_ref) {
+            luaL_unref(rctx->Lc, LUA_REGISTRYINDEX, rqu->req_ref);
+            rqu->req_ref = 0;
+        }
+        assert(rqu->state != RQUEUE_ACTIVE);
+        rqu->state = RQUEUE_IDLE;
+        rqu->flags = 0;
+        rqu->rq = NULL;
+        if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+            _mcp_funcgen_return_rctx(rqu->obj);
+        }
+    }
+}
+
+// TODO: check rctx->awaiting before returning?
+// TODO: separate the "cleanup" portion from the "Return to cache" portion, so
+// we can call that directly for subrctx's
+void mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
+    mcp_funcgen_t *fgen = rctx->fgen;
+    if (rctx->pending_reqs != 0) {
+        // not ready to return to cache yet.
+        return;
+    }
+    if (rctx->parent) {
+        // Important: we need to hold the parent request reference until this
+        // subrctx is fully depleted of outstanding requests itself.
+        rctx->parent->pending_reqs--;
+        assert(rctx->parent->pending_reqs > -1);
+        if (rctx->parent->pending_reqs == 0) {
+            mcp_funcgen_return_rctx(rctx->parent);
+        }
+        return;
+    }
+    _mcp_funcgen_return_rctx(rctx);
+    _mcplib_funcgen_cache(fgen, rctx);
+}
+
+mcp_rcontext_t *mcp_funcgen_get_rctx(lua_State *L, int fgen_ref, mcp_funcgen_t *fgen) {
+    mcp_rcontext_t *rctx = NULL;
+    // nothing left in slot cache, generate a new function.
+    if (fgen->free == 0) {
+        // TODO (perf): pre-create this c closure somewhere hidden.
+        lua_pushcclosure(L, _mcplib_funcgen_gencall, 0);
+        // pull in the funcgen object
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen_ref);
+        // then generator function
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->generator_ref);
+        // then generate a new function slot.
+        int res = lua_pcall(L, 2, 1, 0);
+        if (res != LUA_OK) {
+            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, lua_tostring(L, -1));
+            lua_settop(L, 0);
+            return NULL;
+        }
+        lua_pop(L, 1); // drop the extra funcgen
+    } else {
+        P_DEBUG("%s: serving from cache\n", __func__);
+    }
+
+    rctx = fgen->list[fgen->free-1];
+    fgen->free--;
+
+    // on non-error, return the response object upward.
+    return rctx;
+}
+
+mcp_rcontext_t *mcp_funcgen_start(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_t *pr) {
+    if (fgen->router.type != FGEN_ROUTER_NONE) {
+        fgen = mcp_funcgen_route(L, fgen, pr);
+        if (fgen == NULL) {
+            return NULL;
+        }
+    }
+    // fgen->self_ref must be valid because we cannot start a function that
+    // hasn't been referenced anywhere.
+    mcp_rcontext_t *rctx = mcp_funcgen_get_rctx(L, fgen->self_ref, fgen);
+
+    if (rctx == NULL) {
+        return NULL;
+    }
+
+    // only top level rctx's can have a request object assigned to them.
+    // so we create them late here, in the start function.
+    // Note that we can _technically_ fail with an OOM here, but we've not set
+    // up lua in a way that OOM's are possible.
+    if (rctx->request_ref == 0) {
+        mcp_request_t *rq = lua_newuserdatauv(L, sizeof(mcp_request_t) + MCP_REQUEST_MAXLEN + KEY_MAX_LENGTH, 0);
+        memset(rq, 0, sizeof(mcp_request_t));
+        luaL_getmetatable(L, "mcp.request");
+        lua_setmetatable(L, -2);
+
+        rctx->request_ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop the request
+        rctx->request = rq;
+    }
+
+    // TODO: could probably move a few more lines from proto_proxy into here,
+    // but that's splitting hairs.
+
+    return rctx;
+}
+
+// calling either with self_ref set, or with fgen in stack -1 (ie; from GC
+// function without ever being attached to anything)
+static void mcp_funcgen_cleanup(lua_State *L, mcp_funcgen_t *fgen) {
+    lua_checkstack(L, 5); // paranoia. this can recurse from a router.
+    // pull the fgen into the stack.
+    if (fgen->self_ref) {
+        // pull self onto the stack and hold until the end of the func.
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->self_ref);
+        // remove the C reference to the fgen
+        luaL_unref(L, LUA_REGISTRYINDEX, fgen->self_ref);
+        fgen->self_ref = 0;
+    } else {
+        // we've already cleaned up, probably redundant call from _gc()
+        return;
+    }
+
+    if (fgen->router.type != FGEN_ROUTER_NONE) {
+        // we're actually a "router", send this out for cleanup.
+        mcp_funcgen_router_cleanup(L, fgen);
+    }
+
+    // decrement the slot counter
+    const char *name = NULL;
+    if (fgen->name_ref) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->name_ref);
+        name = lua_tostring(L, -1);
+    } else {
+        name = "anonymous";
+    }
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+    mcp_sharedvm_delta(t->proxy_ctx, SHAREDVM_FGEN_IDX, name, -1);
+
+    // Walk every request context and issue cleanup.
+    for (int x = 0; x < fgen->total; x++) {
+        mcp_rcontext_t *rctx = fgen->list[x];
+
+        luaL_unref(L, LUA_REGISTRYINDEX, rctx->coroutine_ref);
+        luaL_unref(L, LUA_REGISTRYINDEX, rctx->function_ref);
+        if (rctx->request_ref) {
+            luaL_unref(L, LUA_REGISTRYINDEX, rctx->request_ref);
+        }
+        assert(rctx->pending_reqs == 0);
+
+        // cleanup of request queue entries. recurse funcgen cleanup.
+        for (int x = 0; x < fgen->max_queues; x++) {
+            struct mcp_rqueue_s *rqu = &rctx->qslots[x];
+            if (rqu->obj_type == RQUEUE_TYPE_POOL) {
+                // nothing to do.
+            } else if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+                // don't need to recurse, just return the subrctx.
+                mcp_rcontext_t *subrctx = rqu->obj;
+                _mcplib_funcgen_cache(subrctx->fgen, subrctx);
+            } else if (rqu->obj_type != RQUEUE_TYPE_NONE) {
+                assert(1 == 0);
+            }
+            if (rqu->cb_ref) {
+                luaL_unref(L, LUA_REGISTRYINDEX, rqu->cb_ref);
+                rqu->cb_ref = 0;
+            }
+        }
+    }
+    // decrement the slot tracker. apply full delta at once for efficiency.
+    mcp_sharedvm_delta(t->proxy_ctx, SHAREDVM_FGENSLOT_IDX, name, -fgen->total);
+
+    if (fgen->queue_list) {
+        for (int x = 0; x < fgen->max_queues; x++) {
+            struct mcp_rqueue_s *rqu = &fgen->queue_list[x];
+            if (rqu->obj_type == RQUEUE_TYPE_POOL) {
+                // just the obj_ref
+                luaL_unref(L, LUA_REGISTRYINDEX, rqu->obj_ref);
+            } else if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+                // don't need to recurse, just deref.
+                mcp_rcontext_t *subrctx = rqu->obj;
+                mcp_funcgen_dereference(L, subrctx->fgen);
+            } else if (rqu->obj_type != RQUEUE_TYPE_NONE) {
+                assert(1 == 0);
+            }
+        }
+        free(fgen->queue_list);
+    }
+
+    if (fgen->name_ref) {
+        lua_pop(L, 1); // pop the name string.
+        luaL_unref(L, LUA_REGISTRYINDEX, fgen->name_ref);
+    }
+
+    // Finally, get the rctx reference table and nil each reference to allow
+    // garbage collection to happen sooner on the rctx's
+    lua_getiuservalue(L, -1, 1);
+    for (int x = 0; x < fgen->total; x++) {
+        lua_pushnil(L);
+        lua_rawseti(L, -2, x+1);
+    }
+    // drop the reference table and the funcgen reference.
+    lua_pop(L, 2);
+}
+
+// Must be called with the function generator at on top of stack
+// Pops the value from the stack.
+void mcp_funcgen_reference(lua_State *L) {
+    mcp_funcgen_t *fgen = luaL_checkudata(L, -1, "mcp.funcgen");
+    if (fgen->self_ref) {
+        fgen->refcount++;
+        lua_pop(L, 1); // ensure we drop the extra value.
+    } else {
+        fgen->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        fgen->refcount = 1;
+    }
+    P_DEBUG("%s: funcgen referenced: %d\n", __func__, fgen->refcount);
+}
+
+void mcp_funcgen_dereference(lua_State *L, mcp_funcgen_t *fgen) {
+    assert(fgen->refcount > 0);
+    fgen->refcount--;
+    P_DEBUG("%s: funcgen dereferenced: %d\n", __func__, fgen->refcount);
+    if (fgen->refcount == 0) {
+        fgen->closed = true;
+
+        P_DEBUG("%s: funcgen cleaning up\n", __func__);
+        if (fgen->free == fgen->total) {
+            mcp_funcgen_cleanup(L, fgen);
+        }
+    }
+}
+
+// All we need to do here is copy the function reference we've stashed into
+// the C closure's upvalue and return it.
+static int _mcplib_funcgenbare_generator(lua_State *L) {
+    lua_pushvalue(L, lua_upvalueindex(1));
+    return 1;
+}
+
+// helper function to create a function generator with a "default" function.
+// the function passed in here is a standard 'function(r) etc end' prototype,
+// which we want to always return instead of calling a real generator
+// function.
+int mcplib_funcgenbare_new(lua_State *L) {
+    if (!lua_isfunction(L, -1)) {
+        proxy_lua_error(L, "Must pass a function to mcp.funcgenbare_new");
+        return 0;
+    }
+
+    // Pops the function into the upvalue of this C closure function.
+    lua_pushcclosure(L, _mcplib_funcgenbare_generator, 1);
+    // FIXME: not urgent, but this function chain isn't stack balanced, and its caller has
+    // to drop an extra reference.
+    // Need to re-audit and decide if we still need this pushvalue here or if
+    // we can drop the pop from the caller and leave this function balanced.
+    lua_pushvalue(L, -1);
+    int gen_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    // Pass our fakeish generator function down the line.
+    mcplib_funcgen_new(L);
+
+    mcp_funcgen_t *fgen = lua_touserdata(L, -1);
+    const char *name = "anonymous";
+    mcp_sharedvm_delta(fgen->thread->proxy_ctx, SHAREDVM_FGEN_IDX, name, 1);
+
+    fgen->generator_ref = gen_ref;
+    fgen->ready = true;
+    return 1;
+}
+
+#define FGEN_DEFAULT_FREELIST_SIZE 8
+int mcplib_funcgen_new(lua_State *L) {
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+
+    mcp_funcgen_t *fgen = lua_newuserdatauv(L, sizeof(mcp_funcgen_t), 2);
+    memset(fgen, 0, sizeof(mcp_funcgen_t));
+    fgen->thread = t;
+    fgen->free_max = FGEN_DEFAULT_FREELIST_SIZE;
+    fgen->list = calloc(fgen->free_max, sizeof(mcp_rcontext_t *));
+
+    luaL_getmetatable(L, "mcp.funcgen");
+    lua_setmetatable(L, -2);
+
+    // the table we will use to hold references to rctx's
+    lua_createtable(L, 8, 0);
+    // set our table into the uservalue 1 of fgen (idx -2)
+    // pops the table.
+    lua_setiuservalue(L, -2, 1);
+
+    return 1;
+}
+
+int mcplib_funcgen_new_handle(lua_State *L) {
+    mcp_funcgen_t *fgen = lua_touserdata(L, 1);
+    mcp_pool_proxy_t *pp = NULL;
+    mcp_funcgen_t *fg = NULL;
+
+    if (fgen->ready) {
+        proxy_lua_error(L, "cannot modify function generator after calling ready");
+        return 0;
+    }
+
+    if ((pp = luaL_testudata(L, 2, "mcp.pool_proxy")) != NULL) {
+        // good.
+    } else if ((fg = luaL_testudata(L, 2, "mcp.funcgen")) != NULL) {
+        if (fg->router.type != FGEN_ROUTER_NONE) {
+            proxy_lua_error(L, "cannot assign a router to a handle in new_handle");
+            return 0;
+        }
+        if (fg->closed) {
+            proxy_lua_error(L, "cannot use a replaced function in new_handle");
+            return 0;
+        }
+    } else {
+        proxy_lua_error(L, "invalid argument to new_handle");
+        return 0;
+    }
+
+    fgen->max_queues++;
+    if (fgen->queue_list == NULL) {
+        fgen->queue_list = malloc(sizeof(struct mcp_rqueue_s));
+    } else {
+        fgen->queue_list = realloc(fgen->queue_list, fgen->max_queues * sizeof(struct mcp_rqueue_s));
+    }
+    if (fgen->queue_list == NULL) {
+        proxy_lua_error(L, "failed to realloc queue list during new_handle()");
+        return 0;
+    }
+
+    struct mcp_rqueue_s *rqu = &fgen->queue_list[fgen->max_queues-1];
+    memset(rqu, 0, sizeof(*rqu));
+
+    if (pp) {
+        // pops pp from the stack
+        rqu->obj_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        rqu->obj_type = RQUEUE_TYPE_POOL;
+        rqu->obj = pp;
+    } else {
+        // pops the fgen from the stack.
+        mcp_funcgen_reference(L);
+        rqu->obj_type = RQUEUE_TYPE_FGEN;
+        rqu->obj = fg;
+    }
+
+    lua_pushinteger(L, fgen->max_queues-1);
+    return 1;
+}
+
+int mcplib_funcgen_ready(lua_State *L) {
+    mcp_funcgen_t *fgen = lua_touserdata(L, 1);
+    luaL_checktype(L, 2, LUA_TTABLE);
+
+    if (fgen->ready) {
+        proxy_lua_error(L, "cannot modify function generator after calling ready");
+        return 0;
+    }
+
+    if (lua_getfield(L, 2, "f") != LUA_TFUNCTION) {
+        proxy_lua_error(L, "Must specify generator function ('f') to fgen:ready");
+        return 0;
+    }
+    fgen->generator_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    if (lua_getfield(L, 2, "a") != LUA_TNIL) {
+        fgen->argument_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    } else {
+        lua_pop(L, 1);
+    }
+
+    if (lua_getfield(L, 2, "n") == LUA_TSTRING) {
+        fgen->name_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    } else {
+        lua_pop(L, 1);
+    }
+
+    // now we test the generator function and create the first slot.
+    lua_pushvalue(L, 1); // copy the funcgen to pass into gencall
+    lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->generator_ref); // for gencall
+    _mcplib_funcgen_gencall(L);
+    lua_pop(L, 1); // drop extra funcgen ref.
+
+    // add us to the global state
+    const char *name = NULL;
+    if (fgen->name_ref) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, fgen->name_ref);
+        name = lua_tostring(L, -1);
+        lua_pop(L, 1);
+    } else {
+        name = "anonymous";
+    }
+    mcp_sharedvm_delta(fgen->thread->proxy_ctx, SHAREDVM_FGEN_IDX, name, 1);
+
+    fgen->ready = true;
+    return 1;
+}
+
+// Handlers for request contexts
+
+int mcplib_rcontext_handle_set_cb(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    luaL_checktype(L, 2, LUA_TNUMBER);
+    luaL_checktype(L, 3, LUA_TFUNCTION);
+
+    int handle = lua_tointeger(L, 2);
+    if (handle < 0 || handle >= rctx->fgen->max_queues) {
+        proxy_lua_error(L, "invalid handle passed to queue_set_cb");
+        return 0;
+    }
+
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    if (rqu->cb_ref) {
+        luaL_unref(L, LUA_REGISTRYINDEX, rqu->cb_ref);
+    }
+    rqu->cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    return 0;
+}
+
+// call with request object on top of stack.
+// pops the request object
+static void _mcplib_rcontext_queue(lua_State *L, mcp_rcontext_t *rctx, mcp_request_t *rq, int handle) {
+    if (handle < 0 || handle >= rctx->fgen->max_queues) {
+        proxy_lua_error(L, "invalid handle passed to queue");
+        return;
+    }
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+
+    if (rqu->state != RQUEUE_IDLE) {
+        lua_pop(L, 1);
+        return;
+    }
+
+    // If we're queueing to an fgen, arm the coroutine while we have the
+    // objects handy. Else this requires roundtripping a luaL_ref/luaL_unref
+    // later.
+    if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+        mcp_rcontext_t *subrctx = rqu->obj;
+        lua_pushvalue(L, 2); // duplicate the request obj
+        lua_rawgeti(subrctx->Lc, LUA_REGISTRYINDEX, subrctx->function_ref);
+        lua_xmove(L, subrctx->Lc, 1); // move the requet object.
+        subrctx->pending_reqs++;
+    }
+
+    // hold the request reference.
+    rqu->req_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    rqu->state = RQUEUE_QUEUED;
+    rqu->rq = rq;
+}
+
+// first arg is rcontext
+// then a request object
+// then either a handle (integer) or array style table of handles
+int mcplib_rcontext_enqueue(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    mcp_request_t *rq = luaL_checkudata(L, 2, "mcp.request");
+
+    if (rctx->wait_mode != QWAIT_IDLE) {
+        proxy_lua_error(L, "enqueue: cannot enqueue new requests while in a wait");
+        return 0;
+    }
+
+    if (!rq->pr.keytoken) {
+        proxy_lua_error(L, "cannot queue requests without a key");
+        return 0;
+    }
+
+    int type = lua_type(L, 3);
+    if (type == LUA_TNUMBER) {
+        int handle = lua_tointeger(L, 3);
+
+        lua_pushvalue(L, 2);
+        _mcplib_rcontext_queue(L, rctx, rq, handle);
+    } else if (type == LUA_TTABLE) {
+        unsigned int len = lua_rawlen(L, 3);
+        for (int x = 0; x < len; x++) {
+            type = lua_rawgeti(L, 3, x+1);
+            if (type != LUA_TNUMBER) {
+                proxy_lua_error(L, "invalid handle passed to queue via array table");
+                return 0;
+            }
+
+            int handle = lua_tointeger(L, 4);
+            lua_pop(L, 1);
+
+            lua_pushvalue(L, 2);
+            _mcplib_rcontext_queue(L, rctx, rq, handle);
+        }
+    } else {
+        proxy_lua_error(L, "must pass a handle or a table to queue");
+        return 0;
+    }
+
+    return 0;
+}
+
+// TODO: pre-generate a result object into sub-rctx's that we can pull up for
+// this, instead of allocating outside of a protected call.
+static void _mcp_resume_rctx_process_error(mcp_rcontext_t *rctx, struct mcp_rqueue_s *rqu) {
+    // we have an error. need to mark the error into the parent rqu
+    rqu->flags |= RQUEUE_R_ERROR|RQUEUE_R_ANY;
+    mcp_resp_t *r = mcp_prep_bare_resobj(rctx->Lc, rctx->fgen->thread);
+    r->status = MCMC_ERR;
+    r->resp.code = MCMC_CODE_SERVER_ERROR;
+    assert(rqu->res_ref == 0);
+    rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+    mcp_process_rqueue_return(rctx->parent, rctx->parent_handle, r);
+    if (rctx->parent->wait_count) {
+        mcp_process_rctx_wait(rctx->parent, rctx->parent_handle);
+    }
+}
+
+static void _mcp_start_rctx_process_error(mcp_rcontext_t *rctx, struct mcp_rqueue_s *rqu) {
+    // we have an error. need to mark the error into the parent rqu
+    rqu->flags |= RQUEUE_R_ERROR|RQUEUE_R_ANY;
+    mcp_resp_t *r = mcp_prep_bare_resobj(rctx->Lc, rctx->fgen->thread);
+    r->status = MCMC_ERR;
+    r->resp.code = MCMC_CODE_SERVER_ERROR;
+    assert(rqu->res_ref == 0);
+    rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+
+    // queue an IO to return later.
+    io_pending_proxy_t *p = mcp_queue_rctx_io(rctx->parent, NULL, NULL, r);
+    p->return_cb = proxy_return_rqu_cb;
+    p->queue_handle = rctx->parent_handle;
+    p->await_background = true;
+}
+
+static void mcp_start_subrctx(mcp_rcontext_t *rctx) {
+    int res = proxy_run_rcontext(rctx);
+    struct mcp_rqueue_s *rqu = &rctx->parent->qslots[rctx->parent_handle];
+    if (res == LUA_OK) {
+        int type = lua_type(rctx->Lc, 1);
+        mcp_resp_t *r = NULL;
+        if (type == LUA_TUSERDATA && (r = luaL_testudata(rctx->Lc, 1, "mcp.response")) != NULL) {
+            // move stack result object into parent rctx rqu slot.
+            assert(rqu->res_ref == 0);
+            rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+
+            io_pending_proxy_t *p = mcp_queue_rctx_io(rctx->parent, NULL, NULL, r);
+            p->return_cb = proxy_return_rqu_cb;
+            p->queue_handle = rctx->parent_handle;
+            // TODO: change name of property to fast-return once mcp.await is
+            // retired.
+            p->await_background = true;
+        } else if (type == LUA_TSTRING) {
+            // TODO: wrap with a resobj and parse it.
+            // for now we bypass the rqueue process handling
+            // meaning no callbacks/etc.
+            assert(rqu->res_ref == 0);
+            rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+            rqu->flags |= RQUEUE_R_ANY;
+            rqu->state = RQUEUE_COMPLETE;
+            io_pending_proxy_t *p = mcp_queue_rctx_io(rctx->parent, NULL, NULL, NULL);
+            p->return_cb = proxy_return_rqu_cb;
+            p->queue_handle = rctx->parent_handle;
+            p->await_background = true;
+        } else {
+            // generate a generic object with an error.
+            _mcp_start_rctx_process_error(rctx, rqu);
+        }
+    } else if (res == LUA_YIELD) {
+        // normal.
+    } else {
+        lua_pop(rctx->Lc, 1); // drop the error message.
+        _mcp_start_rctx_process_error(rctx, rqu);
+    }
+}
+
+static void mcp_resume_rctx_from_cb(mcp_rcontext_t *rctx) {
+    int res = proxy_run_rcontext(rctx);
+    if (rctx->parent) {
+        struct mcp_rqueue_s *rqu = &rctx->parent->qslots[rctx->parent_handle];
+        if (res == LUA_OK) {
+            int type = lua_type(rctx->Lc, 1);
+            mcp_resp_t *r = NULL;
+            if (type == LUA_TUSERDATA && (r = luaL_testudata(rctx->Lc, 1, "mcp.response")) != NULL) {
+                // move stack result object into parent rctx rqu slot.
+                assert(rqu->res_ref == 0);
+                rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+                mcp_process_rqueue_return(rctx->parent, rctx->parent_handle, r);
+            } else if (type == LUA_TSTRING) {
+                // TODO: wrap with a resobj and parse it.
+                // for now we bypass the rqueue process handling
+                // meaning no callbacks/etc.
+                assert(rqu->res_ref == 0);
+                rqu->res_ref = luaL_ref(rctx->Lc, LUA_REGISTRYINDEX);
+                rqu->flags |= RQUEUE_R_ANY;
+                rqu->state = RQUEUE_COMPLETE;
+            } else {
+                // generate a generic object with an error.
+                _mcp_resume_rctx_process_error(rctx, rqu);
+            }
+            if (rctx->parent->wait_count) {
+                mcp_process_rctx_wait(rctx->parent, rctx->parent_handle);
+            }
+            mcp_funcgen_return_rctx(rctx);
+        } else if (res == LUA_YIELD) {
+            // normal.
+        } else {
+            lua_pop(rctx->Lc, 1); // drop the error message.
+            _mcp_resume_rctx_process_error(rctx, rqu);
+            mcp_funcgen_return_rctx(rctx);
+        }
+    } else {
+        // Parent rctx has returned either a response or error to its top
+        // level resp object and is now complete.
+        // HACK
+        // see notes in proxy_run_rcontext()
+        // NOTE: this function is called from rqu_cb(), which pushes the
+        // submission loop. This code below can call drive_machine(), which
+        // calls submission loop if stuff is queued.
+        // Would remove redundancy if we can signal up to rqu_cb() and either
+        // q->count-- or do the inline submission at that level.
+        if (res != LUA_YIELD) {
+            mcp_funcgen_return_rctx(rctx);
+            io_queue_t *q = conn_io_queue_get(rctx->c, IO_QUEUE_PROXY);
+            q->count--;
+            if (q->count == 0) {
+                // call re-add directly since we're already in the worker thread.
+                conn_worker_readd(rctx->c);
+            }
+        }
+    }
+}
+
+// This "Dummy" IO immediately resumes the yielded function, without a result
+// attached.
+static void proxy_return_rqu_dummy_cb(io_pending_t *pending) {
+    io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
+    mcp_rcontext_t *rctx = p->rctx;
+    conn *c = rctx->c;
+
+    rctx->pending_reqs--;
+    assert(rctx->pending_reqs > -1);
+
+    lua_settop(rctx->Lc, 0);
+    lua_pushinteger(rctx->Lc, 0); // return a "0" done count to the function.
+    mcp_resume_rctx_from_cb(rctx);
+
+    do_cache_free(p->thread->io_cache, p);
+    // We always need a C object right now, but just in case.
+    if (c) {
+        // HACK
+        // see notes above proxy_run_rcontext.
+        // in case the above resume calls queued new work, we have to submit
+        // it to the backend handling system here.
+        for (io_queue_t *q = c->io_queues; q->type != IO_QUEUE_NONE; q++) {
+            if (q->stack_ctx != NULL) {
+                io_queue_cb_t *qcb = thread_io_queue_get(c->thread, q->type);
+                qcb->submit_cb(q);
+            }
+        }
+    }
+}
+
+void mcp_process_rctx_wait(mcp_rcontext_t *rctx, int handle) {
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    int status = rqu->flags;
+    assert(rqu->state == RQUEUE_COMPLETE);
+    // waiting for some IO's to complete before continuing.
+    // meaning if we "match good" here, we can resume.
+    // we can also resume if we are in wait mode but pending_reqs is down
+    // to 1.
+    switch (rctx->wait_mode) {
+        case QWAIT_IDLE:
+            // should be impossible to get here.
+            // TODO: find a better path for throwing real errors from these
+            // side cases. would feel better long term.
+            abort();
+            break;
+        case QWAIT_GOOD:
+            if (status & RQUEUE_R_GOOD) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+        case QWAIT_OK:
+            if (status & (RQUEUE_R_GOOD|RQUEUE_R_OK)) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+        case QWAIT_ANY:
+            rctx->wait_done++;
+            rqu->state = RQUEUE_WAITED;
+            break;
+        case QWAIT_FASTGOOD:
+            if (status & RQUEUE_R_GOOD) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+                // resume early if "good"
+                status |= RQUEUE_R_RESUME;
+            } else if (status & RQUEUE_R_OK) {
+                // count but don't resume early if "ok"
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+        case QWAIT_HANDLE:
+            // waiting for a specific handle to return
+            if (handle == rctx->wait_handle) {
+                rctx->wait_done++;
+                rqu->state = RQUEUE_WAITED;
+            }
+            break;
+    }
+
+    assert(rctx->pending_reqs != 0);
+    if ((status & RQUEUE_R_RESUME) || rctx->wait_done == rctx->wait_count || rctx->pending_reqs == 1) {
+        // ran out of stuff to wait for. time to resume.
+        // TODO: can we do the settop at the yield? nothing we need to
+        // keep in the stack in this mode.
+        lua_settop(rctx->Lc, 0);
+        rctx->wait_count = 0;
+        if (rctx->wait_mode == QWAIT_HANDLE) {
+            mcp_rcontext_push_rqu_res(rctx->Lc, rctx, handle);
+        } else {
+            lua_pushinteger(rctx->Lc, rctx->wait_done);
+        }
+        rctx->wait_mode = QWAIT_IDLE;
+
+        mcp_resume_rctx_from_cb(rctx);
+    }
+}
+
+// sets the slot's return status code, to be used for filtering responses
+// later.
+// if a callback was set, execute it now.
+int mcp_process_rqueue_return(mcp_rcontext_t *rctx, int handle, mcp_resp_t *res) {
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    uint8_t flag = RQUEUE_R_ANY;
+
+    assert(rqu->state == RQUEUE_ACTIVE);
+    rqu->state = RQUEUE_COMPLETE;
+    if (res->status == MCMC_OK) {
+        if (res->resp.code != MCMC_CODE_END) {
+            flag = RQUEUE_R_GOOD;
+        } else {
+            flag = RQUEUE_R_OK;
+        }
+    }
+
+    if (rqu->cb_ref) {
+        lua_settop(rctx->Lc, 0);
+        lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rqu->cb_ref);
+        lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rqu->res_ref);
+        lua_rawgeti(rctx->Lc, LUA_REGISTRYINDEX, rqu->req_ref);
+        if (lua_pcall(rctx->Lc, 2, 2, 0) != LUA_OK) {
+            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, lua_tostring(rctx->Lc, -1));
+        } else if (lua_isinteger(rctx->Lc, 1)) {
+            // allow overriding the result flag from the callback.
+            enum mcp_rqueue_e mode = lua_tointeger(rctx->Lc, 1);
+            switch (mode) {
+                case QWAIT_GOOD:
+                    flag = RQUEUE_R_GOOD;
+                    break;
+                case QWAIT_OK:
+                    flag = RQUEUE_R_OK;
+                    break;
+                case QWAIT_ANY:
+                    break;
+                default:
+                    // ANY
+                    break;
+            }
+
+            // if second result return shortcut status code
+            if (lua_toboolean(rctx->Lc, 2)) {
+                flag |= RQUEUE_R_RESUME;
+            }
+        }
+        lua_settop(rctx->Lc, 0); // FIXME: This might not be necessary.
+                                 // we settop _before_ calling cb's and
+                                 // _before_ setting up for a coro resume.
+    }
+    rqu->flags |= flag;
+    return rqu->flags;
+}
+
+// specific function for queue-based returns.
+static void proxy_return_rqu_cb(io_pending_t *pending) {
+    io_pending_proxy_t *p = (io_pending_proxy_t *)pending;
+    mcp_rcontext_t *rctx = p->rctx;
+    // Hold the client object before we potentially return the rctx below.
+    conn *c = rctx->c;
+
+    if (p->client_resp) {
+        mcp_process_rqueue_return(rctx, p->queue_handle, p->client_resp);
+    }
+    rctx->pending_reqs--;
+    assert(rctx->pending_reqs > -1);
+
+    if (rctx->wait_count) {
+        mcp_process_rctx_wait(rctx, p->queue_handle);
+    } else {
+        mcp_funcgen_return_rctx(rctx);
+    }
+
+    do_cache_free(p->thread->io_cache, p);
+
+    // We always need a C object right now, but just in case.
+    if (c) {
+        // HACK
+        // see notes above proxy_run_rcontext.
+        // in case the above resume calls queued new work, we have to submit
+        // it to the backend handling system here.
+        for (io_queue_t *q = c->io_queues; q->type != IO_QUEUE_NONE; q++) {
+            if (q->stack_ctx != NULL) {
+                io_queue_cb_t *qcb = thread_io_queue_get(c->thread, q->type);
+                qcb->submit_cb(q);
+            }
+        }
+    }
+}
+
+void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle) {
+    struct mcp_rqueue_s *rqu = NULL;
+    rqu = &rctx->qslots[handle];
+
+    if (rqu->state == RQUEUE_QUEUED) {
+        rqu->state = RQUEUE_ACTIVE;
+        if (rqu->obj_type == RQUEUE_TYPE_POOL) {
+            mcp_request_t *rq = rqu->rq;
+            mcp_backend_t *be = mcplib_pool_proxy_call_helper(rqu->obj, MCP_PARSER_KEY(rq->pr), rq->pr.klen);
+            // FIXME: queue requires conn because we're stacking objects
+            // into the connection for later submission, which means we
+            // absolutely cannot queue things once *c becomes invalid.
+            // need to assert/block this from happening.
+            mcp_set_resobj(rqu->res_obj, rq, be, rctx->fgen->thread);
+            io_pending_proxy_t *p = mcp_queue_rctx_io(rctx, rq, be, rqu->res_obj);
+            p->return_cb = proxy_return_rqu_cb;
+            p->queue_handle = handle;
+            rctx->pending_reqs++;
+        } else if (rqu->obj_type == RQUEUE_TYPE_FGEN) {
+            // TODO: NULL the ->c post-return?
+            mcp_rcontext_t *subrctx = rqu->obj;
+            subrctx->c = rctx->c;
+            rctx->pending_reqs++;
+            mcp_start_subrctx(subrctx);
+        } else {
+            assert(1==0);
+        }
+    } else if (rqu->state == RQUEUE_COMPLETE && rctx->wait_count) {
+        // The slot was previously completed from an earlier dispatch, but we
+        // haven't "waited" on it yet.
+        mcp_process_rctx_wait(rctx, handle);
+    }
+}
+
+// TODO: one more function to wait on a list of handles? to queue and wait on
+// a list of handles? expand wait_cond()
+
+// takes num, filter mode
+int mcplib_rcontext_wait_cond(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    int mode = QWAIT_ANY;
+    int wait = 0;
+
+    if (rctx->wait_mode != QWAIT_IDLE) {
+        proxy_lua_error(L, "wait_cond: cannot call while already in wait mode");
+        return 0;
+    }
+
+    if (!lua_isnumber(L, 2)) {
+        proxy_lua_error(L, "must pass number to wait_cond");
+        return 0;
+    } else {
+        wait = lua_tointeger(L, 2);
+        if (wait < 0) {
+            proxy_lua_error(L, "wait count for wait_cond must be positive");
+            return 0;
+        }
+        rctx->wait_count = wait;
+    }
+
+    if (lua_isnumber(L, 3)) {
+        mode = lua_tointeger(L, 3);
+    }
+
+    switch (mode) {
+        case QWAIT_ANY:
+        case QWAIT_OK:
+        case QWAIT_GOOD:
+        case QWAIT_FASTGOOD:
+            break;
+        default:
+            proxy_lua_error(L, "invalid mode sent to wait_cond");
+            return 0;
+    }
+    rctx->wait_done = 0;
+    rctx->wait_mode = mode;
+
+    // waiting for none, meaning just execute the queues.
+    if (wait == 0) {
+        io_pending_proxy_t *p = mcp_queue_rctx_io(rctx, NULL, NULL, NULL);
+        p->return_cb = proxy_return_rqu_dummy_cb;
+        p->await_background = true;
+        rctx->pending_reqs++;
+        rctx->wait_mode = QWAIT_IDLE; // not actually waiting.
+    }
+
+    lua_pushinteger(L, MCP_YIELD_WAITCOND);
+    return lua_yield(L, 1);
+}
+
+int mcplib_rcontext_enqueue_and_wait(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    mcp_request_t *rq = luaL_checkudata(L, 2, "mcp.request");
+    int isnum = 0;
+    int handle = lua_tointegerx(L, 3, &isnum);
+
+    if (rctx->wait_mode != QWAIT_IDLE) {
+        proxy_lua_error(L, "wait_cond: cannot call while already in wait mode");
+        return 0;
+    }
+
+    if (!rq->pr.keytoken) {
+        proxy_lua_error(L, "cannot queue requests without a key");
+        return 0;
+    }
+
+    if (!isnum) {
+        proxy_lua_error(L, "invalid handle passed to wait_handle");
+        return 0;
+    }
+
+    // queue up this handle and yield for the direct wait.
+    lua_pushvalue(L, 2);
+    _mcplib_rcontext_queue(L, rctx, rq, handle);
+    rctx->wait_done = 0;
+    rctx->wait_count = 1;
+    rctx->wait_mode = QWAIT_HANDLE;
+    rctx->wait_handle = handle;
+
+    lua_pushinteger(L, MCP_YIELD_WAITHANDLE);
+    return lua_yield(L, 1);
+}
+
+int mcplib_rcontext_wait_handle(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    int isnum = 0;
+    int handle = lua_tointegerx(L, 2, &isnum);
+
+    if (rctx->wait_mode != QWAIT_IDLE) {
+        proxy_lua_error(L, "wait_cond: cannot call while already in wait mode");
+        return 0;
+    }
+
+    if (!isnum || handle < 0 || handle >= rctx->fgen->max_queues) {
+        proxy_lua_error(L, "invalid handle passed to wait_handle");
+        return 0;
+    }
+
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    if (rqu->state == RQUEUE_IDLE) {
+        proxy_lua_error(L, "wait_handle called on unqueued handle");
+        return 0;
+    }
+
+    rctx->wait_done = 0;
+    rctx->wait_count = 1;
+    rctx->wait_mode = QWAIT_HANDLE;
+    rctx->wait_handle = handle;
+
+    lua_pushinteger(L, MCP_YIELD_WAITHANDLE);
+    return lua_yield(L, 1);
+}
+
+static inline struct mcp_rqueue_s *_mcplib_rcontext_checkhandle(lua_State *L) {
+    mcp_rcontext_t *rctx = lua_touserdata(L, 1);
+    int isnum = 0;
+    int handle = lua_tointegerx(L, 2, &isnum);
+    if (!isnum || handle < 0 || handle >= rctx->fgen->max_queues) {
+        proxy_lua_error(L, "invalid queue handle passed to :good/:ok:/:any");
+        return NULL;
+    }
+
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    return rqu;
+}
+
+int mcplib_rcontext_res_good(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & RQUEUE_R_GOOD) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+int mcplib_rcontext_res_ok(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & (RQUEUE_R_OK|RQUEUE_R_GOOD)) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+int mcplib_rcontext_res_any(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD)) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+    } else {
+        // Shouldn't be possible to get here, unless you're asking about a
+        // queue that was never armed or hasn't completed yet.
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+// returns res, RES_GOOD|OK|ANY
+int mcplib_rcontext_result(lua_State *L) {
+    struct mcp_rqueue_s *rqu = _mcplib_rcontext_checkhandle(L);
+    if (rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD)) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+        // mask away any other queue flags.
+        lua_pushinteger(L, rqu->flags & (RQUEUE_R_ANY|RQUEUE_R_OK|RQUEUE_R_GOOD));
+    } else {
+        lua_pushnil(L);
+        lua_pushnil(L);
+    }
+
+    return 2;
+}
+
+// the supplied handle must be valid.
+void mcp_rcontext_push_rqu_res(lua_State *L, mcp_rcontext_t *rctx, int handle) {
+    struct mcp_rqueue_s *rqu = &rctx->qslots[handle];
+    lua_rawgeti(L, LUA_REGISTRYINDEX, rqu->res_ref);
+}
+
+/*
+ * Specialized router funcgen.
+ * For routing a key across a map of possible function generators, we use a
+ * specialized function generator. This is to keep the attach and start code
+ * consistent, as they only need to think about function generators.
+ * It also keeps the cleanup code consistent, as when a "router" funcgen is
+ * replaced by mcp.attach() during a reload, we can immediately dereference
+ * all of the route fgens, rather than have to wait for GC.
+ *
+ * Another upside is when we're starting a new request, we can immediately
+ * swap out the top level fgen object, rather than force all routes to be
+ * processed as sub-funcs, which is a tiny bit slower and disallows custom
+ * request object sizes.
+ *
+ * The downside is this will appear to be bolted onto the side of the existing
+ * structs rather than be its own object, like I initially wanted.
+ */
+
+static inline const char *_mcp_router_shortsep(const char *key, const int klen, const char needle, size_t *len) {
+    const char *end = NULL;
+    const char *lookup = NULL;
+
+    end = memchr(key, needle, klen);
+    if (end == NULL) {
+        lookup = key;
+    } else {
+        lookup = key;
+        *len = end - key;
+    }
+
+    return lookup;
+}
+
+// we take some liberties here because we know needle and key can't be zero
+// this isn't the most hyper optimized search but prefixes and separators
+// should both be short.
+static inline const char *_mcp_router_longsep(const char *key, const int klen, const char *needle, size_t *len) {
+    const char *end = NULL;
+    const char *lookup = key;
+    size_t nlen = strlen(needle);
+
+    end = memchr(key, needle[0], klen);
+    if (end == NULL) {
+        // definitely no needle in this haystack.
+        return key;
+    }
+
+    // find the last possible position
+    const char *last = key + (klen - nlen);
+
+    while (end != last) {
+        if (*end == needle[0] && memcmp(end, needle, nlen) == 0) {
+            lookup = key;
+            *len = end - key;
+            break;
+        }
+        end++;
+    }
+
+    return lookup;
+}
+
+static inline const char *_mcp_router_anchorsm(const char *key, const int klen, const char *needle, size_t *len) {
+    // check the first byte anchor.
+    if (key[0] != needle[0]) {
+        return NULL;
+    }
+
+    // rest is same as shortsep.
+    return _mcp_router_shortsep(key+1, klen-1, needle[1], len);
+}
+
+static inline const char *_mcp_router_anchorbig(const char *key, const int klen, const struct mcp_router_long_s *conf, size_t *len) {
+    // check long anchored prefix.
+    size_t slen = strlen(conf->start);
+    // check for start len+2 to avoid sending a zero byte haystack to longsep
+    if (slen+2 > klen || memcmp(key, conf->start, slen) != 0) {
+        return NULL;
+    }
+
+    // rest is same as longsep
+    return _mcp_router_longsep(key+slen, klen-slen, conf->stop, len);
+}
+
+static mcp_funcgen_t *mcp_funcgen_route(lua_State *L, mcp_funcgen_t *fgen, mcp_parser_t *pr) {
+    struct mcp_funcgen_router *fr = &fgen->router;
+    if (pr->klen == 0) {
+        return NULL;
+    }
+    const char *key = &pr->request[pr->tokens[pr->keytoken]];
+    const char *lookup = NULL;
+    size_t lookuplen = 0;
+    switch(fr->type) {
+        case FGEN_ROUTER_NONE:
+            break;
+        case FGEN_ROUTER_SHORTSEP:
+            lookup = _mcp_router_shortsep(key, pr->klen, fr->conf.sep, &lookuplen);
+            break;
+        case FGEN_ROUTER_LONGSEP:
+            lookup = _mcp_router_longsep(key, pr->klen, fr->conf.lsep, &lookuplen);
+            break;
+        case FGEN_ROUTER_ANCHORSM:
+            lookup = _mcp_router_anchorsm(key, pr->klen, fr->conf.anchorsm, &lookuplen);
+            break;
+        case FGEN_ROUTER_ANCHORBIG:
+            lookup = _mcp_router_anchorbig(key, pr->klen, &fr->conf.big, &lookuplen);
+            break;
+    }
+
+    if (lookuplen == 0) {
+        return fr->def_fgen;
+    }
+
+    // hoping the lua short string cache helps us avoid allocations at least.
+    // since this lookup code is internal to the router object we can optimize
+    // this later and remove the lua bits.
+    lua_rawgeti(L, LUA_REGISTRYINDEX, fr->map_ref);
+    lua_pushlstring(L, lookup, lookuplen);
+    lua_rawget(L, -2); // pops key, returns value
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 2); // drop nil and map.
+        return fr->def_fgen;
+    } else {
+        int type = lua_type(L, -1);
+        if (type == LUA_TUSERDATA) {
+            mcp_funcgen_t *nfgen = lua_touserdata(L, -1);
+            lua_pop(L, 2); // drop fgen and map.
+            return nfgen;
+        } else if (type == LUA_TTABLE) {
+            lua_rawgeti(L, -1, pr->command);
+            // TODO: if nil, check CMD_ANY_STORAGE index for a default
+            // if none there, return fr->def_fgen
+            mcp_funcgen_t *nfgen = lua_touserdata(L, -1);
+            lua_pop(L, 3); // drop fgen, cmd map, map
+            return nfgen;
+        } else {
+            return fr->def_fgen;
+        }
+    }
+}
+
+// called from mcp_funcgen_cleanup if necessary.
+static int mcp_funcgen_router_cleanup(lua_State *L, mcp_funcgen_t *fgen) {
+    struct mcp_funcgen_router *fr = &fgen->router;
+    lua_rawgeti(L, LUA_REGISTRYINDEX, fr->map_ref);
+
+    // walk the map, de-ref any funcgens found.
+    int tidx = lua_absindex(L, -1);
+    lua_pushnil(L);
+    while (lua_next(L, tidx) != 0) {
+        int type = lua_type(L, -1);
+        if (type == LUA_TUSERDATA) {
+            mcp_funcgen_t *mfgen = lua_touserdata(L, -1);
+            mcp_funcgen_dereference(L, mfgen);
+            lua_pop(L, 1);
+        } else if (type == LUA_TTABLE) {
+            int midx = lua_absindex(L, -1);
+            lua_pushnil(L);
+            while (lua_next(L, midx) != 0) {
+                mcp_funcgen_t *mfgen = lua_touserdata(L, -1);
+                mcp_funcgen_dereference(L, mfgen);
+                lua_pop(L, 1); // drop value
+            }
+            lua_pop(L, 1); // drop command map table
+        }
+    }
+
+    lua_pop(L, 1); // drop the table.
+    luaL_unref(L, LUA_REGISTRYINDEX, fr->map_ref);
+    fr->map_ref = 0;
+
+    if (fr->def_fgen) {
+        mcp_funcgen_dereference(L, fr->def_fgen);
+        fr->def_fgen = NULL;
+    }
+
+    return 0;
+}
+
+// Note: the string should be safe to use after popping it here, because we
+// were fetching it from a table, but I might consider copying it into a
+// buffer from the caller first.
+static const char *_mcplib_router_new_check(lua_State *L, const char *arg, size_t *len) {
+    int type = lua_getfield(L, 1, arg);
+    if (type == LUA_TSTRING) {
+        const char *sep = lua_tolstring(L, -1, len);
+        if (*len == 0) {
+            proxy_lua_ferror(L, "must pass a non-zero length string to %s in mcp.router_new", arg);
+        } else if (*len > KEY_HASH_FILTER_MAX) {
+            proxy_lua_ferror(L, "%s is too long in mcp.router_new", arg);
+        }
+        lua_pop(L, 1); // drop key
+        return sep;
+    } else if (type != LUA_TNIL) {
+        proxy_lua_ferror(L, "must pass a string to %s in mcp.router_new", arg);
+    }
+    return NULL;
+}
+
+static size_t _mcplib_router_new_mapcheck(lua_State *L) {
+    size_t route_count = 0;
+    if (!lua_istable(L, -1)) {
+        proxy_lua_error(L, "Must pass a table to map argument of router_new");
+    }
+    // walk map table, get size count.
+    lua_pushnil(L); // init table key.
+    while (lua_next(L, 2) != 0) {
+        int type = lua_type(L, -1);
+        if (type == LUA_TUSERDATA) {
+            luaL_checkudata(L, -1, "mcp.funcgen");
+        } else if (type == LUA_TTABLE) {
+            int tidx = lua_absindex(L, -1);
+            // If table, it's a command map, poke in and validate.
+            lua_pushnil(L); // init next table key.
+            while (lua_next(L, tidx) != 0) {
+                if (!lua_isinteger(L, -2)) {
+                    proxy_lua_error(L, "Non integer key in router command map in router_new");
+                }
+                int cmd = lua_tointeger(L, -2);
+                if (cmd <= 0 || cmd >= CMD_END_STORAGE) {
+                    proxy_lua_error(L, "Bad command in router command map in router_new");
+                }
+                luaL_checkudata(L, -1, "mcp.funcgen");
+                lua_pop(L, 1); // drop val, keep key.
+            }
+        } else {
+            proxy_lua_error(L, "unhandled data in router_new map");
+        }
+        route_count++;
+        lua_pop(L, 1); // drop val, keep key.
+    }
+
+    return route_count;
+}
+
+// reads the configuration for the router based on the mode.
+static void _mcplib_router_new_mode(lua_State *L, struct mcp_funcgen_router *fr) {
+    const char *type = lua_tostring(L, -1);
+    size_t len = 0;
+    const char *sep = NULL;
+
+    // change internal type based on length of separator
+    if (strcmp(type, "prefix") == 0) {
+        sep = _mcplib_router_new_check(L, "stop", &len);
+        if (sep == NULL) {
+            // defaults
+            fr->type = FGEN_ROUTER_SHORTSEP;
+            fr->conf.sep = '/';
+        } else if (len == 1) {
+            // optimized shortsep case.
+            fr->type = FGEN_ROUTER_SHORTSEP;
+            fr->conf.sep = sep[0];
+        } else {
+            // len is long.
+            fr->type = FGEN_ROUTER_LONGSEP;
+            memcpy(fr->conf.lsep, sep, len);
+            fr->conf.lsep[len] = '\0'; // cap it.
+        }
+    } else if (strcmp(type, "anchor") == 0) {
+        size_t elen = 0; // stop len.
+        const char *usep = _mcplib_router_new_check(L, "stop", &elen);
+        sep = _mcplib_router_new_check(L, "start", &len);
+        if (sep == NULL && usep == NULL) {
+            // no arguments, use a default.
+            fr->type = FGEN_ROUTER_ANCHORSM;
+            fr->conf.anchorsm[0] = '/';
+            fr->conf.anchorsm[1] = '/';
+        } else if (sep == NULL || usep == NULL) {
+            // reduce the combinatorial space because I'm lazy.
+            proxy_lua_error(L, "must specify start and stop if mode is anchor in mcp.router_new");
+        } else if (len == 1 && elen == 1) {
+            fr->type = FGEN_ROUTER_ANCHORSM;
+            fr->conf.anchorsm[0] = sep[0];
+            fr->conf.anchorsm[1] = usep[0];
+        } else {
+            fr->type = FGEN_ROUTER_ANCHORBIG;
+            memcpy(fr->conf.big.start, sep, len);
+            memcpy(fr->conf.big.stop, usep, elen);
+            fr->conf.big.start[len] = '\0';
+            fr->conf.big.stop[elen] = '\0';
+        }
+    } else {
+        proxy_lua_error(L, "unknown type passed to mcp.router_new");
+    }
+}
+
+int mcplib_router_new(lua_State *L) {
+    struct mcp_funcgen_router fr = {0};
+    size_t route_count = 0;
+
+    if (!lua_istable(L, 1)) {
+        proxy_lua_error(L, "Must pass a table of arguments to mcp.router_new");
+    }
+
+    if (lua_getfield(L, 1, "map") != LUA_TNIL) {
+        route_count = _mcplib_router_new_mapcheck(L);
+    }
+    lua_pop(L, 1); // drop map or nil
+
+    // default to a short prefix type with a single byte separator.
+    fr.type = FGEN_ROUTER_SHORTSEP;
+    fr.conf.sep = '/';
+
+    // config:
+    // { mode = "anchor", start = "/", stop = "/" }
+    // { mode = "prefix", stop = "/" }
+    if (lua_getfield(L, 1, "mode") == LUA_TSTRING) {
+        _mcplib_router_new_mode(L, &fr);
+    }
+    lua_pop(L, 1); // drop mode or nil.
+
+    mcp_funcgen_t *fgen = lua_newuserdatauv(L, sizeof(mcp_funcgen_t), 0);
+    memset(fgen, 0, sizeof(mcp_funcgen_t));
+
+    luaL_getmetatable(L, "mcp.funcgen");
+    lua_setmetatable(L, -2);
+
+    int type = lua_getfield(L, 1, "default");
+    if (type == LUA_TUSERDATA) {
+        fr.def_fgen = luaL_checkudata(L, -1, "mcp.funcgen");
+        mcp_funcgen_reference(L); // pops the funcgen.
+    } else {
+        lua_pop(L, 1);
+    }
+
+    fgen->routecount = route_count;
+    memcpy(&fgen->router, &fr, sizeof(struct mcp_funcgen_router));
+
+    // walk map table again, funcgen_ref everyone.
+    lua_createtable(L, 0, route_count);
+    lua_pushvalue(L, -1); // dupe table ref for a moment.
+    fgen->router.map_ref = luaL_ref(L, LUA_REGISTRYINDEX); // pops extra map
+
+    int mymap = lua_absindex(L, -1);
+    lua_getfield(L, 1, "map");
+    int argmap = lua_absindex(L, -1);
+    lua_pushnil(L); // seed walk of the passed in map
+
+    while (lua_next(L, argmap) != 0) {
+        // types are already validated.
+        int type = lua_type(L, -1);
+        if (type == LUA_TUSERDATA) {
+            // first lets reference the function generator.
+            lua_pushvalue(L, -1); // duplicate value.
+            mcp_funcgen_reference(L); // pops the funcgen after referencing.
+
+            // duplicate key.
+            lua_pushvalue(L, -2);
+            // move key underneath value
+            lua_insert(L, -2); // take top (key) and move it down one.
+            // now key, key, value
+            lua_rawset(L, mymap); // pops k, v into our internal table.
+        } else if (type == LUA_TTABLE) {
+            int tidx = lua_absindex(L, -1); // idx of our command map table.
+            lua_createtable(L, CMD_END_STORAGE, 0);
+            int midx = lua_absindex(L, -1); // idx of our new command map.
+            lua_pushnil(L); // seed the iterator
+            while (lua_next(L, tidx) != 0) {
+                lua_pushvalue(L, -1); // duplicate value.
+                mcp_funcgen_reference(L); // pop funcgen.
+
+                lua_pushvalue(L, -2); // dupe key.
+                lua_insert(L, -2); // move key down one.
+                lua_rawset(L, midx); // set to new map table.
+            }
+
+            // -1: new command map
+            // -2: input command map
+            // -3: key
+            lua_pushvalue(L, -3); // dupe key
+            lua_insert(L, -2); // move key down below new cmd map
+            lua_rawset(L, mymap); // pop key, new map into main map.
+            lua_pop(L, 1); // drop input table.
+        }
+    }
+
+    lua_pop(L, 2); // drop argmap, mymap.
+
+    return 1;
+}

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -472,6 +472,16 @@ mcp_request_t *mcp_new_request(lua_State *L, mcp_parser_t *pr, const char *comma
     return rq;
 }
 
+// fill a preallocated request object.
+void mcp_set_request(mcp_parser_t *pr, mcp_request_t *rq, const char *command, size_t cmdlen) {
+    memset(rq, 0, sizeof(mcp_request_t));
+    memcpy(&rq->pr, pr, sizeof(*pr));
+
+    memcpy(rq->request, command, cmdlen);
+    rq->pr.request = rq->request;
+    rq->pr.reqlen = cmdlen;
+}
+
 // Replaces a token inside a request and re-parses.
 // Note that this has some optimization opportunities. Delaying until
 // required.
@@ -530,7 +540,8 @@ int mcp_request_render(mcp_request_t *rq, int idx, const char *tok, size_t len) 
     return 0;
 }
 
-void mcp_request_attach(lua_State *L, mcp_request_t *rq, io_pending_proxy_t *p) {
+// FIXME: remove lua_state from arguments.
+void mcp_request_attach(mcp_request_t *rq, io_pending_proxy_t *p) {
     mcp_parser_t *pr = &rq->pr;
     char *r = (char *) pr->request;
     size_t len = pr->reqlen;
@@ -787,9 +798,7 @@ int mcplib_request_flag_token(lua_State *L) {
     return ret;
 }
 
-int mcplib_request_gc(lua_State *L) {
-    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
-    mcp_request_t *rq = luaL_checkudata(L, -1, "mcp.request");
+void mcp_request_cleanup(LIBEVENT_THREAD *t, mcp_request_t *rq) {
     // During nread c->item is the malloc'ed buffer. not yet put into
     // rq->buf - this gets freed because we've also set c->item_malloced if
     // the connection closes before finishing nread.
@@ -798,7 +807,16 @@ int mcplib_request_gc(lua_State *L) {
         t->proxy_buffer_memory_used -= rq->pr.vlen;
         pthread_mutex_unlock(&t->proxy_limit_lock);
         free(rq->pr.vbuf);
+        // need to ensure we NULL this out now, since we can call the cleanup
+        // routine independent of GC, and a later GC would double-free.
+        rq->pr.vbuf = NULL;
     }
+}
+
+int mcplib_request_gc(lua_State *L) {
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+    mcp_request_t *rq = luaL_checkudata(L, -1, "mcp.request");
+    mcp_request_cleanup(t, rq);
 
     return 0;
 }

--- a/t/proxyfuncgen.lua
+++ b/t/proxyfuncgen.lua
@@ -1,0 +1,732 @@
+-- New style request factories and backend request handling.
+--
+-- Please look at the examples below, and refer to the API notes here if
+-- necessary.
+--
+-- First, this API adds a "request func generation" step when a new request
+-- starts: if there is not already a cached function to use, call the
+-- "generator" function, then use the response to run the request. This generated
+-- function is reused until the parent generator is swapped out during reload.
+-- This allows the user to pre-allocate and pre-calculate objects and data,
+-- offering both safety and performance.
+-- Future API revisions (such as stats) will rely on this generation step to
+-- be more user friendly while retaining performance.
+--
+-- For backend IO's this unifies what was once two API's:
+--  - result = pool(request): the non-async API
+--  - table = mcp.await(etc)
+--
+-- It is now a single system governeed by a request context object (rctx).
+-- This new system allows queueing a nearly arbitrary set of requests,
+-- "blocking" a client on any individual response, and using callbacks to
+-- make decisions on if a response is "good", to resume processing early, or
+-- post-process once all responses are received.
+--
+-- The queueing system is now recursive: a fgen can new_handle() another fgen.
+-- Meaning configurations can be assembled as call graphs. IE: If you have a
+-- route function A and want to "shadow" some of its requests onto route
+-- function B, instead of making A more complex you can create a third
+-- function C which splits the traffic.
+--
+-- This is demonstrated below with the prefix factory.
+--
+-- API:
+-- fgen = mcp.funcgen_new({ func = generator, arg = a, max_queues = n})
+--  - creates a new factory object. pass this object as the function argument
+--  to mcp.attach() or rctx:new_handle.
+--
+-- handle = rctx:new_handle(pool||funcgen, [cb])
+--  - to be called from the factory generator function, pre-assigns a pool or
+--  child fgen and optional callback function. returns a handle.
+--
+-- rctx:enqueue(r, handle || table)
+--  - to be called from the request function, queues up a request against the
+--  designated slot handle, or an array style table of N handles
+--
+-- res = rctx:enqueue_and_wait(r, h)
+--  - Directly returns a single result object after asynchronously waiting on
+--  a specified unqueued handle.
+--
+-- res = rctx:wait_handle(h)
+--  - Directly returns a single result object after asynchronously waiting on
+--  a specified prequeued handle.
+--
+-- num_good = rctx:wait_cond(count, mode)
+--  - Asynchronously waits for up to "count" results out of all currently
+--  queued handles. Takes a mode to filter for valid responses to count:
+--  - mcp.WAIT_OK, WAIT_GOOD, WAIT_ANY
+--
+-- rctx:res_good(handle)
+--  - returns result object if the queue response was considered "Good", else
+--  nil.
+-- rctx:res_any(handle)
+--  - same but "WAIT_ANY"
+-- rctx:res_ok(handle)
+--  - same but "WAIT_OK"
+-- res, mode = rctx:result(handle)
+--  - returns result object, mcp.RESULT_GOOD|OK|ANY
+
+verbose = true
+-- global for an error handling test
+failgen_armed = false
+failgenret_armed = false
+
+function say(...)
+    if verbose then
+        print(...)
+    end
+end
+
+function mcp_config_pools()
+    local srv = mcp.backend
+
+    local b1 = srv('b1', '127.0.0.1', 12011)
+    local b2 = srv('b2', '127.0.0.1', 12012)
+    local b3 = srv('b3', '127.0.0.1', 12013)
+    local b4 = srv('b4', '127.0.0.1', 12014)
+    local b1z = mcp.pool({b1})
+    local b2z = mcp.pool({b2})
+    local b3z = mcp.pool({b3})
+    local b4z = mcp.pool({b4})
+    local p = {p = {b1z, b2z, b3z}, b = b4z}
+
+    --return mcp.pool(b1z, { iothread = false })
+    return p
+end
+
+-- many of these factories have the same basic init pattern, so we can save
+-- some code.
+function new_basic_factory(arg, func)
+    local fgen = mcp.funcgen_new()
+    local o = { t = {}, c = 0 }
+
+    -- some of them have a wait, some don't.
+    -- here would be a good place to do bounds checking on arguments in
+    -- similar functions.
+    o.wait = arg.wait
+    for _, v in pairs(arg.list) do
+        table.insert(o.t, fgen:new_handle(v))
+        o.c = o.c + 1
+    end
+
+    fgen:ready({ f = func, a = o, n = arg.name})
+    return fgen
+end
+
+function new_prefix_factory(arg)
+    local fgen = mcp.funcgen_new()
+    local o = {}
+    o.pattern = arg.pattern
+    o.default = fgen:new_handle(arg.default)
+
+    o.map = {}
+    -- get handler ids for each sub-route value
+    -- convert the map.
+    for k, v in pairs(arg.list) do
+        o.map[k] = fgen:new_handle(v)
+    end
+
+    fgen:ready({ f = prefix_factory_gen, a = o, n = arg.name })
+    return fgen
+end
+
+function prefix_factory_gen(rctx, arg)
+    local p = arg.pattern
+    local map = arg.map
+    local d = arg.default
+
+    say("generating a prefix factory function")
+
+    return function(r)
+        local key = r:key()
+
+        local handle = map[string.match(key, p)]
+        if handle == nil then
+            return rctx:enqueue_and_wait(r, d)
+        end
+        return rctx:enqueue_and_wait(r, handle)
+    end
+end
+
+function new_direct_factory(arg)
+    local fgen = mcp.funcgen_new()
+    local h = fgen:new_handle(arg.p)
+    fgen:ready({ f = direct_factory_gen, a = h, n = arg.name })
+    return fgen
+end
+
+function direct_factory_gen(rctx, h)
+    say("generating direct factory function")
+
+    return function(r)
+        say("waiting on a single pool")
+        return rctx:enqueue_and_wait(r, h)
+    end
+end
+
+function new_locality_factory(arg)
+    local fgen = mcp.funcgen_new()
+    local h = fgen:new_handle(arg.p)
+    fgen:ready({ f = locality_factory_gen, a = h, n = arg.name })
+    return fgen
+end
+
+-- factory for proving slots have unique environmental memory.
+-- we need to wait on a backend to allow the test to pipeline N requests in
+-- parallel, to prove that each parallel slot has a unique lua environment.
+function locality_factory_gen(rctx, h)
+    say("generating locality factory function")
+    local x = 0
+
+    return function(r)
+        x = x + 1
+        say("returning from locality: " .. x)
+        local res = rctx:enqueue_and_wait(r, h)
+        return "HD t" .. x .. "\r\n"
+    end
+end
+
+-- waits for only the _first_ queued handle to return.
+-- ie; position 1 in the table.
+-- we do a numeric for loop in the returned function to avoid allocations done
+-- by a call to pairs()
+function first_factory_gen(rctx, arg)
+    say("generating first factory function")
+    local t = arg.t
+    local count = arg.c
+
+    return function(r)
+        say("waiting on first of " .. count .. " pools")
+        for x=1, count do
+            rctx:enqueue(r, t[x])
+        end
+
+        return rctx:wait_handle(t[1])
+    end
+end
+
+-- wait on x out of y
+function partial_factory_gen(rctx, arg)
+    say("generating partial factory function")
+    local t = arg.t
+    local count = arg.c
+    local wait = arg.wait
+
+    return function(r)
+        say("waiting on first " .. wait .. " out of " .. count)
+        for x=1, count do
+            rctx:enqueue(r, t[x])
+        end
+
+        local done = rctx:wait_cond(wait)
+        for x=1, count do
+            -- :good will only return the result object if the handle's
+            -- response was considered "good"
+            local res = rctx:res_good(t[x])
+            if res ~= nil then
+                say("found a result")
+                return res
+            end
+            -- TODO: tally up responses and send summary for test.
+        end
+        say("found nothing")
+        -- didn't return anything good, so return one at random.
+        for x=1, count do
+            local res = rctx:res_any(t[x])
+            if res ~= nil then
+                return res
+            end
+        end
+    end
+end
+
+-- wait on all pool arguments
+function all_factory_gen(rctx, arg)
+    say("generating all factory function")
+    local t = arg.t
+    local count = arg.c
+    -- should be a minor speedup avoiding the table lookup.
+    local mode = mcp.WAIT_ANY
+
+    return function(r)
+        say("waiting on " .. count)
+
+        rctx:enqueue(r, t)
+        local done = rctx:wait_cond(count, mode)
+        -- :any will give us the result object for that handle, regardless
+        -- of return code/status.
+        local res = rctx:res_any(t[1])
+
+        -- TODO: tally up the responses and return summary for test.
+        return res
+    end
+end
+
+-- wait on the first good or N of total
+function fastgood_factory_gen(rctx, arg)
+    say("generating fastgood factory function")
+    local t = arg.t
+    local count = arg.c
+    local wait = arg.wait
+
+    local cb = function(res)
+        say("running in a callback!")
+        if res:hit() then
+            say("was a hit!")
+            -- return an extra arg telling us to shortcut the wait count
+            return mcp.WAIT_GOOD, mcp.WAIT_RESUME
+        end
+        -- default return code is mcp.WAIT_ANY
+    end
+
+    for _, v in pairs(t) do
+        rctx:handle_set_cb(v, cb)
+    end
+
+    return function(r)
+        say("first good or wait for N")
+
+        rctx:enqueue(r, t)
+        local done = rctx:wait_cond(wait, mcp.WAIT_GOOD)
+        say("fastgood done:", done)
+
+        if done == 1 then
+            -- if we just got one "good", we're probably happy.
+            for x=1, count do
+                -- loop to find the good handle.
+                local res = rctx:res_good(t[x])
+                if res ~= nil then
+                    return res
+                end
+            end
+        else
+            -- else we had to wait and now need to decide if it was a miss or
+            -- network error.
+            -- but for this test we'll just return the first result.
+            for x=1, count do
+                local res = rctx:res_any(t[x])
+                if res ~= nil then
+                    return res
+                end
+            end
+        end
+    end
+end
+
+-- fastgood implemented using internal fastgood state
+function fastgoodint_factory_gen(rctx, arg)
+    local t = arg.t
+    local count = arg.c
+    local wait = arg.wait
+
+    return function(r)
+        rctx:enqueue(r, t)
+        local done = rctx:wait_cond(wait, mcp.WAIT_FASTGOOD)
+        say("fastgoodint done:", done)
+
+        local final = nil
+        for x=1, count do
+            local res, mode = rctx:result(t[x])
+            if mode == mcp.WAIT_GOOD then
+                return res
+            elseif res ~= nil then
+                final = res
+            end
+        end
+        -- if no good found, return anything.
+        return final
+    end
+end
+
+function new_blocker_factory(arg)
+    local fgen = mcp.funcgen_new()
+    local o = { c = 0, t = {} }
+    o.b = fgen:new_handle(arg.blocker)
+
+    for _, v in pairs(arg.list) do
+        table.insert(o.t, fgen:new_handle(v))
+        o.c = o.c + 1
+    end
+
+    fgen:ready({ f = blocker_factory_gen, a = o, n = arg.name })
+    return fgen
+end
+
+-- queue a bunch, but shortcut if a special auxiliary handle fails
+function blocker_factory_gen(rctx, arg)
+    say("generating blocker factory function")
+    local t = arg.t
+    local count = arg.c
+    local blocker = arg.b
+    local was_blocked = false
+
+    local cb = function(res)
+        -- check the response or tokens or anything special to indicate
+        -- success.
+        -- for this test we just check if it was a hit.
+        if res:hit() then
+            was_blocked = false
+            return mcp.WAIT_GOOD
+        else
+            was_blocked = true
+            return mcp.WAIT_ANY
+        end
+    end
+
+    rctx:handle_set_cb(blocker, cb)
+
+    return function(r)
+        say("function blocker test")
+
+        -- queue up the real queries we wanted to run.
+        rctx:enqueue(r, t)
+
+        -- any wait command will execute all queued queries at once, but here
+        -- we only wait for the blocker to complete.
+        local bres = rctx:enqueue_and_wait(r, blocker)
+
+        -- another way of doing this is to ask:
+        -- local res = rctx:res_good(blocker)
+        -- if a result was returned, the callback had returned WAIT_GOOD
+        if was_blocked == false then
+            -- our blocker is happy...
+            -- wait for the rest of the handles to come in and make a decision
+            -- on what to return to the client.
+            local done = rctx:wait_cond(count, mcp.WAIT_ANY)
+            return rctx:res_any(t[1])
+        else
+            return "SERVER_ERROR blocked\r\n"
+        end
+    end
+end
+
+-- log on all callbacks, even if waiting for 1
+function logall_factory_gen(rctx, arg)
+    say("generating logall factory function")
+    local t = arg.t
+
+    local cb = function(res, req)
+        say("received a response, logging...")
+        mcp.log("received a response: " .. tostring(res:ok()))
+        mcp.log_req(req, res, "even more logs")
+        return mcp.WAIT_ANY
+    end
+
+    for _, v in pairs(t) do
+        rctx:handle_set_cb(v, cb)
+    end
+
+    return function(r)
+        rctx:enqueue(r, t)
+        return rctx:wait_handle(t[1])
+    end
+end
+
+-- log a summary after all callbacks run
+function summary_factory_gen(rctx, arg)
+    say("generating summary factory function")
+    local t = arg.t
+    local count = arg.c
+
+    local todo = 0
+    local cb = function(res)
+        say("responses TODO: " .. todo)
+        todo = todo - 1
+        if todo == 0 then
+            mcp.log("received all responses")
+        end
+    end
+
+    for _, v in pairs(t) do
+        rctx:handle_set_cb(v, cb)
+    end
+
+    return function(r)
+        -- re-seed the todo value that the callback uses
+        todo = count
+
+        rctx:enqueue(r, t)
+        -- we're just waiting for a single response, but we queue all of the
+        -- handles. the callback uses data from the shared environment and a
+        -- summary is logged.
+        return rctx:wait_handle(t[1])
+    end
+end
+
+-- testing various waitfor conditions.
+function waitfor_factory_gen(rctx, arg)
+    say("generating background factory function")
+    local t = arg.t
+    local count = arg.c
+
+    return function(r)
+        local key = r:key()
+        if key == "waitfor/a" then
+            rctx:enqueue(r, t)
+            rctx:wait_cond(0) -- issue the requests in the background
+            return "HD t1\r\n" -- return whatever to the client
+        elseif key == "waitfor/b" then
+            rctx:enqueue(r, t)
+            rctx:wait_cond(0) -- issue requests and resume
+            -- now go back into wait mode, but we've already dispatched
+            local done = rctx:wait_cond(2)
+            if done ~= 2 then
+                return "SERVER_ERROR invalid wait"
+            end
+            -- TODO: bonus points, count the goods or check that everyone's t
+            -- flag is right.
+            for x=1, count do
+                local res = rctx:res_good(x)
+                if res ~= nil then
+                    return res
+                end
+                return "SERVER_ERROR no good response"
+            end
+        elseif key == "waitfor/c" then
+            rctx:enqueue(r, t[1])
+            rctx:wait_cond(0) -- issue the first queued request
+            -- queue two more
+            rctx:enqueue(r, t[2])
+            rctx:enqueue(r, t[3])
+            -- wait explicitly for the first queued one.
+            return rctx:wait_handle(t[1])
+        elseif key == "waitfor/d" then
+            -- queue two then wait on each individually
+            rctx:enqueue(r, t[1])
+            rctx:enqueue(r, t[2])
+            rctx:wait_handle(t[1])
+            return rctx:wait_handle(t[2])
+        end
+    end
+end
+
+-- try "primary zone" and then fail over to secondary zones.
+-- using simplified code that just treats the first pool as the primary zone.
+function failover_factory_gen(rctx, arg)
+    say("generating failover factory function")
+    local t = {}
+    local count = arg.c
+    local first = arg.t[1]
+
+    for x=2, count do
+        table.insert(t, arg.t[x])
+    end
+
+    return function(r)
+        -- first try local
+        local fres = rctx:enqueue_and_wait(r, first)
+
+        if fres == nil or fres:hit() == false then
+            -- failed to get a local hit, queue all "far" zones.
+            rctx:enqueue(r, t)
+            -- wait for one.
+            local done = rctx:wait_cond(1, mcp.WAIT_GOOD)
+            -- find the good from the second set.
+            for x=1, count-1 do
+                local res = rctx:res_good(t[x])
+                if res ~= nil then
+                    say("found a result")
+                    return res
+                end
+            end
+            -- got nothing from second set, just return anything.
+            return rctx:res_any(first)
+        else
+            return fres
+        end
+    end
+end
+
+function new_error_factory(func, name)
+    local fgen = mcp.funcgen_new()
+    fgen:ready({ f = func, n = name })
+    return fgen
+end
+
+function errors_factory_gen(rctx)
+    say("generating errors factory")
+
+    return function(r)
+        local key = r:key()
+        -- failure scenarios that require a top-level request context
+        if key == "errors/reterror" then
+            error("test error")
+        elseif key == "errors/retnil" then
+            return nil
+        elseif key == "errors/retint" then
+            return 5
+        elseif key == "errors/retnone" then
+            return
+        end
+    end
+end
+
+function suberrors_factory_gen(rctx)
+    say("generating suberrors factory function")
+
+    return function(r)
+        local key = r:key()
+        if key == "suberrors/error" then
+            error("test error")
+        elseif key == "suberrors/nil" then
+            return nil
+        elseif key == "suberrors/int" then
+            return 5
+        elseif key == "suberrors/none" then
+            return
+        end
+
+    end
+end
+
+function new_split_factory(arg)
+    local fgen = mcp.funcgen_new()
+    local o = {}
+    o.a = fgen:new_handle(arg.a)
+    o.b = fgen:new_handle(arg.b)
+    fgen:ready({ f = split_factory_gen, a = o, n = name })
+    return fgen
+end
+
+-- example of a factory that takes two other factories and copies traffic
+-- across them.
+-- If an additional API's for hashing to numerics are added, keys can be
+-- hashed to allow "1/n" of keys to copy to one of the splits. This allows
+-- shadowing traffic to new/experimental pools, slow-warming traffic, etc.
+function split_factory_gen(rctx, arg)
+    say("generating split factory function")
+    local a = arg.a
+    local b = arg.b
+
+    return function(r)
+        say("splitting traffic")
+        -- b is the split path.
+        rctx:enqueue(r, b)
+
+        -- a is the main path. so we only explicitly wait on and return a.
+        return rctx:enqueue_and_wait(r, a)
+    end
+end
+
+-- test handling of failure to generate a function slot
+function failgen_factory_gen(rctx)
+    if failgen_armed then
+        say("throwing failgen error")
+        error("failgen")
+    end
+    say("arming failgen")
+    failgen_armed = true
+
+    return function(r)
+        return "NF\r\n"
+    end
+end
+
+function failgenret_factory_gen(rctx)
+    if failgenret_armed then
+        return nil
+    end
+    failgenret_armed = true
+
+    return function(r)
+        return "NF\r\n"
+    end
+end
+
+function badreturn_gen(rctx)
+    -- returning a userdata that isn't the correct kind of userdata.
+    -- shouldn't crash the daemon!
+    return function(r)
+        return rctx
+    end
+end
+
+-- TODO: this might be supported only in a later update.
+-- new queue after parent return
+-- - do an immediate return + cb queue, queue from that callback
+-- - should still work but requires worker lua vm
+-- requires removing the need of having an active client socket object to
+-- queue new requests for processing.
+function postreturn_factory(rctx, arg)
+
+end
+
+-- TODO: demonstrate a split call graph
+-- ie; an all split into two single
+
+function mcp_config_routes(p)
+    local b_pool = p.b
+    p = p.p
+    local single = new_direct_factory({ p = p[1], name = "single" })
+    -- use the typically unused backend.
+    local singletwo = new_direct_factory({ p = b_pool, name = "singletwo" })
+
+    local first = new_basic_factory({ list = p, name = "first" }, first_factory_gen)
+    local partial = new_basic_factory({ list = p, wait = 2, name = "partial" }, partial_factory_gen)
+    local all = new_basic_factory({ list = p, name = "all" }, all_factory_gen)
+    local fastgood = new_basic_factory({ list = p, wait = 2, name = "fastgood" }, fastgood_factory_gen)
+    local fastgoodint = new_basic_factory({ list = p, wait = 2, name = "fastgoodint" }, fastgoodint_factory_gen)
+    local blocker = new_blocker_factory({ blocker = b_pool, list = p, name = "blocker" })
+    local logall = new_basic_factory({ list = p, name = "logall" }, logall_factory_gen)
+    local summary = new_basic_factory({ list = p, name = "summary" }, summary_factory_gen)
+    local waitfor = new_basic_factory({ list = p, name = "waitfor" }, waitfor_factory_gen)
+    local failover = new_basic_factory({ list = p, name = "failover" }, failover_factory_gen)
+    local locality = new_locality_factory({ p = p[1], name = "locality" })
+
+    local errors = new_error_factory(errors_factory_gen, "errors")
+    local suberrors = new_error_factory(suberrors_factory_gen, "suberrors")
+    local suberr_wrap = new_direct_factory({ p = suberrors, name = "suberrwrap" })
+    local badreturn = new_error_factory(badreturn_gen, "badreturn")
+
+    -- for testing traffic splitting.
+    local split = new_split_factory({ a = single, b = singletwo, name = "split" })
+    local splitfailover = new_split_factory({ a = failover, b = singletwo, name = "splitfailover" })
+
+    local map = {
+        ["single"] = single,
+        ["first"] = first,
+        ["partial"] = partial,
+        ["all"] = all,
+        ["fastgood"] = fastgood,
+        ["fastgoodint"] = fastgoodint,
+        ["blocker"] = blocker,
+        ["logall"] = logall,
+        ["summary"] = summary,
+        ["waitfor"] = waitfor,
+        ["failover"] = failover,
+        ["suberrors"] = suberr_wrap,
+        ["errors"] = errors,
+        ["split"] = split,
+        ["splitfailover"] = splitfailover,
+        ["locality"] = locality,
+        ["badreturn"] = badreturn,
+    }
+
+    local parg = {
+        default = single,
+        list = map,
+        pattern = "^/(%a+)/"
+    }
+
+    local failgen = new_error_factory(failgen_factory_gen, "failgen")
+    local failgenret = new_error_factory(failgenret_factory_gen, "failgenret")
+
+    local mapfail = {
+        ["failgen"] = failgen,
+        ["failgenret"] = failgenret,
+    }
+    local farg = {
+        default = single,
+        list = mapfail,
+        pattern = "^(%a+)/",
+        name = "prefixfail"
+    }
+
+    local pfx = mcp.router_new({ map = map })
+    local pfxfail = new_prefix_factory(farg)
+
+    mcp.attach(mcp.CMD_ANY_STORAGE, pfx)
+    -- TODO: might need to move this fail stuff to another test file.
+    mcp.attach(mcp.CMD_MS, pfxfail)
+    mcp.attach(mcp.CMD_MD, pfxfail)
+end

--- a/t/proxyfuncgen.t
+++ b/t/proxyfuncgen.t
@@ -1,0 +1,440 @@
+#!/usr/bin/env perl
+# Was wondering why we didn't use subtest more.
+# Turns out it's "relatively new", so it wasn't included in CentOS 5. which we
+# had to support until a few years ago. So most of the tests had been written
+# beforehand.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up the listeners _before_ starting the proxy.
+# the fourth listener is only occasionally used.
+my $t = Memcached::ProxyTest->new(servers => [12011, 12012, 12013, 12014]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyfuncgen.lua');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+{
+    # Comment out unused sections when debugging.
+    test_pipeline();
+    test_split();
+    test_basic();
+    test_waitfor();
+    # Run test returns twice for extra leak checking.
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    test_returns();
+    test_returns();
+    check_func_counts($ps, $func_before);
+    test_errors();
+}
+
+done_testing();
+
+# This kind of testing is difficult to do from integration level test suites
+# like this, but do what we can.
+sub test_errors {
+    note 'test specific error handling';
+
+    # Looking specifically for slot leaks. So we run the test N times and
+    # check immediately.
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    subtest 'bad data chunk' => sub {
+        for (1 .. 3) {
+            $t->c_send("ms badchunk 2\r\nfail");
+            $t->c_recv("CLIENT_ERROR bad data chunk\r\n", "got bad data chunk response");
+        }
+        $t->clear();
+    };
+    check_func_counts($ps, $func_before);
+
+    # Need to pipeline to force the second slot to generate.
+    subtest 'slot generation failure' => sub {
+        my $cmd = "md failgen/a\r\n";
+        $t->c_send("$cmd$cmd");
+        $t->c_recv("NF\r\n");
+        $t->c_recv("SERVER_ERROR lua start failure\r\n");
+        $t->clear();
+    };
+
+    subtest 'wrong return object' => sub {
+        $t->c_send("mg badreturn/a\r\n");
+        $t->c_recv("SERVER_ERROR bad response\r\n");
+        $t->clear();
+    };
+}
+
+sub test_pipeline {
+    note 'test pipelining of requests';
+
+    # We're expecting the slots to actually increase on the first loop, so
+    # make sure we test that explicitly.
+    my $func_before = mem_stats($ps, "proxyfuncs");
+
+    subtest 'some pipelines' => sub {
+        note 'run a couple pipelines to check for leaks';
+        for my $count (1 .. 3) {
+            my @keys = ("a".."f");
+            my $cmd = '';
+            for my $k (@keys) {
+                $cmd .= "mg all/$k O$k\r\n";
+            }
+            $t->c_send("$cmd");
+            for my $k (@keys) {
+                $t->be_recv([0, 1, 2], "mg all/$k O$k\r\n", "backend received pipelined $k");
+                $t->be_send([0, 1, 2], "HD O$k\r\n");
+            }
+
+            for my $k (@keys) {
+                $t->c_recv("HD O$k\r\n", "client got res $k");
+            }
+            $t->clear();
+
+            if ($count == 1) {
+                my $func_after = mem_stats($ps, "proxyfuncs");
+                cmp_ok($func_after->{"slots_all"}, '>=', $func_before->{"slots_all"}, 'slot count increased');
+                # ensure we don't add more slots after this run.
+                $func_before = $func_after;
+            } else {
+                check_func_counts($ps, $func_before);
+            }
+        }
+    };
+
+    subtest 'ensuring unique slot environments' => sub {
+        # In each loop we send the command three times pipelined, but we
+        # should get three unique lua environments.
+        # In subsequent loops, the numbers will increment in lockstep.
+        for my $x (1 .. 5) {
+            # key doesn't matter; function isn't looking at it.
+            my $cmd = "mg locality/a\r\n";
+            $t->c_send("$cmd$cmd$cmd");
+            for (1 .. 3) {
+                $t->be_recv([0], $cmd, "backend 0 received locaity req");
+                $t->be_send([0], "EN\r\n"); # not sending to client.
+            }
+            for (1 .. 3) {
+                $t->c_recv("HD t$x\r\n", "client got return sequence $x");
+            }
+        }
+    };
+}
+
+sub test_split {
+    note 'test tiering of factories';
+
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    # be's 0 and 3 are in use.
+    subtest 'basic split' => sub {
+        $t->c_send("mg split/a t\r\n");
+        $t->be_recv_c([0, 3], 'each factory be gets the request');
+        $t->be_send(3, "EN\r\n");
+        $t->be_send(0, "HD t70\r\n");
+        $t->c_recv_be('client received hit');
+        $t->clear();
+    };
+
+    # one side of split is a complex function; doing its own waits and wakes.
+    # other side is simple, and response ignored.
+    subtest 'failover split' => sub {
+        $t->c_send("mg splitfailover/f t\r\n");
+        $t->be_recv_c(0, 'first backend receives client req');
+        $t->be_recv_c(3, 'split factory gets client req');
+        $t->be_send(3, "HD t133\r\n");
+
+        # ensure all of the failover backends have their results processed.
+        $t->be_send(0, "EN Ofirst\r\n");
+        $t->be_recv_c([1, 2], 'rest of be receives retry');
+        $t->be_send([1, 2], "EN Ofailover\r\n");
+        $t->c_recv("EN Ofirst\r\n", 'client receives first res');
+        $t->clear();
+    };
+    check_func_counts($ps, $func_before);
+}
+
+sub test_returns {
+    note 'stress testing return scenarios for ctx and sub-ctx';
+
+    # TODO: check that we don't re-generate a slot after each error type
+    subtest 'top level result errors' => sub {
+        $t->c_send("mg errors/reterror t\r\n");
+        $t->c_recv("SERVER_ERROR lua failure\r\n", "lua threw an error");
+
+        $t->c_send("mg errors/retnil t\r\n");
+        $t->c_recv("SERVER_ERROR bad response\r\n", "lua returned nil");
+
+        $t->c_send("mg errors/retint t\r\n");
+        $t->c_recv("SERVER_ERROR bad response\r\n", "lua returned an integer");
+
+        $t->c_send("mg errors/retnone t\r\n");
+        $t->c_recv("SERVER_ERROR bad response\r\n", "lua returned nothing");
+        $t->clear();
+    };
+
+    # TODO: method to differentiate a sub-rctx failure from a "backend
+    # failure"
+    subtest 'sub-rctx result errors' => sub {
+        $t->c_send("mg suberrors/error t\r\n");
+        $t->c_recv("SERVER_ERROR backend failure\r\n", "lua threw an error");
+
+        $t->c_send("mg suberrors/nil t\r\n");
+        $t->c_recv("SERVER_ERROR backend failure\r\n", "lua returned nil");
+
+        $t->c_send("mg suberrors/int t\r\n");
+        $t->c_recv("SERVER_ERROR backend failure\r\n", "lua returned an integer");
+
+        $t->c_send("mg suberrors/none t\r\n");
+        $t->c_recv("SERVER_ERROR backend failure\r\n", "lua returned nothing");
+        $t->clear();
+    };
+}
+
+sub test_waitfor {
+    note 'stress testing rctx:wait_cond scenarios';
+
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    subtest 'wait_fastgood: hit, c_recv, miss miss' => sub {
+        $t->c_send("mg fastgoodint/a\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send(0, "HD t1\r\n");
+        $t->c_recv_be('first good response');
+        $t->be_send([1, 2], "EN Ohmm\r\n");
+        $t->clear();
+    };
+
+    subtest 'wait_fastgood: miss, miss, c_recv, hit' => sub {
+        $t->c_send("mg fastgoodint/a\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([1, 2], "EN Ommh\r\n");
+        $t->c_recv_be('received miss');
+        $t->be_send([0], "HD t40\r\n");
+        $t->clear();
+    };
+
+    subtest 'wait_fastgood: miss, hit, hit' => sub {
+        $t->c_send("mg fastgoodint/a\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send(0, "EN Omhh\r\n");
+        $t->be_send(1, "HD t43\r\n");
+        $t->be_send(2, "HD t44\r\n");
+        $t->c_recv("HD t43\r\n", 'received first');
+        $t->clear();
+    };
+
+    subtest 'wait_cond(0)' => sub {
+        $t->c_send("mg waitfor/a\r\n");
+        $t->c_recv("HD t1\r\n", 'client response before backends receive cmd');
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t9\r\n");
+        $t->clear();
+    };
+
+    subtest 'wait_cond(0) then wait_cond(2)' => sub {
+        $t->c_send("mg waitfor/b t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t13\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'wait_cond(0) then queue then wait_cond(1)' => sub {
+        $t->c_send("mg waitfor/c t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t11\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'queue two, wait_handle individually' => sub {
+        $t->c_send("mg waitfor/d t\r\n");
+        $t->be_recv_c([0, 1]);
+        # respond from the non-waited be first
+        $t->be_send(1, "HD t23\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(0, "HD t17\r\n");
+        $t->c_recv("HD t23\r\n");
+        $t->clear();
+    };
+
+    # failover is referenced from another funcgen, so when we first fetch it
+    # here we end up creating a new slot deliberately.
+    $func_before->{slots_failover}++;
+    subtest 'failover route first success' => sub {
+        $t->c_send("mg failover/a t\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD t31\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'failover route failover success' => sub {
+        $t->c_send("mg failover/b t\r\n");
+        $t->be_recv_c(0, 'first backend receives client req');
+        $t->be_send(0, "EN\r\n");
+        # TODO: test that they aren't active before we send the resposne to 0?
+        $t->be_recv_c([1, 2], 'rest of be then receive the retry');
+        $t->be_send(1, "EN\r\n");
+        $t->be_send(2, "HD t41\r\n");
+        $t->c_recv_be('client received last response');
+    };
+
+    subtest 'failover route failover fail' => sub {
+        $t->c_send("mg failover/c t\r\n");
+        $t->be_recv_c(0, 'first backend receives client req');
+        $t->be_send(0, "EN Ofirst\r\n");
+        $t->be_recv_c([1, 2], 'rest of be receives retry');
+        $t->be_send([1, 2], "EN Ofailover\r\n");
+        $t->c_recv("EN Ofirst\r\n", 'client receives first res');
+    };
+    check_func_counts($ps, $func_before);
+}
+
+sub test_basic {
+    note 'basic functionality tests';
+
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    # actually referenced an extra time.
+    $func_before->{slots_single}++;
+    subtest 'single backend route' => sub {
+        $t->c_send("mg single/a\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'first route' => sub {
+        $t->c_send("mg first/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        # respond from the other two backends first.
+        $t->be_send([1, 2], "HD t5\r\n");
+        $t->be_send(0, "HD t1\r\n");
+        # receive just the last command.
+        $t->c_recv_be();
+        $t->clear();
+    };
+
+    subtest 'partial route' => sub {
+        $t->c_send("mg partial/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send(0, "HD t4\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(1, "HD t4\r\n");
+        $t->c_recv_be('response received after 2/3 returned');
+        $t->be_send(2, "HD t5\r\n");
+        $t->clear();
+    };
+
+    subtest 'all route' => sub {
+        $t->c_send("mg all/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1], "HD t1\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(2, "HD t1\r\n");
+        $t->c_recv_be('response received after 3/3 returned');
+        $t->clear();
+    };
+
+    subtest 'fastgood route' => sub {
+        $t->c_send("mg fastgood/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        # Send one valid but not a hit.
+        $t->be_send(0, "EN\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(1, "HD t5\r\n");
+        $t->c_recv_be('response received after first good');
+        $t->be_send(2, "EN\r\n");
+        $t->clear();
+    };
+
+    subtest 'blocker route' => sub {
+        # The third backend is our blocker, first test that normal backends return
+        # but we don't return to client.
+        $t->c_send("mg blocker/a t Ltest\r\n");
+        $t->be_recv_c([0, 1, 2, 3], 'received blocker requests');
+        $t->be_send([0, 1, 2], "HD t10\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(3, "HD t15\r\n");
+        # Now, be sure we didn't receive the blocker response
+        $t->c_recv("HD t10\r\n");
+        $t->clear();
+
+        note '... failed blocker';
+        $t->c_send("mg blocker/b t Ltest\r\n");
+        $t->be_recv_c([0, 1, 2, 3]);
+        $t->be_send([0, 1, 2], "HD t10\r\n");
+        ok(!$t->wait_c(0.2), 'client doesnt become readable');
+        $t->be_send(3, "EN\r\n");
+        # Should get the blocker failed response.
+        $t->c_recv("SERVER_ERROR blocked\r\n");
+        $t->clear();
+    };
+
+    subtest 'logall route' => sub {
+        my $w = $p_srv->new_sock;
+        print $w "watch proxyuser proxyreqs\n";
+        is(<$w>, "OK\r\n", 'watcher enabled');
+
+        $t->c_send("mg logall/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t3\r\n");
+        $t->c_recv_be();
+        for (0 .. 2) {
+            like(<$w>, qr/received a response: /, 'got a log line');
+            like(<$w>, qr/even more logs/, 'got logreq line');
+        }
+        $t->clear();
+    };
+
+    subtest 'summary_factory' => sub {
+        my $w = $p_srv->new_sock;
+        print $w "watch proxyuser\n";
+        is(<$w>, "OK\r\n", 'watcher enabled');
+
+        $t->c_send("mg summary/a t\r\n");
+        $t->be_recv_c([0, 1, 2]);
+        $t->be_send([0, 1, 2], "HD t8\r\n");
+        $t->c_recv_be();
+        like(<$w>, qr/received all responses/, 'got a log summary line');
+        $t->clear();
+    };
+
+    check_func_counts($ps, $func_before);
+}
+
+# To help debug, if a failure is encountered move this function up in its
+# caller function and bisect.
+# This is an out of band test: it won't fail on the test that breaks it.
+# If a slot isn't returned properly the next test will generate one, and
+# the counts will be off after that.
+# This might mean to be absolutely sure, we should run the last test in a set
+# twice.
+sub check_func_counts {
+    my $c = shift;
+    my $a = shift;
+    my $b = mem_stats($c, "proxyfuncs");
+    for my $key (keys %$a) {
+        # Don't want to pollute/slow down the output with tons of ok's here,
+        # so only fail on the fail conditions.
+        if (! exists $b->{$key}) {
+            fail("func stat gone missing: $key");
+        }
+        if ($a->{$key} != $b->{$key}) {
+            cmp_ok($b->{$key}, '==', $a->{$key}, "func stat for $key");
+        }
+    }
+}

--- a/t/proxyintext.lua
+++ b/t/proxyintext.lua
@@ -1,0 +1,44 @@
+-- using mcp.internal() with extstore
+
+function new_splitter(afg, bfg)
+    local fg = mcp.funcgen_new()
+    local h_a = fg:new_handle(afg)
+    local h_b = fg:new_handle(bfg)
+
+    fg:ready({ f = function(rctx)
+        return function(r)
+            rctx:enqueue(r, h_a)
+            rctx:enqueue(r, h_b)
+            rctx:wait_cond(2, mcp.WAIT_ANY)
+            return rctx:res_any(h_a)
+        end
+    end
+    })
+
+    return fg
+end
+
+function mcp_config_pools()
+end
+
+function mcp_config_routes()
+    local mfg = mcp.funcgen_new()
+    mfg:ready({ f = function(rctx)
+            return function(r)
+                return mcp.internal(r)
+            end
+        end
+    })
+
+    -- test running internal from subrctx's
+    local split = new_splitter(mfg, mfg)
+
+    local map = {
+        ["top"] = mfg,
+        ["split"] = split,
+    }
+
+    local router = mcp.router_new({ map = map })
+
+    mcp.attach(mcp.CMD_ANY_STORAGE, router)
+end

--- a/t/proxyintext.t
+++ b/t/proxyintext.t
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+#
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $ext_path;
+
+if (!supports_extstore()) {
+    plan skip_all => 'extstore not enabled';
+    exit 0;
+}
+
+$ext_path = "/tmp/extstore.$$";
+
+my $value;
+{
+    my @chars = ("C".."Z");
+    for (1 .. 20000) {
+        $value .= $chars[rand @chars];
+    }
+}
+
+my $t = Memcached::ProxyTest->new(servers => [12081]);
+
+my $p_srv = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_item_size=512,ext_item_age=2,ext_path=$ext_path:64m,ext_max_sleep=100000,proxy_config=./t/proxyintext.lua");
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+#$t->accept_backends();
+
+{
+    test_basic();
+    subtest 'extstore tests', \&test_ext;
+}
+
+done_testing();
+
+sub test_basic {
+    subtest 'top level in memory mcp.internal() values' => sub {
+        $t->c_send("ms top/a 2 F1 Oa1\r\nhi\r\n");
+        $t->c_recv("HD Oa1\r\n", "set small value");
+
+        $t->c_send("mg top/a v f Oa2\r\n");
+        $t->c_recv("VA 2 f1 Oa2\r\n", "header received");
+        $t->c_recv("hi\r\n", "payload received");
+        $t->clear();
+    };
+
+    subtest 'sub level in memory mcp.internal() values' => sub {
+        plan skip_all => 'sub-rctx internal calls do not work';
+        $t->c_send("ms split/b 2 F2 Ob1\r\nho\r\n");
+        $t->c_recv("HD Ob1\r\n", "set small to subrctx");
+
+        $t->c_send("mg split/b v f Ob2\r\n");
+        $t->c_recv("VA 2 f2 Ob2\r\n", "header received");
+        $t->c_recv("ho\r\n", "payload received");
+        $t->clear();
+    };
+}
+
+# don't need tons of keys for this test as we're focusing on fetch/return
+# functionality.
+sub test_ext {
+    my $count = 20;
+    for my $c (1 .. $count) {
+        $t->c_send("ms top/$c 20000 F$c\r\n$value\r\n");
+        $t->c_recv("HD\r\n");
+
+        # sub-rctx internal calls do not work.
+        #$t->c_send("ms split/$c 20000 F$c\r\n$value\r\n");
+        #$t->c_recv("HD\r\n");
+    }
+    $t->clear();
+
+    wait_ext_flush($ps);
+
+    $t->c_send("mg top/1 f v\r\n");
+    $t->c_recv("VA 20000 f1\r\n", "header received");
+    $t->c_recv("$value\r\n", "value received");
+
+    #$t->c_send("mg split/2 f v\r\n");
+    #$t->c_recv("VA 20000 F2\r\n", "header received");
+    #$t->c_recv("$value\r\n", "value received");
+    $t->clear();
+}
+
+END {
+    unlink $ext_path if $ext_path;
+}

--- a/t/proxyrouter.lua
+++ b/t/proxyrouter.lua
@@ -1,0 +1,63 @@
+
+verbose = true
+
+function say(...)
+    if verbose then
+        print(...)
+    end
+end
+
+function mcp_config_pools()
+    local srv = mcp.backend
+    local b1 = srv('b1', '127.0.0.1', 12021)
+    return mcp.pool({b1})
+end
+
+function factory(rctx, h)
+    return function(r)
+        return rctx:enqueue_and_wait(r, h)
+    end
+end
+
+function d_factory(rctx)
+    return function(r)
+        return "SERVER_ERROR default route\r\n"
+    end
+end
+
+function string_fgen(msg)
+    local fg = mcp.funcgen_new()
+    fg:ready({ f = function(rctx)
+        return function(r)
+            return msg
+        end
+    end})
+    return fg
+end
+
+-- TODO: make default path and some other paths that return static data
+function mcp_config_routes(p)
+    local fg = mcp.funcgen_new()
+    local fgh = fg:new_handle(p)
+    fg:ready({ f = factory, a = fgh })
+
+    local def_fg = mcp.funcgen_new()
+    def_fg:ready({ f = d_factory })
+
+    local map = {
+        ["one"] = fg,
+        ["two"] = fg,
+        ["cmd"] = { [mcp.CMD_MG] = string_fgen("SERVER_ERROR cmd_mg\r\n"),
+            [mcp.CMD_MS] = string_fgen("SERVER_ERROR cmd_ms\r\n") },
+    }
+
+    local rpfx_short = mcp.router_new({ map = map, mode = "prefix", stop = "|", default = def_fg })
+    local rpfx_long = mcp.router_new({ map = map, mode = "prefix", stop = "+#+", default = def_fg })
+    local ranc_short = mcp.router_new({ map = map, mode = "anchor", start = "_", stop = ",", default = def_fg })
+    local ranc_long = mcp.router_new({ map = map, mode = "anchor", start = "=?=", stop = "__", default = def_fg })
+
+    mcp.attach(mcp.CMD_MG, rpfx_short)
+    mcp.attach(mcp.CMD_MS, rpfx_long)
+    mcp.attach(mcp.CMD_MD, ranc_short)
+    mcp.attach(mcp.CMD_MA, ranc_long)
+end

--- a/t/proxyrouter.t
+++ b/t/proxyrouter.t
@@ -1,0 +1,128 @@
+#!/usr/bin/env perl
+# Was wondering why we didn't use subtest more.
+# Turns out it's "relatively new", so it wasn't included in CentOS 5. which we
+# had to support until a few years ago. So most of the tests had been written
+# beforehand.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up the listeners _before_ starting the proxy.
+# the fourth listener is only occasionally used.
+my $t = Memcached::ProxyTest->new(servers => [12021]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyrouter.lua');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+{
+    test_submap();
+    test_basic();
+    test_separators();
+}
+
+done_testing();
+
+sub test_submap {
+    subtest 'check sub map routing' => sub {
+        $t->c_send("mg cmd|test t3\r\n");
+        $t->c_recv("SERVER_ERROR cmd_mg\r\n", "routed to sub-mg function");
+        $t->c_send("ms cmd+#+test 2 T3\r\nhi\r\n");
+        $t->c_recv("SERVER_ERROR cmd_ms\r\n", "routed to sub-ms function");
+        $t->clear();
+    };
+}
+
+sub test_basic {
+    # If there's a lua stack leak somewhere running the query a few hundred
+    # times will cause a crash.
+    my $func_before = mem_stats($ps, "proxyfuncs");
+    subtest 'loop checking for lua leak' => sub {
+        for (1 .. 500) {
+            $t->c_send("mg one|key t$_\r\n");
+            $t->be_recv_c(0);
+            $t->be_send(0, "EN\r\n");
+            $t->c_recv_be();
+        }
+    };
+    check_func_counts($ps, $func_before);
+}
+
+# Router has short and long prefix and anchored prefix modes
+sub test_separators {
+    subtest 'short separator' => sub {
+        $t->c_send("mg one|key t3\r\n");
+        $t->be_recv_c(0, 'backend received mg');
+        $t->be_send(0, "EN\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("mg one/found\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+
+    subtest 'long separator' => sub {
+        $t->c_send("ms one+#+foo 2\r\nhi\r\n");
+        $t->be_recv(0, "ms one+#+foo 2\r\n", 'backend received ms');
+        $t->be_recv(0, "hi\r\n", 'backend received data');
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("ms one+#found 2\r\nhi\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+
+    subtest 'short anchor' => sub {
+        $t->c_send("md _one,bar\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("md _one+nothing\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+
+    subtest 'long anchor' => sub {
+        $t->c_send("ma =?=one__key\r\n");
+        $t->be_recv_c(0, 'backend received ma');
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be();
+
+        $t->c_send("ma =?=one_nothing\r\n");
+        $t->c_recv("SERVER_ERROR default route\r\n", 'got default route');
+        $t->clear();
+    };
+}
+
+sub check_func_counts {
+    my $c = shift;
+    my $a = shift;
+    my $b = mem_stats($c, "proxyfuncs");
+    for my $key (keys %$a) {
+        # Don't want to pollute/slow down the output with tons of ok's here,
+        # so only fail on the fail conditions.
+        if (! exists $b->{$key}) {
+            fail("func stat gone missing: $key");
+        }
+        if ($a->{$key} != $b->{$key}) {
+            cmp_ok($b->{$key}, '==', $a->{$key}, "func stat for $key");
+        }
+    }
+}

--- a/t/proxytags.lua
+++ b/t/proxytags.lua
@@ -1,0 +1,28 @@
+-- get some information about the test being run from an external file
+-- so we can modify ourselves.
+local mode = dofile("/tmp/proxytagmode.lua")
+
+function mcp_config_pools()
+    -- we only ever need the one backend for this test.
+    -- we're explicitly not testing for changes in the backend, but that
+    -- routes are overwritten properly.
+    local be = mcp.backend('be', '127.0.0.1', 12050)
+    local p = mcp.pool({ be })
+    return p
+end
+
+function mcp_config_routes(p)
+    if mode == "start" then
+        -- one without tag
+        mcp.attach(mcp.CMD_MG, function(r) return p(r) end)
+        -- no listener on a
+        mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR tag A\r\n" end, "a")
+        -- listener on b
+        mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR tag B\r\n" end, "b")
+        -- extra listener.
+        mcp.attach(mcp.CMD_MG, function(r) return "SERVER_ERROR tag CCCC\r\n" end, "cccc")
+    end
+    -- TODO: reload to replace functions, ensure change.
+    -- TODO: mcp.CMD_ANY_STORAGE on reload
+    -- TODO: mcp.CMD_ANY_STORAGE and then replace a single CMD_MG
+end

--- a/t/proxytags.t
+++ b/t/proxytags.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $modefile = "/tmp/proxytagmode.lua";
+my $t = Memcached::ProxyTest->new(servers => [12050]);
+
+write_modefile('return "start"');
+my $p_srv = new_memcached('-l 127.0.0.1:12051 -l tag_b_:127.0.0.1:12052 -l tag_cccc_:127.0.0.1:12053 -o proxy_config=./t/proxytags.lua', 12051);
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+my $tagpsb = IO::Socket::INET->new(PeerAddr => "127.0.0.1:12052");
+my $tagpsc = IO::Socket::INET->new(PeerAddr => "127.0.0.1:12053");
+
+$t->set_c($ps);
+$t->accept_backends();
+
+{
+    test_basic();
+}
+
+done_testing();
+
+sub test_basic {
+    subtest 'untagged pass-thru' => sub {
+        $t->set_c($ps);
+        $t->c_send("mg foo t\r\n");
+        $t->be_recv_c(0, 'backend received pass-thru cmd');
+        $t->be_send(0, "HD t97\r\n");
+        $t->c_recv_be('client received pass-thru response');
+    };
+
+    subtest 'tag B works' => sub {
+        $t->set_c($tagpsb);
+        $t->c_send("mg bar t\r\n");
+        # No backend, looking for string response.
+        $t->c_recv("SERVER_ERROR tag B\r\n", 'received resp from tagged handler');
+    };
+
+    subtest 'tag CCCC works' => sub {
+        $t->set_c($tagpsc);
+        $t->c_send("mg baz t\r\n");
+        # No backend, looking for string response.
+        $t->c_recv("SERVER_ERROR tag CCCC\r\n", 'received resp from tagged handler');
+    };
+}
+
+sub write_modefile {
+    my $cmd = shift;
+    open(my $fh, "> $modefile") or die "Couldn't overwrite $modefile: $!";
+    print $fh $cmd;
+    close($fh);
+}
+
+sub wait_reload {
+    my $w = shift;
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=start/, "reload started");
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=done/, "reload completed");
+}
+
+END {
+    unlink $modefile;
+}


### PR DESCRIPTION
See #1085 for development history

See t/proxyfuncgen.lua for documentation on API changes.

See also https://github.com/memcached/memcached/wiki/Proxy

This change revolves around holding context during request execution. Previously the lua context simply "floated", being carried with a backend IO request when necessary and resumed during a later callback. It was not possible to know things for the full duration of a request. It was also not possible to hold references for the full duration of a request.

For example, previously when lua executes a request against a single pool (pool(req) syntax), the pool and request objects are held in the coroutine's execution stack, then the coroutine is suspended. This prevents the pool from being garbage collected while the request executes. Nothing else explicitly prevents this from happening.

Nor can we pre-allocate memory and request objects. In a typical request, at minimum:

- a coroutine thread is allocated
- a request object is allocated
- response objects are allocated
- any strings are allocated
- all of the above must later be garbage collected.

This can add up to a lot of CPU. Object creation is especially slow (setting metatables) and argument checking can get expensive. This puts a high floor on the CPU usage of a request. With pre-allocation it should be possible to run a request from start to finish with zero allocations (and thus zero garbage collection).

Further, the "async API" available via mcp.await was supposed to be a temporary workaround before making the API change available in this pull request. mcp.await is implemented by bolting itself over the existing system, with hacks to know when to resume the coroutine. Further, it creates even more allocations:

- the await tracking object
- a table to hold the response objects to be returned to lua

... and itself is limited. There is no way to execute callbacks, to execute different requests against different pools, to wait on specific pools, and so on.

Further, there is no way to compose a configuration as a directed graph, as was done with mcrouter and similar systems. Without this configurations are less composible, requiring significant code changes to do things like shadow traffic, pre-warm pools, and so on.

---

We now use a request context to track an incoming request until the response has been sent to the client. We use a pre-generation stage to allow pre-allocating objects, caching lookups, creating callback contexts, and so on. These pre-allocted request contexts and their associated functions are re-used until the configuration is reloaded and overwritten.

The new API allows for composing configurations as a directed graph, composing functions that can call either pools or other functions directly.