### PR TITLE
proxy: add global rate limiter

### DIFF
--- a/proxy_config.c
+++ b/proxy_config.c
@@ -78,7 +78,7 @@ int proxy_first_confload(void *arg) {
 // Manages a queue of inbound objects destined to be deallocated.
 static void *_proxy_manager_thread(void *arg) {
     proxy_ctx_t *ctx = arg;
-    pool_head_t head;
+    globalobj_head_t head;
 
     pthread_mutex_lock(&ctx->manager_lock);
     while (1) {
@@ -94,17 +94,10 @@ static void *_proxy_manager_thread(void *arg) {
         // Config lock is required for using config VM.
         pthread_mutex_lock(&ctx->config_lock);
         lua_State *L = ctx->proxy_state;
-        mcp_pool_t *p;
-        STAILQ_FOREACH(p, &head, next) {
-            // we let the pool object _gc() handle backend references.
-
-            luaL_unref(L, LUA_REGISTRYINDEX, p->phc_ref);
-            // need to... unref self.
-            // NOTE: double check if we really need to self-reference.
-            // this is a backup here to ensure the external refcounts hit zero
-            // before lua garbage collects the object. other things hold a
-            // reference to the object though.
-            luaL_unref(L, LUA_REGISTRYINDEX, p->self_ref);
+        struct mcp_globalobj_s *g;
+        STAILQ_FOREACH(g, &head, next) {
+            // we let the object _gc() handle backend/etc references
+            luaL_unref(L, LUA_REGISTRYINDEX, g->self_ref);
         }
         // force lua garbage collection so any resources close out quickly.
         lua_gc(L, LUA_GCCOLLECT);
@@ -268,7 +261,7 @@ int proxy_load_config(void *arg) {
 }
 
 static int _copy_pool(lua_State *from, lua_State *to, LIBEVENT_THREAD *thr) {
-    // from, -3 should have he userdata.
+    // from, -3 should have the userdata.
     mcp_pool_t *p = luaL_checkudata(from, -3, "mcp.pool");
     size_t size = sizeof(mcp_pool_proxy_t);
     mcp_pool_proxy_t *pp = lua_newuserdatauv(to, size, 0);
@@ -281,9 +274,9 @@ static int _copy_pool(lua_State *from, lua_State *to, LIBEVENT_THREAD *thr) {
         // allow 0 indexing for backends when unique to each worker thread
         pp->pool = &p->pool[thr->thread_baseid * p->pool_size];
     }
-    pthread_mutex_lock(&p->lock);
-    p->refcount++;
-    pthread_mutex_unlock(&p->lock);
+    pthread_mutex_lock(&p->g.lock);
+    p->g.refcount++;
+    pthread_mutex_unlock(&p->g.lock);
     return 0;
 }
 
@@ -307,6 +300,9 @@ static void _copy_config_table(lua_State *from, lua_State *to, LIBEVENT_THREAD *
                     const char *name = lua_tostring(from, -1);
                     if (strcmp(name, "mcp.pool") == 0) {
                         _copy_pool(from, to, thr);
+                        found = true;
+                    } else if (strcmp(name, "mcp.ratelim_global_tbf") == 0) {
+                        mcp_ratelim_proxy_tbf(from, to);
                         found = true;
                     }
                 }

--- a/proxy_ratelim.c
+++ b/proxy_ratelim.c
@@ -11,7 +11,62 @@ struct mcp_ratelim_tbf {
     int64_t last_update; // time in milliseconds
 };
 
+struct mcp_ratelim_global_tbf {
+    struct mcp_globalobj_s g;
+    struct mcp_ratelim_tbf tbf;
+};
+
 #define TIMEVAL_TO_MILLIS(n) (n.tv_usec / 1000 + n.tv_sec * (uint64_t)1000)
+
+// global config VM object GC
+int mcplib_ratelim_global_tbf_gc(lua_State *L) {
+    struct mcp_ratelim_global_tbf *lim = luaL_checkudata(L, 1, "mcp.ratelim_global_tbf");
+    assert(lim->g.refcount == 0);
+    pthread_mutex_destroy(&lim->g.lock);
+
+    // no other memory to directly free, just kill the mutex.
+    return 0;
+}
+
+// worker thread proxy object GC
+int mcplib_ratelim_proxy_tbf_gc(lua_State *L) {
+    struct mcp_ratelim_global_tbf **lim_p = luaL_checkudata(L, 1, "mcp.ratelim_proxy_tbf");
+    struct mcp_ratelim_global_tbf *lim = *lim_p;
+    proxy_ctx_t *ctx = PROXY_GET_THR_CTX(L);
+
+    // TODO: the third time we do this, should be easy to abstract into a library
+    // funtion covering this/pools/etc.
+    pthread_mutex_lock(&lim->g.lock);
+    lim->g.refcount--;
+    if (lim->g.refcount == 0) {
+        pthread_mutex_lock(&ctx->manager_lock);
+        STAILQ_INSERT_TAIL(&ctx->manager_head, &lim->g, next);
+        pthread_cond_signal(&ctx->manager_cond);
+        pthread_mutex_unlock(&ctx->manager_lock);
+    }
+    pthread_mutex_unlock(&lim->g.lock);
+
+    return 0;
+}
+
+int mcp_ratelim_proxy_tbf(lua_State *from, lua_State *to) {
+    // from, -3 should have the userdata.
+    struct mcp_ratelim_global_tbf *lim = luaL_checkudata(from, -3, "mcp.ratelim_global_tbf");
+    struct mcp_ratelim_global_tbf **lim_p = lua_newuserdatauv(to, sizeof(struct mcp_ratelim_global_tbf *), 0);
+    luaL_setmetatable(to, "mcp.ratelim_proxy_tbf");
+
+    *lim_p = lim;
+    pthread_mutex_lock(&lim->g.lock);
+    // self reference on our first up-reference.
+    if (lim->g.self_ref == 0) {
+        lua_pushvalue(from, -3); // copy the ratelim object
+        lim->g.self_ref = luaL_ref(from, LUA_REGISTRYINDEX); // pops
+    }
+    lim->g.refcount++;
+    pthread_mutex_unlock(&lim->g.lock);
+
+    return 0;
+}
 
 static lua_Integer _tbf_check(lua_State *L, char *key) {
     lua_Integer n = 0;
@@ -25,12 +80,8 @@ static lua_Integer _tbf_check(lua_State *L, char *key) {
     return n;
 }
 
-int mcplib_ratelim_tbf(lua_State *L) {
-    struct mcp_ratelim_tbf *lim = lua_newuserdatauv(L, sizeof(*lim), 0);
+static void _setup_tbf(lua_State *L, struct mcp_ratelim_tbf *lim) {
     struct timeval now;
-    memset(lim, 0, sizeof(*lim));
-    luaL_setmetatable(L, "mcp.ratelim_tbf");
-
     luaL_checktype(L, 1, LUA_TTABLE);
     lim->limit = _tbf_check(L, "limit");
     lim->fill_rate = _tbf_check(L, "fillrate");
@@ -40,20 +91,32 @@ int mcplib_ratelim_tbf(lua_State *L) {
     lim->bucket = lim->limit;
     gettimeofday(&now, NULL);
     lim->last_update = TIMEVAL_TO_MILLIS(now);
+}
+
+int mcplib_ratelim_tbf(lua_State *L) {
+    struct mcp_ratelim_tbf *lim = lua_newuserdatauv(L, sizeof(*lim), 0);
+    memset(lim, 0, sizeof(*lim));
+    luaL_setmetatable(L, "mcp.ratelim_tbf");
+
+    _setup_tbf(L, lim);
     return 1;
 }
 
-int mcplib_ratelim_tbf_call(lua_State *L) {
-    struct mcp_ratelim_tbf *lim = luaL_checkudata(L, 1, "mcp.ratelim_tbf");
-    luaL_checktype(L, 2, LUA_TNUMBER);
-    int take = lua_tointeger(L, 2);
-    struct timeval now;
-    uint64_t now_millis = 0;
-    uint64_t delta = 0;
+int mcplib_ratelim_global_tbf(lua_State *L) {
+    struct mcp_ratelim_global_tbf *lim = lua_newuserdatauv(L, sizeof(*lim), 0);
+    memset(lim, 0, sizeof(*lim));
+    // TODO: during next refactor, add "globalobj init" phase, which probably
+    // just does this.
+    pthread_mutex_init(&lim->g.lock, NULL);
+    luaL_setmetatable(L, "mcp.ratelim_global_tbf");
 
-    gettimeofday(&now, NULL);
-    now_millis = TIMEVAL_TO_MILLIS(now);
-    delta = now_millis - lim->last_update;
+    _setup_tbf(L, &lim->tbf);
+    return 1;
+}
+
+static int _update_tbf(struct mcp_ratelim_tbf *lim, int take, uint64_t now) {
+    uint64_t delta = 0;
+    delta = now - lim->last_update;
 
     if (delta > lim->tick_rate) {
         // find how many ticks to add to the bucket.
@@ -69,10 +132,51 @@ int mcplib_ratelim_tbf_call(lua_State *L) {
 
     if (lim->bucket > take) {
         lim->bucket -= take;
-        lua_pushboolean(L, 1);
+        return 1;
     } else {
-        lua_pushboolean(L, 0);
+        return 0;
     }
+}
 
+int mcplib_ratelim_tbf_call(lua_State *L) {
+    struct mcp_ratelim_tbf *lim = luaL_checkudata(L, 1, "mcp.ratelim_tbf");
+    luaL_checktype(L, 2, LUA_TNUMBER);
+    int take = lua_tointeger(L, 2);
+    struct timeval now;
+    uint64_t now_millis = 0;
+
+    gettimeofday(&now, NULL);
+    now_millis = TIMEVAL_TO_MILLIS(now);
+    lua_pushboolean(L, _update_tbf(lim, take, now_millis));
+
+    return 1;
+}
+
+// NOTE: it should be possible to run a TBF using atomics, in the future when
+// we start to support C11 atomics.
+// Flip the concept of checking the time, updating, then subtracting the take
+// to:
+// - how much "time elapsed" is necessary for the take requested
+// - atomically load the old time
+// - if not enough time delta between old time and now, return false
+// - else atomically swap the update time with the new time
+//   - compare and update the oldtime to newtime
+// - not sure how much perf this buys you. would have to test.
+int mcplib_ratelim_proxy_tbf_call(lua_State *L) {
+    struct mcp_ratelim_global_tbf **lim_p = luaL_checkudata(L, 1, "mcp.ratelim_proxy_tbf");
+    // line was kinda long / hard to read.
+    struct mcp_ratelim_global_tbf *lim = *lim_p;
+    struct timeval now;
+    luaL_checktype(L, 2, LUA_TNUMBER);
+    int take = lua_tointeger(L, 2);
+    gettimeofday(&now, NULL);
+    uint64_t now_millis = 0;
+    now_millis = TIMEVAL_TO_MILLIS(now);
+
+    pthread_mutex_lock(&lim->g.lock);
+    int res = _update_tbf(&lim->tbf, take, now_millis);
+    pthread_mutex_unlock(&lim->g.lock);
+
+    lua_pushboolean(L, res);
     return 1;
 }

--- a/t/proxyratelim.lua
+++ b/t/proxyratelim.lua
@@ -1,6 +1,7 @@
 
 function mcp_config_pools()
-    return {}
+    local tbf_global = mcp.ratelim_global_tbf({limit = 25, fillrate = 5, tickrate = 500})
+    return tbf_global
 end
 
 function mcp_config_routes(t)
@@ -9,11 +10,21 @@ function mcp_config_routes(t)
     -- tickrate is milliseconds
     local tbf = mcp.ratelim_tbf({limit = 50, fillrate = 4, tickrate = 500})
 
+    local tbf_global = t
+
     mcp.attach(mcp.CMD_MG, function(r)
         if tbf(15) then
             return "HD\r\n"
         else
             return "SERVER_ERROR slow down\r\n"
+        end
+    end)
+
+    mcp.attach(mcp.CMD_GET, function(r)
+        if tbf_global(10) then
+            return "END\r\n"
+        else
+            return "SERVER_ERROR global slow down\r\n"
         end
     end)
 end

--- a/t/proxyratelim.t
+++ b/t/proxyratelim.t
@@ -35,4 +35,21 @@ $ps->autoflush(1);
     is(scalar <$ps>, "HD\r\n", "not blocked after longer sleep");
 }
 
+{
+    my $x = 10;
+    while ($x--) {
+        print $ps "get na\r\n";
+        my $res = scalar <$ps>;
+        last if $res =~ m/SERVER_ERROR/;
+    }
+    cmp_ok($x, '>', 0, "global hit rate limit without trying too many times");
+    sleep 0.5;
+    print $ps "get na\r\n";
+    is(scalar <$ps>, "SERVER_ERROR global slow down\r\n", "global still blocked after short sleep");
+    sleep 3;
+    print $ps "get na\r\n";
+    is(scalar <$ps>, "END\r\n", "global not blocked after longer sleep");
+
+}
+
 done_testing();


### PR DESCRIPTION
If created during mcp_config_pools() and then passed into mcp_config_routes(), utilizes a centralized rate limiter.

TODO:
- [x] step through with debugger to validate the objects/proxies are correct
- [x] add self_ref code (during proxy setup?)
- [x] generalize the "manager" code used by pools for de-allocating pools
- [x] port pool and global ratelim to the general code.
- [x] add __gc routine for global_tbf so it can destroy its mutex.

waiting a few days then more code review/testing and merge.