### PR TITLE
fix: prevent giving negative number with -R, -m options

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -5145,7 +5145,7 @@ int main (int argc, char **argv) {
             break;
         case 'R':
             settings.reqs_per_event = atoi(optarg);
-            if (settings.reqs_per_event == 0) {
+            if (settings.reqs_per_event <= 0) {
                 fprintf(stderr, "Number of requests per event must be greater than 0\n");
                 return 1;
             }
@@ -5169,7 +5169,7 @@ int main (int argc, char **argv) {
             break;
         case 'n':
             settings.chunk_size = atoi(optarg);
-            if (settings.chunk_size == 0) {
+            if (settings.chunk_size <= 0) {
                 fprintf(stderr, "Chunk size must be greater than 0\n");
                 return 1;
             }


### PR DESCRIPTION
I think giving negative number when using -R, -m options rarely happens.
But, It makes the program behave abnormally.

Other options were written consistent with the log message like below.
```c
case 't':
    settings.num_threads = atoi(optarg);
    if (settings.num_threads <= 0) {
        fprintf(stderr, "Number of threads must be greater than 0\n");
        return 1;
    }
```
Only those two are different. Are those intentional?
