### PR TITLE
Proxy lua GC tuning

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -749,6 +749,10 @@ typedef struct {
     void *proxy_event_thread; // worker threads can also be proxy IO threads
     struct event *proxy_gc_timer; // periodic GC pushing.
     pthread_mutex_t proxy_limit_lock;
+    int proxy_vm_extra_kb;
+    int proxy_vm_last_kb;
+    int proxy_vm_gcrunning;
+    bool proxy_vm_needspoke;
     uint64_t proxy_active_req_limit;
     uint64_t proxy_buffer_memory_limit; // protected by limit_lock
     uint64_t proxy_buffer_memory_used; // protected by limit_lock

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -17,6 +17,7 @@ void proxy_start_reload(void *arg);
 int proxy_first_confload(void *arg);
 int proxy_load_config(void *arg);
 void proxy_worker_reload(void *arg, LIBEVENT_THREAD *thr);
+void proxy_gc_poke(LIBEVENT_THREAD *t);
 
 void proxy_submit_cb(io_queue_t *q);
 void proxy_complete_cb(io_queue_t *q);

--- a/thread.c
+++ b/thread.c
@@ -525,9 +525,16 @@ static void *worker_libevent(void *arg) {
     }
 
     register_thread_initialized();
-
+#ifdef PROXY
+    while (!event_base_got_exit(me->base)) {
+        event_base_loop(me->base, EVLOOP_ONCE);
+        if (me->proxy_ctx) {
+            proxy_gc_poke(me);
+        }
+    }
+#else
     event_base_loop(me->base, 0);
-
+#endif
     // same mechanism used to watch for all threads exiting.
     register_thread_initialized();
 


### PR DESCRIPTION
Tries to move the GC run from inline requests to outside of requests.

Passes tests but not benchmarked yet. Might not be interacting properly with the "GC Pause" tunable on when to actually kick off a GC.

Also avoids running GC during code reload and ignores memory allocated during code reload.

TODO:
 - [x] Change the old GCSTEP calls to instead increment `t->proxy_vm_extra` and add during poke
 - [x] Doesn't currently emulate the internal "GC pause" algorithm well, might end up using too much CPU. edit: seems fine.