### PR TITLE
core: add client flag to output of lru_crawler metadump

### DIFF
--- a/crawler.c
+++ b/crawler.c
@@ -268,17 +268,20 @@ static void crawler_metadump_eval(crawler_module_t *cm, item *it, uint32_t hv, i
         refcount_decr(it);
         return;
     }
+    client_flags_t flags;
+    FLAGS_CONV(it, flags);
     // TODO: uriencode directly into the buffer.
     uriencode(ITEM_key(it), keybuf, it->nkey, KEY_MAX_URI_ENCODED_LENGTH);
     int total = snprintf(cm->c.buf + cm->c.bufused, 4096,
-            "key=%s exp=%ld la=%llu cas=%llu fetch=%s cls=%u size=%lu\n",
+            "key=%s exp=%ld la=%llu cas=%llu fetch=%s cls=%u size=%lu flags=" CLIENT_FLAG_FORMAT_SPECIFIER "\n",
             keybuf,
             (it->exptime == 0) ? -1 : (long)(it->exptime + process_started),
             (unsigned long long)(it->time + process_started),
             (unsigned long long)ITEM_get_cas(it),
             (it->it_flags & ITEM_FETCHED) ? "yes" : "no",
             ITEM_clsid(it),
-            (unsigned long) ITEM_ntotal(it));
+            (unsigned long) ITEM_ntotal(it),
+            flags);
     refcount_decr(it);
     // TODO: some way of tracking the errors. these should be impossible given
     // the space requirements.

--- a/crawler.c
+++ b/crawler.c
@@ -273,7 +273,7 @@ static void crawler_metadump_eval(crawler_module_t *cm, item *it, uint32_t hv, i
     // TODO: uriencode directly into the buffer.
     uriencode(ITEM_key(it), keybuf, it->nkey, KEY_MAX_URI_ENCODED_LENGTH);
     int total = snprintf(cm->c.buf + cm->c.bufused, 4096,
-            "key=%s exp=%ld la=%llu cas=%llu fetch=%s cls=%u size=%lu flags=" CLIENT_FLAG_FORMAT_SPECIFIER "\n",
+            "key=%s exp=%ld la=%llu cas=%llu fetch=%s cls=%u size=%lu flags=%llu\n",
             keybuf,
             (it->exptime == 0) ? -1 : (long)(it->exptime + process_started),
             (unsigned long long)(it->time + process_started),

--- a/memcached.h
+++ b/memcached.h
@@ -95,9 +95,11 @@
 #ifdef LARGE_CLIENT_FLAGS
 typedef uint64_t client_flags_t;
 #define safe_strtoflags safe_strtoull
+#define CLIENT_FLAG_FORMAT_SPECIFIER "%llu"
 #else
 typedef uint32_t client_flags_t;
 #define safe_strtoflags safe_strtoul
+#define CLIENT_FLAG_FORMAT_SPECIFIER "%lu"
 #endif
 
 /*

--- a/memcached.h
+++ b/memcached.h
@@ -95,11 +95,9 @@
 #ifdef LARGE_CLIENT_FLAGS
 typedef uint64_t client_flags_t;
 #define safe_strtoflags safe_strtoull
-#define CLIENT_FLAG_FORMAT_SPECIFIER "%llu"
 #else
 typedef uint32_t client_flags_t;
 #define safe_strtoflags safe_strtoul
-#define CLIENT_FLAG_FORMAT_SPECIFIER "%lu"
 #endif
 
 /*


### PR DESCRIPTION
## Background
Add the client flag value stored in each item as part of the output produced by the `lru_crawler metadump` command. This will allow for a more complete re-creation of cache state from metadump output.

## Tests
Ensured all unit tests were still passing. Performed the following manual tests.
### Test 1: Large Client Flags Disabled
```python
mg test_key1 v c N100
VA 0 c1 W
ms test_key1 4 C1
data
HD
mg test_key2 v c N100
VA 0 c3 W
ms test_key2 5 C3
data4 
HD
lru_crawler metadump hash
key=test_key2 exp=-1 la=1708028539 cas=4 fetch=no cls=1 size=73 flags=0
key=test_key1 exp=-1 la=1708028519 cas=2 fetch=no cls=1 size=72 flags=0
END
ms test_key2 5 C4 F18446744073709551615 # 2^64 - 1
data4
HD
lru_crawler metadump hash
key=test_key2 exp=-1 la=1708028651 cas=5 fetch=no cls=1 size=77 flags=4294967295 # overflow
key=test_key1 exp=-1 la=1708028519 cas=2 fetch=no cls=1 size=72 flags=0
END
```
### Test 2: Large Client Flags Enabled
```python
mg test_key1 v c N100
VA 0 c1 W
ms test_key1 4 C1
data
HD
mg test_key2 v c N100
VA 0 c3 W
ms test_key2 5 C3
data4
HD
lru_crawler metadump hash
key=test_key2 exp=-1 la=1708029738 cas=4 fetch=no cls=1 size=73 flags=0
key=test_key1 exp=-1 la=1708029730 cas=2 fetch=no cls=1 size=72 flags=0
END
ms test_key2 5 C4 F18446744073709551615 # 2^64 - 1
data4
HD
lru_crawler metadump hash
key=test_key2 exp=-1 la=1708029746 cas=5 fetch=no cls=1 size=81 flags=18446744073709551615
key=test_key1 exp=-1 la=1708029730 cas=2 fetch=no cls=1 size=72 flags=0
END
```