### PR TITLE
HLC timer support for Proxy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,7 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_xxhash.c proxy.h \
 					 proxy_await.c proxy_ustats.c \
 					 proxy_ratelim.c \
+					 proxy_hlc.c proxy_hlc.h \
 					 proxy_jump_hash.c proxy_request.c \
 					 proxy_network.c proxy_lua.c \
 					 proxy_luafgen.c \

--- a/proxy.h
+++ b/proxy.h
@@ -32,6 +32,8 @@
 #define XXH_INLINE_ALL // modifier for xxh3's include below
 #include "xxhash.h"
 
+#include "proxy_hlc.h"
+
 #ifdef PROXY_DEBUG
 #define P_DEBUG(...) \
     do { \
@@ -40,6 +42,8 @@
 #else
 #define P_DEBUG(...)
 #endif
+
+#define TIMEVAL_TO_MILLIS(n) (n.tv_usec / 1000 + n.tv_sec * (uint64_t)1000)
 
 #define WSTAT_L(t) pthread_mutex_lock(&t->stats.mutex);
 #define WSTAT_UL(t) pthread_mutex_unlock(&t->stats.mutex);

--- a/proxy_config.c
+++ b/proxy_config.c
@@ -381,6 +381,9 @@ static void _copy_config_table(lua_State *from, lua_State *to, LIBEVENT_THREAD *
                     } else if (strcmp(name, "mcp.ratelim_global_tbf") == 0) {
                         mcp_ratelim_proxy_tbf(from, to);
                         found = true;
+                    } else if (strcmp(name, "mcp.global_hlc") == 0) {
+                        mcp_proxy_hlc(from, to);
+                        found = true;
                     }
                 }
                 lua_pop(from, 2);

--- a/proxy_hlc.c
+++ b/proxy_hlc.c
@@ -1,0 +1,304 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+// TODO: worth making counter vs opaque bits configurable?
+#define LOGICAL_BITS 15
+#define LOGICAL_MAX ((1<<15)-1)
+// can have 256 unique machines in a cluster
+#define OPAQUE_BITS 8
+
+// name: cas_hlc? time_hlc? order_hlc?
+struct mcp_hlc {
+    uint64_t physical_time; // last observed time in milliseconds
+    uint16_t logical_time; // logical clock counter.
+    uint8_t opaque; // opaque constant trailer
+};
+
+struct mcp_global_hlc {
+    struct mcp_globalobj_s g;
+    struct mcp_hlc t;
+};
+
+int mcplib_global_hlc_gc(lua_State *L) {
+    struct mcp_global_hlc *hlc = luaL_checkudata(L, 1, "mcp.global_hlc");
+    assert(hlc->g.refcount == 0);
+    pthread_mutex_destroy(&hlc->g.lock);
+
+    return 0;
+}
+
+int mcplib_proxy_hlc_gc(lua_State *L) {
+    struct mcp_global_hlc **hlc_p = luaL_checkudata(L, 1, "mcp.proxy_hlc");
+    struct mcp_global_hlc *hlc = *hlc_p;
+    proxy_ctx_t *ctx = PROXY_GET_THR_CTX(L);
+
+    pthread_mutex_lock(&hlc->g.lock);
+    hlc->g.refcount--;
+    if (hlc->g.refcount == 0) {
+        pthread_mutex_lock(&ctx->manager_lock);
+        STAILQ_INSERT_TAIL(&ctx->manager_head, &hlc->g, next);
+        pthread_cond_signal(&ctx->manager_cond);
+        pthread_mutex_unlock(&ctx->manager_lock);
+    }
+    pthread_mutex_unlock(&hlc->g.lock);
+
+    return 0;
+}
+
+// create the proxy object.
+int mcp_proxy_hlc(lua_State *from, lua_State *to) {
+    struct mcp_global_hlc *hlc = luaL_checkudata(from, -3, "mcp.global_hlc");
+    struct mcp_global_hlc **hlc_p = lua_newuserdatauv(to, sizeof(struct mcp_global_hlc *), 0);
+    luaL_setmetatable(to, "mcp.proxy_hlc");
+
+    *hlc_p = hlc;
+    pthread_mutex_lock(&hlc->g.lock);
+    // self reference on our first up-reference.
+    if (hlc->g.self_ref == 0) {
+        lua_pushvalue(from, -3); // copy the object
+        hlc->g.self_ref = luaL_ref(from, LUA_REGISTRYINDEX); // pops
+    }
+    hlc->g.refcount++;
+    pthread_mutex_unlock(&hlc->g.lock);
+
+    return 0;
+}
+
+int mcplib_global_hlc(lua_State *L) {
+    luaL_checktype(L, 1, LUA_TTABLE);
+    struct mcp_global_hlc *hlc = lua_newuserdatauv(L, sizeof(*hlc), 0);
+    memset(hlc, 0, sizeof(*hlc));
+
+    pthread_mutex_init(&hlc->g.lock, NULL);
+    luaL_setmetatable(L, "mcp.global_hlc");
+
+    if (lua_getfield(L, 1, "opaque") != LUA_TNIL) {
+        hlc->t.opaque = lua_tointeger(L, -1) & 0xFF;
+    }
+    lua_pop(L, 1); // pop value or nil.
+
+    return 1;
+}
+
+static int _hlc_time(struct mcp_global_hlc *hlc, lua_Integer *res, lua_Integer *opaque) {
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    uint64_t physical_time = TIMEVAL_TO_MILLIS(now);
+
+    // 64 bits to use.
+    // 41 MSB: time-millis
+    // 15 bit counter
+    // 8 bit opaque
+
+    pthread_mutex_lock(&hlc->g.lock);
+    *opaque = hlc->t.opaque;
+    // ALGORITHM:
+    // If now > last pt:
+    // - set logical to 1
+    // - assemble number, return value
+    // If now <= last pt:
+    // - increment logical
+    // If logical at max (1<<15 - 1) then return nil
+    if (physical_time > hlc->t.physical_time) {
+        hlc->t.physical_time = physical_time;
+        hlc->t.logical_time = 1;
+    } else {
+        // unlikely() would be nice here.
+        if (hlc->t.logical_time == LOGICAL_MAX) {
+            // Bail early because we couldn't make a new counter.
+            pthread_mutex_unlock(&hlc->g.lock);
+            return 0;
+        } else {
+            hlc->t.logical_time++;
+        }
+    }
+
+    // Assemble the clock and logical time together.
+    // We don't assemble with the OPAQUE here because we want to use all 64
+    // bits, and lua integers are signed 64bit. Thus we only have 63 bits
+    // usable unless we want to make user level numeric comparisons more
+    // difficult.
+    *res = (hlc->t.physical_time << LOGICAL_BITS) | hlc->t.logical_time;
+
+    pthread_mutex_unlock(&hlc->g.lock);
+
+    return 1;
+}
+
+// Function takes no inputs, returns a (likely) increasing time value
+int mcplib_proxy_hlc_time(lua_State *L) {
+    struct mcp_global_hlc **hlc_p = luaL_checkudata(L, 1, "mcp.proxy_hlc");
+    struct mcp_global_hlc *hlc = *hlc_p;
+
+    lua_Integer res = 0;
+    lua_Integer opaque = 0;
+
+    if (_hlc_time(hlc, &res, &opaque)) {
+        lua_pushinteger(L, res);
+        lua_pushinteger(L, opaque);
+        return 2;
+    } else {
+        lua_pushnil(L);
+        return 1;
+    }
+}
+
+// Render full time + opaque as a string and return it.
+// If a string is supplied, prepend the first character
+int mcplib_proxy_hlc_time_string(lua_State *L) {
+    char temp[22]; // space for 64bit num + a char + null 0
+    char *p = temp;
+    struct mcp_global_hlc **hlc_p = luaL_checkudata(L, 1, "mcp.proxy_hlc");
+    struct mcp_global_hlc *hlc = *hlc_p;
+    lua_Integer res = 0;
+    lua_Integer opaque = 0;
+
+    if (_hlc_time(hlc, &res, &opaque) == 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    if (lua_isstring(L, 2)) {
+        size_t len = 0;
+        const char *str = lua_tolstring(L, 1, &len);
+        if (len > 0) {
+            *p = str[0];
+            p++;
+        }
+    }
+
+    p = itoa_u64(((uint64_t)res << OPAQUE_BITS) | opaque, p);
+    *p = 0;
+    lua_pushstring(L, temp);
+
+    return 1;
+}
+
+// TODO: func that takes a string and splits it into hlc/opaque numbers
+
+int mcplib_proxy_hlc_add_to_req(lua_State *L) {
+    struct mcp_global_hlc **hlc_p = luaL_checkudata(L, 1, "mcp.proxy_hlc");
+    struct mcp_global_hlc *hlc = *hlc_p;
+    mcp_request_t *rq = luaL_checkudata(L, -1, "mcp.request");
+    char temp[22];
+    lua_Integer res = 0;
+    lua_Integer opaque = 0;
+
+    // Couldn't get a new time value, let caller know.
+    if (_hlc_time(hlc, &res, &opaque) == 0) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    char *p = temp;
+    p = itoa_u64(((uint64_t)res << OPAQUE_BITS) | opaque, p);
+    *p = 0;
+
+    // Find if we already have an E flag
+    int x = mcp_request_find_flag_index(rq, 'E');
+    if (x > 0) {
+        // can fail due to request being too long/etc.
+        if (mcp_request_render(rq, x, 'E', temp, p - temp) != 0) {
+            lua_pushboolean(L, 0);
+            return 1;
+        }
+    } else {
+        if (mcp_request_append(rq, 'E', temp, p - temp) != 0) {
+            lua_pushboolean(L, 0);
+            return 1;
+        }
+    }
+
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+// Note: not currently using the HLC object itself. We will need to use it if
+// I end up making the counter/opaque bits dynamic.
+int mcplib_proxy_hlc_get_from_res(lua_State *L) {
+    luaL_checkudata(L, 1, "mcp.proxy_hlc");
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    // res->buf and res->blen is the full response line.
+    // res->resp.rline and res->resp.rlen is the start and end of the "meta
+    // parameters" for flags/tokens.
+
+    // check for rline/rlen
+    if (r->resp.rlen) {
+        lua_Integer res = 0;
+        lua_Integer opaque = 0;
+        uint64_t time = 0;
+
+        // manually parse the string looking for 'cTOKEN'
+        const char *p = r->resp.rline;
+        const char *e = p + r->resp.rlen;
+        while (p != e) {
+            if (*p == ' ') {
+                // skip one space.
+                p++;
+            } else if (*p == 'c') {
+                // TODO: we need (soon) a strtoull that takes a length
+                if (safe_strtoull(p+1, &time)) {
+                    // doing the work directly inside the loop as I can't
+                    // think of a way of doing this without an extra branch
+                    // test outside of the loop, or a goto...
+                    opaque = time & 0xFF;
+                    time >>= OPAQUE_BITS;
+                    res = time;
+
+                    lua_pushinteger(L, res);
+                    lua_pushinteger(L, opaque);
+                    return 2;
+                }
+            } else {
+                // skip a flag/token
+                while (p != e && *p != ' ') {
+                    p++;
+                }
+            }
+        }
+    }
+
+    // got here because nothing found.
+    lua_pushnil(L);
+    return 1;
+}
+
+// Note: not currently using the HLC object itself. We will need to use it if
+// I end up making the counter/opaque bits dynamic.
+int mcplib_proxy_hlc_get_from_req(lua_State *L) {
+    luaL_checkudata(L, 1, "mcp.proxy_hlc");
+    mcp_request_t *rq = luaL_checkudata(L, -1, "mcp.request");
+    lua_Integer res = 0;
+    lua_Integer opaque = 0;
+
+    const char *token = NULL;
+    size_t len = 0;
+    int x = mcp_request_find_flag_token(rq, 'E', &token, &len);
+    if (x > 0) {
+        uint64_t time = 0;
+        // strtoull the string -> number
+        // then split off res from opaque and return both
+        if (safe_strtoull(token, &time)) {
+            // pull off the opaque value
+            opaque = time & 0xFF;
+            // shift res into place so lua won't eat the MSB.
+            time >>= OPAQUE_BITS;
+            res = time;
+
+            lua_pushinteger(L, res);
+            lua_pushinteger(L, opaque);
+            return 2;
+        } else {
+            // failed to parse a number.
+            lua_pushnil(L);
+            return 1;
+        }
+    } else {
+        // no flag found.
+        lua_pushnil(L);
+        return 1;
+    }
+
+    return 0;
+}

--- a/proxy_hlc.h
+++ b/proxy_hlc.h
@@ -1,0 +1,14 @@
+#ifndef PROXY_HLC_H
+#define PROXY_HLC
+
+int mcplib_global_hlc_gc(lua_State *L);
+int mcplib_proxy_hlc_gc(lua_State *L);
+int mcp_proxy_hlc(lua_State *from, lua_State *to);
+int mcplib_global_hlc(lua_State *L);
+int mcplib_proxy_hlc_time(lua_State *L);
+int mcplib_proxy_hlc_time_string(lua_State *L);
+int mcplib_proxy_hlc_add_to_req(lua_State *L);
+int mcplib_proxy_hlc_get_from_res(lua_State *L);
+int mcplib_proxy_hlc_get_from_req(lua_State *L);
+
+#endif

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1487,6 +1487,21 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {NULL, NULL}
     };
 
+    const struct luaL_Reg mcplib_global_hlc_m[] = {
+        {"__gc", mcplib_global_hlc_gc},
+        {NULL, NULL}
+    };
+
+    const struct luaL_Reg mcplib_proxy_hlc_m[] = {
+        {"__gc", mcplib_proxy_hlc_gc},
+        {"time", mcplib_proxy_hlc_time},
+        {"time_string", mcplib_proxy_hlc_time_string},
+        {"add_to_req", mcplib_proxy_hlc_add_to_req},
+        {"get_from_req", mcplib_proxy_hlc_get_from_req},
+        {"get_from_res", mcplib_proxy_hlc_get_from_res},
+        {NULL, NULL}
+    };
+
     const struct luaL_Reg mcplib_rcontext_m[] = {
         {"handle_set_cb", mcplib_rcontext_handle_set_cb},
         {"enqueue", mcplib_rcontext_enqueue},
@@ -1513,6 +1528,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"backend", mcplib_backend},
         {"add_stat", mcplib_add_stat},
         {"ratelim_global_tbf", mcplib_ratelim_global_tbf},
+        {"global_hlc", mcplib_global_hlc},
         {"stat_limit", mcplib_stat_limit},
         {"backend_connect_timeout", mcplib_backend_connect_timeout},
         {"backend_retry_timeout", mcplib_backend_retry_timeout},
@@ -1584,6 +1600,12 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         luaL_setfuncs(L, mcplib_ratelim_proxy_tbf_m, 0); // register methods
         lua_pop(L, 1);
 
+        luaL_newmetatable(L, "mcp.proxy_hlc");
+        lua_pushvalue(L, -1); // duplicate metatable.
+        lua_setfield(L, -2, "__index"); // mt.__index = mt
+        luaL_setfuncs(L, mcplib_proxy_hlc_m, 0); // register methods
+        lua_pop(L, 1);
+
         luaL_newmetatable(L, "mcp.rcontext");
         lua_pushvalue(L, -1); // duplicate metatable.
         lua_setfield(L, -2, "__index"); // mt.__index = mt
@@ -1632,6 +1654,12 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         lua_pushvalue(L, -1); // duplicate metatable.
         lua_setfield(L, -2, "__index"); // mt.__index = mt
         luaL_setfuncs(L, mcplib_ratelim_global_tbf_m, 0); // register methods
+        lua_pop(L, 1);
+
+        luaL_newmetatable(L, "mcp.global_hlc");
+        lua_pushvalue(L, -1); // duplicate metatable.
+        lua_setfield(L, -2, "__index"); // mt.__index = mt
+        luaL_setfuncs(L, mcplib_global_hlc_m, 0); // register methods
         lua_pop(L, 1);
 
         luaL_newlibtable(L, mcplib_f_config);

--- a/proxy_ratelim.c
+++ b/proxy_ratelim.c
@@ -16,8 +16,6 @@ struct mcp_ratelim_global_tbf {
     struct mcp_ratelim_tbf tbf;
 };
 
-#define TIMEVAL_TO_MILLIS(n) (n.tv_usec / 1000 + n.tv_sec * (uint64_t)1000)
-
 // global config VM object GC
 int mcplib_ratelim_global_tbf_gc(lua_State *L) {
     struct mcp_ratelim_global_tbf *lim = luaL_checkudata(L, 1, "mcp.ratelim_global_tbf");

--- a/t/proxyhlc.lua
+++ b/t/proxyhlc.lua
@@ -1,0 +1,39 @@
+
+function mcp_config_pools()
+    local hlc = mcp.global_hlc({ opaque = 127 })
+    local be = mcp.backend('b1', '127.0.0.1', 19211)
+    local p = mcp.pool({be})
+    return { hlc = hlc, p = p }
+end
+
+function mcp_config_routes(c)
+    local hlc = c.hlc
+    local p = c.p
+
+    local ms = mcp.funcgen_new()
+    local ms_h = ms:new_handle(p)
+    ms:ready({
+        f = function(rctx)
+            return function(r)
+                -- slap on a timer
+                hlc:add_to_req(r)
+                return rctx:enqueue_and_wait(r, ms_h)
+            end
+        end,
+    })
+
+    local mg = mcp.funcgen_new()
+    local mg_h = mg:new_handle(p)
+    mg:ready({
+        f = function(rctx)
+            return function(r)
+                local res = rctx:enqueue_and_wait(r, mg_h)
+                local time, opaque = hlc:get_from_res(res)
+                return res
+            end
+        end,
+    })
+
+    mcp.attach(mcp.CMD_MS, ms)
+    mcp.attach(mcp.CMD_MG, mg)
+end

--- a/t/proxyhlc.t
+++ b/t/proxyhlc.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $t = Memcached::ProxyTest->new(servers => [19211]);
+my $p_srv = new_memcached('-o proxy_config=./t/proxyhlc.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+subtest 'hlc pass through' => sub {
+    $t->c_send("ms foo 2\r\nhi\r\n");
+    $t->be_recv_like(0, qr/^ms foo 2 E[0-9]+/, "backend received client request");
+    $t->be_recv(0, "hi\r\n");
+    $t->be_send(0, "HD\r\n");
+    $t->c_recv_be("client received HD");
+
+    $t->c_send("mg foo c s\r\n");
+    $t->be_recv_c(0);
+    $t->be_send(0, "HD s2 c14335932268801950079\r\n");
+    $t->c_recv_be("client received HLC-like response");
+};
+
+# TODO:
+# - different flag ordering in request/response
+# - check that opaque is what we expect it to be both inbound/outbound
+# - check that two runs in a row gives an incrementing number
+# what else? not a lot of ways this can fail due to lack of inputs.
+
+done_testing();


### PR DESCRIPTION
While working on replication support for routelib, I want to:
- Be able to know if all N copies of an item across pools are the same.
- Have some useful information about when the items were stored and where they came from.
- Ensure that item identifiers are unique, allowing out of band repair decisions (LWW or delete/retry) if a copy is gone or missing.

For this, I want:
- A globally atomically incrementing value.
- This value reflects the time and which host stored the item
- This value cannot go backwards _per proxy instance_

### The problem with timestamps

- `REALTIME` clocks can go backwards on computers: often small microsecond or millisecond adjustments, and occasionally by whole seconds.
- `MONOTONIC` clocks will always go forward, but do not represent real time. They represent the uptime of the system or start time of a process, and will slowly drift out of sync.

Monotonic clocks are useful, but cannot easily be compared cross-machine and do not represent "real time" so we cannot "loosely order" lists of items or know when items were created.

### Hybrid Logical Clocks

HLC's are a well used pattern and can (as we'll show later) usefully be compressed to 64bits. UUID's could also solve this problem but are 128bits or longer.

We don't need or use (at least right now) the gossip synchronization part of HLC's. Instead we use them to do loose global ordering and strict local ordering.

In this case, an HLC is defined as:
1. 41 bits of epoch time at milisecond resolution (known as Physical Time)
2. 15 bits of logical counter
3. 8 bits of opaque (used as a machine identifier in a pool)

In the proxy we use `REALTIME` clock as the source for Physical Time. When a timestamp is requested we:

- Check if realtime milliseconds is higher than the last time we were called.
- If so, reset logical counter to 1
- Assemble the 64bit time and return upstream

If realtime is the same or has gone backwards:
- Increase the logical counter by 1
- Assemble the 64bit time and return upstream

If the logical counter would overflow:
- Return nil, causing an error upstream.

### Properties of the HLC

- Time cannot go backwards.
- The same time can be repeated 32767 times per millisecond before we throw an error.
- If NTP is being used properly time should not jump by huge values (rarely a full second, usually by milliseconds a few times per day)
- Thus the clock can continue to move forward when time temporarily moves backwards.

This gives us:
- If we have N copies of an item across N pools, and all three HLC values match, the items were set at the same time.
- If one of the copies is "newer" than other copies, but all copies have _the same opaque value_, we can guarantee the newest copy is the latest
- If one of the copies is "newer", but not all of the opaques match, we know that the data was set by multiple machines and cannot be trusted. See advanced notes below for repairing beyond an uncertainty window.

### Implementation via CAS

- Client flags are only 32bits.
- HLC's cannot reasonably fit in 32bits.
- Client flags are used for other things (compression flags, data encoding, or other such information)

However, our CAS value is a 64bit opaque. So long as a CAS value is generally increasing for the same item, it does not matter what the number is or if it's globally unique.

CAS ID's are generated per memcached node via a 64bit number, incrementing by one each time an item is updated. Thus CAS ID's across nodes cannot relate to each other. We also cannot set our own CAS.

### Setting our own CAS

- Add `E` flag to the meta protocol, which means "if operation is successful, use this value as your new CAS"
- This lets use set the HLC as the CAS value on a successful update of an item.
- The CAS feature continues to work as normal: if cas does not match exactly, the update will fail.
- If using "old CAS causes stale bit to be set" mode, this will still generally work since HLC's are generally always increasing, and a higher CAS value than requested will fail.

The CAS value is still _opaque_ and does NOT directly relate to an HLC. This leaves flexibility in the system for other kinds of data consistency models:

1. Set CAS from data row versions from source data.
2. Set CAS from a combination of row versions and CRC32
3. Different configurations of HLC
4. A global data versioner,
5. etc.

### HLC's in the proxy

HLC's are standard lua objects. They use a global data structure that is synchronized across all worker VM's in a proxy.
You can thus either have one HLC for all sets going through a proxy, or one HLC per namespace if the proxy handles many unrelated pools of data, or so on. Having many HLC's means more logical capacity for time errors.

### Advanced break-fix resolution

- If N copies of an item exists, but they do not have the same time and do not have the same opaque ID's, it's still possible to automatically repair the data if a 'time uncertainty window' is used.

Basically:
- We state that: we manage NTP carefully and observe that the clocks in a cluster cannot be more than 5 seconds apart. It takes a great deal of work to get very close (milliseconds), but multiple seconds can be done reasonably.
- Thus, if the opaque ID's do not match, but the "highest time" is more than 5 seconds newer than the next newest item, we can reasonably assume this is the latest write and repair the copies.


### TODO:

Time estimate: two days of work. Likely less.
- [x] Finish implementing HLC API (reading the data off of a request/response and appending the data to a request)
- [ ] Test suite for the lua HLC side
- [x] More tests for the CAS change
- [ ] Implement in routelib to kick the API's tires.
- [ ] Maybe: make bit amounts for logical / opaque selectable.