### PR TITLE
fix build on uclibc-ng

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -694,6 +694,7 @@ AC_CHECK_FUNCS(clock_gettime)
 AC_CHECK_FUNCS(preadv)
 AC_CHECK_FUNCS(pread)
 AC_CHECK_FUNCS(eventfd)
+AC_CHECK_FUNCS([pthread_setname_np],[AC_DEFINE(HAVE_PTHREAD_SETNAME_NP, 1, [Define to 1 if support pthread_setname_np])])
 AC_CHECK_FUNCS([accept4], [AC_DEFINE(HAVE_ACCEPT4, 1, [Define to 1 if support accept4])])
 AC_CHECK_FUNCS([getopt_long], [AC_DEFINE(HAVE_GETOPT_LONG, 1, [Define to 1 if support getopt_long])])
 

--- a/extstore.c
+++ b/extstore.c
@@ -119,7 +119,7 @@ struct store_engine {
 #define THR_NAME_MAXLEN 16
 static void thread_setname(pthread_t thread, const char *name) {
 assert(strlen(name) < THR_NAME_MAXLEN);
-#if defined(__linux__)
+#if defined(__linux__) && defined(HAVE_PTHREAD_SETNAME_NP)
 pthread_setname_np(thread, name);
 #endif
 }

--- a/thread.c
+++ b/thread.c
@@ -677,7 +677,7 @@ static void thread_libevent_process(evutil_socket_t fd, short which, void *arg) 
 #define THR_NAME_MAXLEN 16
 void thread_setname(pthread_t thread, const char *name) {
 assert(strlen(name) < THR_NAME_MAXLEN);
-#if defined(__linux__)
+#if defined(__linux__) && defined(HAVE_PTHREAD_SETNAME_NP)
 pthread_setname_np(thread, name);
 #endif
 }


### PR DESCRIPTION
Fix the following build failure with uclibc-ng raised since version 1.6.18 and https://github.com/memcached/memcached/commit/875371a75cbf1f92350de2d1fa0fae4a35ed572b:

```
/home/buildroot/autobuild/instance-2/output-1/host/lib/gcc/arc-buildroot-linux-uclibc/10.2.0/../../../../arc-buildroot-linux-uclibc/bin/ld: memcached-thread.o: in function `thread_setname':
thread.c:(.text+0xea2): undefined reference to `pthread_setname_np'
```

Fixes:
 - http://autobuild.buildroot.org/results/e856d381f5ec7d2727f21c8bd46dacb456984416