### PR TITLE
proxy: allow early freeing rcontexts

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -640,23 +640,25 @@ struct mcp_funcgen_router {
     int map_ref;
 };
 
+#define FGEN_NAME_MAXLEN 80
 struct mcp_funcgen_s {
     LIBEVENT_THREAD *thread; // worker thread that created this funcgen.
     int generator_ref; // reference to the generator function.
     int self_ref; // self-reference if we're attached anywhere
     int argument_ref; // reference to an argument to pass to generator
-    int name_ref; // reference to string name for the generator
     int max_queues; // how many queue slots rctx's have
     unsigned int refcount; // reference counter
     unsigned int total; // total contexts managed
     unsigned int free; // free contexts
     unsigned int free_max; // size of list below.
+    unsigned int free_pressure; // "pressure" for when to early release rctx
     unsigned int routecount; // total routes if this fgen is a router.
     bool closed; // the hook holding this fgen has been replaced
     bool ready; // if we're locked down or not.
     mcp_rcontext_t **list;
     struct mcp_rqueue_s *queue_list;
     struct mcp_funcgen_router router;
+    char name[FGEN_NAME_MAXLEN+1]; // string name for the generator.
 };
 
 #define RQUEUE_TYPE_NONE 0
@@ -691,6 +693,7 @@ struct mcp_rqueue_s {
 };
 
 struct mcp_rcontext_s {
+    int self_ref; // reference to our own object
     int request_ref; // top level request for this context.
     int function_ref; // ref to the created route function.
     int coroutine_ref; // ref to our encompassing coroutine.

--- a/proxy_config.c
+++ b/proxy_config.c
@@ -234,6 +234,12 @@ int proxy_load_config(void *arg) {
     db->buf = malloc(db->size);
     lua_dump(L, _dump_helper, db, 0);
     // 0 means no error.
+    if (ctx->proxy_code) {
+        struct _dumpbuf *old = ctx->proxy_code;
+        free(old->buf);
+        free(old);
+        ctx->proxy_code = NULL;
+    }
     ctx->proxy_code = db;
 
     // now we complete the data load by calling the function.

--- a/t/proxyslotcache.lua
+++ b/t/proxyslotcache.lua
@@ -1,0 +1,51 @@
+function mcp_config_pools()
+    -- print("CONFIG GARBAGE: " .. collectgarbage("count"))
+    local b1 = mcp.backend('b1', '127.0.0.1', 12101)
+    return mcp.pool({b1})
+end
+
+-- the same fgen should be fine for the whole test. it doesn't matter how
+-- complicated each individual fgen is, just that we're stacking them and
+-- routing them.
+-- Even with just one item linked they'll have all of the request/result/etc
+-- objects referenced.
+function basic_fgen(p)
+    local fgen = mcp.funcgen_new()
+    local h = fgen:new_handle(p)
+    fgen:ready({ n = "foo", f = function(rctx)
+        return function(r)
+            local k = r:key()
+
+            if string.find(k, "collect$") then
+                collectgarbage()
+                collectgarbage()
+                local mem = collectgarbage("count")
+                return "SERVER_ERROR " .. tostring(mem) .. "\r\n"
+            elseif string.find(k, "go$") then
+                return rctx:enqueue_and_wait(r, h)
+            else
+                return "SERVER_ERROR unknown key: " .. k .. "\r\n"
+            end
+        end
+    end})
+    return fgen
+end
+
+function mcp_config_routes(p)
+    local map = {
+        ["one"] = basic_fgen(p),
+        ["two"] = basic_fgen(basic_fgen(p)),
+        ["three"] = basic_fgen(basic_fgen(basic_fgen(p))),
+    }
+    -- "leak" an fgen on purpose.
+    -- this gets a cleanup routine through the GC instead of directly during
+    -- dereferencing.
+    basic_fgen(p)
+
+    -- defaults are fine. "prefix/etc"
+    local router = mcp.router_new({
+        map = map,
+    })
+
+    mcp.attach(mcp.CMD_MG, router)
+end

--- a/t/proxyslotcache.t
+++ b/t/proxyslotcache.t
@@ -1,0 +1,185 @@
+#!/usr/bin/env perl
+# Check funcgen and memory accounting.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up the listeners _before_ starting the proxy.
+# the fourth listener is only occasionally used.
+my $t = Memcached::ProxyTest->new(servers => [12101]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyslotcache.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+sub get_mem {
+    $t->c_send("mg one/collect\r\n");
+    # TODO: func to just read the client data back out?
+    my $mem = scalar <$ps>;
+    like($mem, qr/^SERVER_ERROR \d+/, "got garbage size back");
+    # get the beginning total memory usage
+    $mem =~ s/^SERVER_ERROR (\d+).+$/$1/s;
+
+    return $mem;
+}
+
+sub slot_test {
+    my $prefix = shift;
+    my $etotal = shift; # expected slot total
+
+    my $mem_start = get_mem();
+    my $cmd = "mg $prefix/go N50\r\n";
+    my $fcmd = '';
+    my $cnt = 100;
+    for (1 .. $cnt) {
+        $fcmd .= $cmd;
+    }
+    $t->c_send($fcmd);
+    # first receive all requests but don't send responses to ensure all
+    # coroutines are generated.
+    for (1 .. $cnt) {
+        $t->be_recv(0, $cmd, "received request $_");
+    }
+    ok("received all requests");
+    for (1 .. $cnt) {
+        $t->be_send(0, "HD\r\n");
+    }
+    # once all responses are received the client gets woken up again.
+    for (1 .. $cnt) {
+        $t->c_recv_be("received response $_");
+    }
+    $t->clear();
+
+    my $stats = mem_stats($ps, "proxyfuncs");
+    is($stats->{funcs_foo}, 6, "six total function");
+    is($stats->{slots_foo}, $etotal, "$etotal total slots in use");
+    my $mem_middle = get_mem();
+    cmp_ok($mem_start * 1.5, '<', $mem_middle, "memory usage grew a bit: $mem_start - $mem_middle");
+
+    # run some non-pipelined requests and check that slots are still max
+    for (1 .. 50) {
+        $t->c_send("mg $prefix/go C$_\r\n");
+        $t->be_recv_c(0, "received request $_");
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be("received response $_");
+    }
+
+    $stats = mem_stats($ps, "proxyfuncs");
+    is($stats->{funcs_foo}, 6, "after batch: six total function");
+    is($stats->{slots_foo}, $etotal, "after batch: $etotal total slots in use");
+
+    # run some more and check that slots have dropped
+    for (1 .. 100) {
+        $t->c_send("mg $prefix/go C$_\r\n");
+        $t->be_recv_c(0, "received request $_");
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be("received response $_");
+    }
+
+    $stats = mem_stats($ps, "proxyfuncs");
+    is($stats->{funcs_foo}, 6, "after batch 2: six total function");
+    cmp_ok($stats->{slots_foo}, '<', $etotal, "after batch 2: fewer total slots in use");
+    cmp_ok($stats->{slots_foo}, '>', 1, "after batch 2: ... but more than one slot");
+
+    # run enough to drop below 1 and check that it's 1
+    for (1 .. (12 * $cnt)) {
+        $t->c_send("mg $prefix/go C$_\r\n");
+        $t->be_recv_c(0, "received request $_");
+        $t->be_send(0, "HD\r\n");
+        $t->c_recv_be("received response $_");
+    }
+
+    $stats = mem_stats($ps, "proxyfuncs");
+    is($stats->{funcs_foo}, 6, "final batch: six total function");
+    # algorithm will reduce slot cache count down to 2, not one. so we have
+    # one more slot than functions.
+    is($stats->{slots_foo}, 6, "final batch: 6 slots");
+    my $mem_end = get_mem();
+    cmp_ok($mem_start * 1.5, '>', $mem_end, "memory usage dropped back: $mem_start - $mem_end");
+
+}
+
+# minimum slot count is 6.
+# "two" is two total slots per top level slot.
+# "three" is three total slots per top level slot"
+# so "three" * 100 + 3 extra base slots from two and one being unused
+# ... is where that weird 303 comes from.
+subtest 'excess slot freeing depth 1' => sub {
+    slot_test("one", 105);
+};
+
+subtest 'excess slot freeing depth 2' => sub {
+    slot_test("two", 204);
+};
+
+subtest 'excess slot freeing depth 3' => sub {
+    slot_test("three", 303);
+};
+
+sub wait_reload {
+    my $w = shift;
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=start/, "reload started");
+    like(<$w>, qr/ts=(\S+) gid=\d+ type=proxy_conf status=done/, "reload completed");
+}
+
+# reload a bunch of times and check that the proxyfuncs slots aren't
+# leaking and the total memory usage isn't consistently creeping up
+subtest 'reload memory leaks' => sub {
+    my $mem_start = get_mem();
+    my $watcher = $p_srv->new_sock;
+    print $watcher "watch proxyevents\n";
+    is(<$watcher>, "OK\r\n", "watcher enabled");
+
+    my $mem_end = 0;
+    my $mem_end_last = 0;
+    for (1 .. 20) {
+        my $cmd = "mg three/go N50\r\n";
+        my $fcmd = '';
+        my $cnt = 100;
+        for (1 .. $cnt) {
+            $fcmd .= $cmd;
+        }
+        $t->c_send($fcmd);
+        for (1 .. $cnt) {
+            $t->be_recv(0, $cmd, "received request $_");
+            $t->be_send(0, "HD\r\n");
+        }
+        for (1 .. $cnt) {
+            $t->c_recv_be("received response $_");
+        }
+
+        $p_srv->reload();
+        wait_reload($watcher);
+        # start tracking end memory after looping once.
+        my $mem_end = get_mem();
+        if ($mem_end_last) {
+            is($mem_end, $mem_end_last, "post-collect $_: $mem_end is the same");
+        }
+        $mem_end_last = $mem_end;
+    }
+
+    $mem_end = get_mem();
+
+    cmp_ok($mem_end, '<', $mem_start * 2, "memory didn't bloat");
+    my $stats = mem_stats($ps, "proxyfuncs");
+    is($stats->{funcs_foo}, 6, "post reload: function count");
+    is($stats->{slots_foo}, 6, "post reload: slot count matches func count");
+};
+
+done_testing();


### PR DESCRIPTION
Any allocated request context would stay in memory attached to its function generator until the next reload, which would replace the function generators. A replaced fgen would eventually run out of attach references and cleanup itself, removing all rcontexts.

A one-time burst of concurrent request contexts would thus take up memory forever. With this change we use an easing function to slowly free unneeded request contexts.

This can help for both memory usage scenarios and instances where the GC is still used in the request path and tail latency can become poor.

TODO:

- [x] Need specific tests.

There aren't tests monitoring `stats proxyfuncs` so something specific to this is probably necessary. We need to validate it across reloads and during various easing scenarios after temporary concurrent blasts.

Should be easier to test concurrency via pipelined requests than doing lots of client sockets. Numbers don't have to be huge they just have to be at least a few and then drop back down after many non-concurrent requests.

- [x] add slot bloating to the reload test

Should make a memory leak related to said cleanup more obvious.