### PR TITLE
meta: md with I and x removes value

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -830,6 +830,7 @@ The flags used by the 'md' command are:
 - O(token): opaque to copy back.
 - q: noreply
 - T(token): updates TTL, only when paired with the 'I' flag
+- x: removes the item value, but leaves the item.
 
 The flags are now repeated with detailed information where useful:
 
@@ -857,6 +858,12 @@ response lines with the code "DE". It will still return any other responses.
 When marking an item as stale with 'I', the 'T' flag can be used to update the
 TTL as well; limiting the amount of time an item will live while stale and
 waiting to be recached.
+
+- x: removes the item value, but leaves the item.
+
+This deletes the value off of an item (by replacing it with an empty value
+item atomically). Combined with I this can leave what is effectively a
+tombstone of a previous value.
 
 Meta Arithmetic
 ---------------


### PR DESCRIPTION
If `md` is given the `I` flag _and_ `x` flags it will mark stale and
remove the value, but leave the item.

This allows the user to create a tombstone of a previous value with a
new TTL.

TODO:

- [ ] Update `doc/protocol.txt`
- [x] Decide if this should _require_ `I` or work independently of it.