### PR TITLE
Add a couple of sanity checks

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -2482,7 +2482,7 @@ static enum try_read_result try_read_network(conn *c) {
     assert(c != NULL);
 
     if (c->rcurr != c->rbuf) {
-        if (c->rbytes != 0) /* otherwise there's nothing to copy */
+        if (c->rbytes > 0) /* otherwise there's nothing to copy */
             memmove(c->rbuf, c->rcurr, c->rbytes);
         c->rcurr = c->rbuf;
     }
@@ -6215,6 +6215,10 @@ int main (int argc, char **argv) {
         if (portnumber_filename != NULL) {
             len = strlen(portnumber_filename)+4+1;
             temp_portnumber_filename = malloc(len);
+            if (temp_portnumber_filename == NULL) {
+                vperror("Failed to allocate memory for portnumber file");
+                exit(EX_OSERR);
+            }
             snprintf(temp_portnumber_filename,
                      len,
                      "%s.lck", portnumber_filename);

--- a/proto_bin.c
+++ b/proto_bin.c
@@ -737,7 +737,7 @@ static void process_bin_sasl_auth(conn *c) {
 
     assert(c->binary_header.request.extlen == 0);
 
-    int nkey = c->binary_header.request.keylen;
+    uint16_t nkey = c->binary_header.request.keylen;
     int vlen = c->binary_header.request.bodylen - nkey;
 
     if (nkey > MAX_SASL_MECH_LEN) {
@@ -776,7 +776,7 @@ static void process_bin_complete_sasl_auth(conn *c) {
     assert(c->item);
     init_sasl_conn(c);
 
-    int nkey = c->binary_header.request.keylen;
+    uint16_t nkey = c->binary_header.request.keylen;
     int vlen = c->binary_header.request.bodylen - nkey;
 
     if (nkey > ((item*) c->item)->nkey) {
@@ -1082,7 +1082,7 @@ static void dispatch_bin_command(conn *c, char *extbuf) {
 
 static void process_bin_update(conn *c, char *extbuf) {
     char *key;
-    int nkey;
+    uint16_t nkey;
     int vlen;
     item *it;
     protocol_binary_request_set* req = (void *)extbuf;
@@ -1191,7 +1191,7 @@ static void process_bin_update(conn *c, char *extbuf) {
 
 static void process_bin_append_prepend(conn *c) {
     char *key;
-    int nkey;
+    uint16_t nkey;
     int vlen;
     item *it;
 


### PR DESCRIPTION
 - Handle failure in `malloc()` for temp port number file initialization to avoid NULL pointer de-referencing
 - Ensure value of `c->rbytes` (which is `int` type) is positive before using it in memmove, which implicitly cast it into `size_t`. This avoids undesired behavior if the value of `c->rbytes` is negative.
 - Avoid implicit conversion of unsigned int to signed int for `keylen` in `proto_bin.c`