### PR TITLE
proxy: `stats proxybe` to show bad backends

### DIFF
--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -4,6 +4,7 @@
 void proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
 void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
 void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c);
+void process_proxy_bestats(void *arg, ADD_STAT add_stats, conn *c);
 
 /* proxy mode handlers */
 int try_read_command_proxy(conn *c);

--- a/proto_text.c
+++ b/proto_text.c
@@ -806,6 +806,8 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
         process_proxy_stats(settings.proxy_ctx, &append_stats, c);
     } else if (strcmp(subcommand, "proxyfuncs") == 0) {
         process_proxy_funcstats(settings.proxy_ctx, &append_stats, c);
+    } else if (strcmp(subcommand, "proxybe") == 0) {
+        process_proxy_bestats(settings.proxy_ctx, &append_stats, c);
 #endif
     } else {
         /* getting here means that the subcommand is either engine specific or

--- a/proxy.h
+++ b/proxy.h
@@ -104,6 +104,7 @@ struct mcp_memprofile {
 
 #define SHAREDVM_FGEN_IDX 1
 #define SHAREDVM_FGENSLOT_IDX 2
+#define SHAREDVM_BACKEND_IDX 3
 
 // all possible commands.
 #define CMD_FIELDS \
@@ -556,6 +557,7 @@ typedef struct {
 // utils
 bool proxy_bufmem_checkadd(LIBEVENT_THREAD *t, int len);
 void mcp_sharedvm_delta(proxy_ctx_t *ctx, int tidx, const char *name, int delta);
+void mcp_sharedvm_remove(proxy_ctx_t *ctx, int tidx, const char *name);
 
 // networking interface
 void proxy_init_event_thread(proxy_event_thread_t *t, proxy_ctx_t *ctx, struct event_base *base);

--- a/t/proxybestats.lua
+++ b/t/proxybestats.lua
@@ -1,0 +1,18 @@
+function mcp_config_pools()
+    mcp.backend_read_timeout(0.25)
+    mcp.backend_connect_timeout(0.5)
+    mcp.backend_failure_limit(1)
+    mcp.backend_retry_waittime(0.5) -- fast retry for test
+    local b1 = mcp.backend('b1', '127.0.0.1', 12131)
+    local b2 = mcp.backend('b2', '127.0.0.1', 12132)
+    local b3 = mcp.backend('b3', '127.0.0.1', 12133)
+    return mcp.pool({b1, b2, b3})
+end
+
+-- not making requests, just opening/closing backends
+function mcp_config_routes(p)
+    pool = p -- stash this in a global.
+    mcp.attach(mcp.CMD_MG, function(r)
+        return "SERVER_ERROR nothing\r\n"
+    end)
+end

--- a/t/proxybestats.t
+++ b/t/proxybestats.t
@@ -1,0 +1,66 @@
+#!/usr/bin/env perl
+# Check funcgen and memory accounting.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $t = Memcached::ProxyTest->new(servers => [12131, 12132, 12133]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxybestats.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+subtest 'cause bad backends' => sub {
+    my $s = mem_stats($ps, "proxybe");
+    is(keys %$s, 0, "no bad backends");
+
+    $t->close_backend(0);
+    # wait for retry to mark it bad.
+    sleep 1;
+    $s = mem_stats($ps, "proxybe");
+    is($s->{bad_b1}, 1, "b1 is now bad");
+
+    # Could have multiple sockets queued as the proxy retries. We can get all
+    # the way through read validation then not know if the socket was closed
+    # until the _next_ time we read from it.
+    # So we can either try to read and accept in a loop, or keep checking if
+    # there's a conn waiting to be accepted.
+    while ($t->srv_accept_waiting(0, 1)) {
+        $t->accept_backend(0);
+    }
+    $s = mem_stats($ps, "proxybe");
+    is(keys %$s, 0, "no bad backends anymore");
+
+    $t->close_backend(1);
+    $t->close_backend(2);
+    sleep 1;
+    $s = mem_stats($ps, "proxybe");
+    is($s->{bad_b2}, 1, "b2 is now bad");
+    is($s->{bad_b3}, 1, "b3 is now bad");
+    for (1 .. 2) {
+        while ($t->srv_accept_waiting($_, 1)) {
+            $t->accept_backend($_);
+        }
+    }
+    $s = mem_stats($ps, "proxybe");
+    is(keys %$s, 0, "no bad backends anymore");
+
+};
+
+done_testing();


### PR DESCRIPTION
stats command intended for backend state information.

so far just outputs "bad_label" [count] for each backend currently marked bad. The count is the number of backend objects marked bad.

If in "per worker thread mode" (default) if all workers recognize the backend as down, the count will be the same as the number of worker threads. If the IO thread is in use it would be 1.

If a backend has normal status, it is not included in the output.

TODO:
- [x] was hand testing.. need a specific unit test.