### PR TITLE
proxy: wait timeout API

### DIFF
--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -2,10 +2,6 @@
 
 #include "proxy.h"
 
-// sad, I had to look this up...
-#define NANOSECONDS(x) ((x) * 1E9 + 0.5)
-#define MICROSECONDS(x) ((x) * 1E6 + 0.5)
-
 // func prototype example:
 // static int fname (lua_State *L)
 // normal library open:
@@ -1588,6 +1584,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"res_any", mcplib_rcontext_res_any},
         {"result", mcplib_rcontext_result},
         {"cfd", mcplib_rcontext_cfd},
+        //{"sleep", mcplib_rcontext_sleep}, see comments on function
         {NULL, NULL}
     };
 

--- a/t/proxyrctxtimeout.lua
+++ b/t/proxyrctxtimeout.lua
@@ -1,0 +1,179 @@
+function mcp_config_pools()
+    local b1 = mcp.backend('b1', '127.0.0.1', 12141)
+    local b2 = mcp.backend('b2', '127.0.0.1', 12142)
+    local b3 = mcp.backend('b3', '127.0.0.1', 12143)
+
+    return {
+        z1 = mcp.pool({b1}),
+        z2 = mcp.pool({b2}),
+        z3 = mcp.pool({b3})
+    }
+end
+
+function cond_timeout(p)
+    local fgen = mcp.funcgen_new()
+    local near = fgen:new_handle(p.z1)
+    local far = { fgen:new_handle(p.z2),
+        fgen:new_handle(p.z3) }
+
+    local all = { near, far[1], far[2] }
+
+    fgen:ready({ n = "cond_timeout", f = function(rctx)
+        return function(r)
+            rctx:enqueue(r, near)
+            local done, timeout = rctx:wait_cond(1, mcp.WAIT_GOOD, 0.5)
+
+            if timeout then
+                rctx:enqueue(r, far)
+                local done = rctx:wait_cond(1, mcp.WAIT_GOOD)
+                for x=1,#all do
+                    local res = rctx:res_any(all[x])
+                    if res then
+                        return res
+                    end
+                end
+                return "SERVER_ERROR no responses\r\n"
+            else
+                return rctx:res_any(near)
+            end
+        end
+    end})
+    return fgen
+end
+
+function enqueue_timeout(p)
+    local fgen = mcp.funcgen_new()
+    local near = fgen:new_handle(p.z1)
+    local far = { fgen:new_handle(p.z2),
+        fgen:new_handle(p.z3) }
+
+    local all = { near, far[1], far[2] }
+    fgen:ready({ n = "enqueue_timeout", f = function(rctx)
+        return function(r)
+            local nres, timeout = rctx:enqueue_and_wait(r, near, 0.5)
+
+            if timeout then
+                rctx:enqueue(r, far)
+                local done = rctx:wait_cond(1, mcp.WAIT_GOOD)
+                for x=1,#all do
+                    local res = rctx:res_any(all[x])
+                    if res then
+                        return res
+                    end
+                end
+                return "SERVER_ERROR no responses\r\n"
+            else
+                return nres
+            end
+        end
+    end})
+    return fgen
+end
+
+function wait_handle_timeout(p)
+    local fgen = mcp.funcgen_new()
+    local near = fgen:new_handle(p.z1)
+    local far = { fgen:new_handle(p.z2),
+        fgen:new_handle(p.z3) }
+
+    local all = { near, far[1], far[2] }
+    fgen:ready({ n = "handle_timeout", f = function(rctx)
+        return function(r)
+            rctx:enqueue(r, near)
+            local nres, timeout = rctx:wait_handle(near, 0.5)
+
+            if timeout then
+                rctx:enqueue(r, far)
+                local done = rctx:wait_cond(1, mcp.WAIT_GOOD)
+                for x=1,#all do
+                    local res = rctx:res_any(all[x])
+                    if res then
+                        return res
+                    end
+                end
+                return "SERVER_ERROR no responses\r\n"
+            else
+                return nres
+            end
+        end
+    end})
+    return fgen
+end
+
+function wait_more(p)
+    local fgen = mcp.funcgen_new()
+    local near = fgen:new_handle(p.z1)
+
+    fgen:ready({ n = "wait_more", f = function(rctx)
+        return function(r)
+            rctx:enqueue(r, near)
+            local nres, timeout = rctx:wait_handle(near, 0.25)
+
+            -- wait on the same handle twice.
+            if timeout then
+                local xres = rctx:wait_handle(near)
+                return xres
+            else
+                return "SERVER_ERROR no timeout\r\n"
+            end
+        end
+    end})
+    return fgen
+end
+
+function wait_double(p)
+    local fgen = mcp.funcgen_new()
+    local near = fgen:new_handle(p.z1)
+
+    fgen:ready({ n = "wait_double", f = function(rctx)
+        return function(r)
+            rctx:enqueue(r, near)
+            -- timeout via sleep twice, then continue to function.
+            local nres, timeout = rctx:wait_handle(near, 0.1)
+            nres, timeout = rctx:wait_handle(near, 0.1)
+
+            -- wait on the same handle twice.
+            if timeout then
+                local xres = rctx:wait_handle(near)
+                return xres
+            else
+                return "SERVER_ERROR no timeout\r\n"
+            end
+        end
+    end})
+    return fgen
+end
+
+function rctx_sleep(p)
+    local fgen = mcp.funcgen_new()
+    local near = fgen:new_handle(p.z1)
+
+    fgen:ready({ n = "sleep", f = function(rctx)
+        return function(r)
+            rctx:sleep(0.5)
+            local nres = rctx:enqueue_and_wait(r, near)
+            return nres
+        end
+    end})
+    return fgen
+end
+
+-- TODO: different cond_timeout test with 2/3 instead of 1
+
+function mcp_config_routes(p)
+    local map = {
+        ["cond_timeout"] = cond_timeout(p),
+        ["enqueue_timeout"] = enqueue_timeout(p),
+        ["handle_timeout"] = wait_handle_timeout(p),
+        ["wait_more"] = wait_more(p),
+        ["wait_double"] = wait_double(p),
+        ["sleep"] = rctx_sleep(p),
+    }
+
+    -- defaults are fine. "prefix/etc"
+    local router = mcp.router_new({
+        map = map,
+    })
+
+    mcp.attach(mcp.CMD_MG, router)
+end

--- a/t/proxyrctxtimeout.t
+++ b/t/proxyrctxtimeout.t
@@ -1,0 +1,129 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+# Set up the listeners _before_ starting the proxy.
+# the fourth listener is only occasionally used.
+my $t = Memcached::ProxyTest->new(servers => [12141, 12142, 12143]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyrctxtimeout.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+subtest 'sleep' => sub {
+    plan skip_all => 'sleep does not work';
+    $t->c_send("mg sleep/foo t\r\n");
+    $t->be_recv_c(0, "near got request");
+    $t->be_send(0, "HD t94\r\n");
+    $t->c_recv_be();
+    $t->clear();
+};
+
+subtest 'no timeout' => sub {
+    # first response is good
+    $t->c_send("mg cond_timeout/foo\r\n");
+    $t->be_recv_c(0);
+    $t->be_send(0, "HD\r\n");
+    $t->c_recv_be();
+    $t->clear();
+};
+
+subtest 'first req times out' => sub {
+    $t->c_send("mg cond_timeout/boo t\r\n");
+    $t->be_recv_c([1,2], "far backends received requests");
+    $t->be_recv_c(0, "near req still arrived");
+    $t->be_send([1,2], "HD t90\r\n");
+    $t->c_recv_be();
+    # Should get eaten.
+    $t->be_send(0, "HD t40\r\n");
+    $t->clear();
+};
+
+subtest 'first req times out, but still returns' => sub {
+    $t->c_send("mg cond_timeout/qoo t\r\n");
+    $t->be_recv_c([1,2], "near timeout, far received req");
+    $t->be_recv_c(0, "near received request");
+
+    $t->be_send(0, "HD t14\r\n");
+    $t->c_recv_be("near timed out but client got its response");
+    # returned but doesn't go anywhere.
+    $t->be_send([1,2], "HD t17\r\n");
+    $t->clear();
+};
+
+subtest 'enqueue_timeout' => sub {
+    $t->c_send("mg enqueue_timeout/foo t\r\n");
+    $t->be_recv_c([1,2], "near timeout, far received req");
+    $t->be_recv_c(0, "near req still arrived");
+    $t->be_send([1,2], "HD t91\r\n");
+    $t->c_recv_be();
+    $t->be_send(0, "HD t15\r\n");
+    $t->clear();
+};
+
+subtest 'enqueue_and_wait no timeout' => sub {
+    $t->c_send("mg enqueue_timeout/foo t\r\n");
+    $t->be_recv_c(0, "near req arrived");
+    $t->be_send(0, "HD t16\r\n");
+    $t->c_recv_be();
+    $t->clear();
+};
+
+subtest 'handle_timeout' => sub {
+    $t->c_send("mg handle_timeout/foo t\r\n");
+    $t->be_recv_c([1,2], "near timeout, far received req");
+    $t->be_recv_c(0, "near req still arrived");
+    $t->be_send([1,2], "HD t92\r\n");
+    $t->c_recv_be();
+    $t->be_send(0, "HD t16\r\n");
+    $t->clear();
+};
+
+subtest 'wait on the same handle twice' => sub {
+    $t->c_send("mg wait_more/foo t\r\n");
+    $t->be_recv_c(0, "near got request");
+    # Let it internally time out.
+    sleep 0.75;
+    pass("short sleep");
+    $t->be_send(0, "HD t93\r\n");
+    $t->c_recv_be();
+    $t->clear();
+};
+
+subtest 'wait handle no timeout' => sub {
+    $t->c_send("mg wait_more/foo t\r\n");
+    $t->be_recv_c(0, "near got request");
+    $t->be_send(0, "HD t93\r\n");
+    $t->c_recv("SERVER_ERROR no timeout\r\n", "client received SERVER_ERROR");
+    $t->clear();
+};
+
+subtest 'wait double' => sub {
+    $t->c_send("mg wait_double/foo t\r\n");
+    $t->be_recv_c(0, "near got request");
+    # Let it internally time out.
+    sleep 0.75;
+    pass("short sleep");
+    $t->be_send(0, "HD t98\r\n");
+    $t->c_recv_be();
+    $t->clear();
+};
+
+done_testing();


### PR DESCRIPTION
give request contexts the ability to time out on wait operations. this allows moving along the logic without cancelling in flight requests or resetting backends.

TODO:
- [x] Might go with an extra argument instead of `_timeout()` versions of each function.

This is due to the API still missing a few variants of `wait` (ie: enqueue and wait cond, wait and return "best", etc). Internally the `_timeout()` version is identical except for the extra argument parsing. So with `_timeout()` variants we'd have like ten wait functions...

- [x] port to `wait_handle` and etc once above is decided.
- [x] add `rctx:sleep()` for testing disaster scenarios
- [x] remove an armed alarm during rctx cleanup phase.
- [x] complete the testing. basic tests pass as of this writing.

not feeling great today so finishing this tomorrow.