### PR TITLE
proxy: config thread cron functions

### DIFF
--- a/proxy_config.c
+++ b/proxy_config.c
@@ -123,6 +123,128 @@ static void *_proxy_manager_thread(void *arg) {
     return NULL;
 }
 
+static void proxy_config_reload(proxy_ctx_t *ctx) {
+    LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "start");
+    STAT_INCR(ctx, config_reloads, 1);
+    // gen. used for tracking object lifecycles over time.
+    // ie: ensuring old things are unloaded.
+    ctx->config_generation++;
+    lua_State *L = ctx->proxy_state;
+    lua_settop(L, 0); // clear off any crud that could have been left on the stack.
+
+    // The main stages of config reload are:
+    // - load and execute the config file
+    // - run mcp_config_pools()
+    // - for each worker:
+    //   - copy and execute new lua code
+    //   - copy selector table
+    //   - run mcp_config_routes()
+
+    if (proxy_load_config(ctx) != 0) {
+        // Failed to load. log and wait for a retry.
+        STAT_INCR(ctx, config_reload_fails, 1);
+        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "failed");
+        return;
+    }
+
+    // TODO (v2): create a temporary VM to test-load the worker code into.
+    // failing to load partway through the worker VM reloads can be
+    // critically bad if we're not careful about references.
+    // IE: the config VM _must_ hold references to selectors and backends
+    // as long as they exist in any worker for any reason.
+
+    for (int x = 0; x < settings.num_threads; x++) {
+        LIBEVENT_THREAD *thr = get_worker_thread(x);
+
+        pthread_mutex_lock(&ctx->worker_lock);
+        ctx->worker_done = false;
+        ctx->worker_failed = false;
+        proxy_reload_notify(thr);
+        while (!ctx->worker_done) {
+            // in case of spurious wakeup.
+            pthread_cond_wait(&ctx->worker_cond, &ctx->worker_lock);
+        }
+        pthread_mutex_unlock(&ctx->worker_lock);
+
+        // Code load bailed.
+        if (ctx->worker_failed) {
+            STAT_INCR(ctx, config_reload_fails, 1);
+            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "failed");
+            return;
+        }
+    }
+
+    lua_pop(ctx->proxy_state, 1); // drop config_pools return value
+    LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "done");
+}
+
+// Very basic scheduler. Unsorted because we don't expect a huge list of
+// functions to run.
+static void proxy_run_crons(proxy_ctx_t *ctx) {
+    lua_State *L = ctx->proxy_state;
+    assert(lua_gettop(L) == 0);
+    assert(ctx->cron_ref);
+    struct timespec now;
+
+    // Fetch the cron table. Created on startup so must exist.
+    lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->cron_ref);
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    if (ctx->cron_next <= now.tv_sec) {
+        ctx->cron_next = INT_MAX;
+    } else {
+        // no crons ready.
+        return;
+    }
+
+    // Loop the cron entries.
+    lua_pushnil(L);
+    while (lua_next(L, 1) != 0) {
+        const char *key = lua_tostring(L, -2);
+        mcp_cron_t *ce = lua_touserdata(L, -1);
+        int idx = lua_absindex(L, -1);
+
+        // check generation.
+        if (ctx->config_generation != ce->gen) {
+            // remove entry.
+            lua_pushnil(L);
+            lua_setfield(L, 1, key);
+        } else if (ce->next <= now.tv_sec) {
+            // grab func and execute it
+            lua_getiuservalue(L, idx, 1);
+            // no arguments or return values
+            int res = lua_pcall(L, 0, 0, 0);
+            STAT_INCR(ctx, config_cron_runs, 1);
+            if (res != LUA_OK) {
+                LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_ERROR, NULL, lua_tostring(L, -1));
+                STAT_INCR(ctx, config_cron_fails, 1);
+                lua_pop(L, 1); // drop error.
+            }
+
+            if (ce->repeat) {
+                ce->next = now.tv_sec + ce->every;
+                // if rescheduled, check next against ctx. update if sooner
+                if (ctx->cron_next > ce->next) {
+                    ctx->cron_next = ce->next;
+                }
+            } else {
+                // non-repeating cron. delete entry.
+                lua_pushnil(L);
+                lua_setfield(L, 1, key);
+            }
+        } else {
+            // not scheduled to run now, but check if we're next.
+            if (ctx->cron_next > ce->next) {
+                ctx->cron_next = ce->next;
+            }
+        }
+
+        lua_pop(L, 1); // drop value so we can loop.
+    }
+
+    lua_pop(L, 1); // drop cron table.
+}
+
 // Thread handling the configuration reload sequence.
 // TODO (v2): get a logger instance.
 // TODO (v2): making this "safer" will require a few phases of work.
@@ -136,60 +258,23 @@ static void *_proxy_manager_thread(void *arg) {
 //    the old structures where marked dirty.
 static void *_proxy_config_thread(void *arg) {
     proxy_ctx_t *ctx = arg;
+    struct timespec wait = {0};
 
     logger_create();
     pthread_mutex_lock(&ctx->config_lock);
     pthread_cond_signal(&ctx->config_cond);
     while (1) {
         ctx->loading = false;
-        pthread_cond_wait(&ctx->config_cond, &ctx->config_lock);
-        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "start");
-        STAT_INCR(ctx, config_reloads, 1);
-        lua_State *L = ctx->proxy_state;
-        lua_settop(L, 0); // clear off any crud that could have been left on the stack.
 
-        // The main stages of config reload are:
-        // - load and execute the config file
-        // - run mcp_config_pools()
-        // - for each worker:
-        //   - copy and execute new lua code
-        //   - copy selector table
-        //   - run mcp_config_routes()
+        // cron only thinks in whole seconds.
+        wait.tv_sec = ctx->cron_next;
+        pthread_cond_timedwait(&ctx->config_cond, &ctx->config_lock, &wait);
 
-        if (proxy_load_config(ctx) != 0) {
-            // Failed to load. log and wait for a retry.
-            STAT_INCR(ctx, config_reload_fails, 1);
-            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "failed");
-            continue;
+        proxy_run_crons(ctx);
+
+        if (ctx->loading) {
+            proxy_config_reload(ctx);
         }
-
-        // TODO (v2): create a temporary VM to test-load the worker code into.
-        // failing to load partway through the worker VM reloads can be
-        // critically bad if we're not careful about references.
-        // IE: the config VM _must_ hold references to selectors and backends
-        // as long as they exist in any worker for any reason.
-
-        for (int x = 0; x < settings.num_threads; x++) {
-            LIBEVENT_THREAD *thr = get_worker_thread(x);
-
-            pthread_mutex_lock(&ctx->worker_lock);
-            ctx->worker_done = false;
-            ctx->worker_failed = false;
-            proxy_reload_notify(thr);
-            while (!ctx->worker_done) {
-                // in case of spurious wakeup.
-                pthread_cond_wait(&ctx->worker_cond, &ctx->worker_lock);
-            }
-            pthread_mutex_unlock(&ctx->worker_lock);
-
-            // Code load bailed.
-            if (ctx->worker_failed) {
-                STAT_INCR(ctx, config_reload_fails, 1);
-                LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "failed");
-                continue;
-            }
-        }
-        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_CONFIG, NULL, "done");
     }
 
     return NULL;

--- a/t/proxycron.lua
+++ b/t/proxycron.lua
@@ -1,0 +1,54 @@
+function set_crons()
+    mcp.register_cron("foo",
+        { every = 2, func = function()
+            foo_run = 1
+        end })
+
+    mcp.register_cron("reload",
+        { every = 3, func = function()
+            if foo_run and once_run then
+                mcp.schedule_config_reload()
+            end
+        end })
+
+    -- will run once per reload.
+    mcp.register_cron("once",
+        { every = 1, rerun = false, func = function()
+            once_run = 1
+        end })
+end
+
+function set_crons2()
+    mcp.register_cron("bar",
+        { every = 2, func = function()
+            bar_run = 1
+        end })
+
+    mcp.register_cron("reload",
+        { every = 3, func = function()
+            -- ensure the old crons didn't also run.
+            if bar_run and not foo_run and once_again and not once_run then
+                mcp.schedule_config_reload()
+            end
+        end })
+
+    -- will run once per reload.
+    mcp.register_cron("onceagain",
+        { every = 3, rerun = false, func = function()
+            once_again = 1
+        end })
+end
+
+function mcp_config_pools()
+    if foo_run == nil then
+        set_crons()
+    else
+        foo_run = nil
+        once_run = nil
+        set_crons2()
+    end
+end
+
+function mcp_config_routes()
+    -- do nothing.
+end

--- a/t/proxycron.t
+++ b/t/proxycron.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+# Basic testing of cron functionality.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxycron.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+sub wait_reload {
+    my $w = shift;
+    while (my $line = <$w>) {
+        if ($line =~ m/type=proxy_conf status=done/) {
+            last;
+        }
+    }
+    pass("reload complete");
+}
+
+# The crons will do some fiddling then issue a self-reload twice.
+subtest 'wait for reload' => sub {
+    my $w = $p_srv->new_sock;
+    print $w "watch proxyevents\n";
+    is(<$w>, "OK\r\n", "watcher enabled");
+
+    wait_reload($w);
+    wait_reload($w);
+    my $stats = mem_stats($ps);
+    cmp_ok($stats->{proxy_config_cron_runs}, '>', 3, "crons ran");
+    is($stats->{proxy_config_cron_fails}, 0, "no crons failed");
+};
+
+done_testing();


### PR DESCRIPTION
Adds a system for periodically running functions in the configuration thread. These crons may also signal to reload the configuration after they run. IE: you may shell out or run a module to fetch and download new json data, then reload the configuration.

mcp.register_cron("name",
  { every = seconds, func = function()
    print("cron running")
  end })

Also accepts { rerun = false } to run the cron once after a reload. Can be used to check something after a reload has run, or simply issue a reload after an exact amount of time since the previous reload finished.

Crons that are not seen after a config reload are unloaded. IE: the only crons that may run must have been registered during the last configuration reload.

If a cron is overwriting itself, and the 'every' period has not changed, it will "inherit" the next scheduled run time. Thus config reloads will not interrupt the scheduling of crons that are not changing their time schedule.

Also adds `mcp.config_reload()` which will schedule the system to reload its configuration after the cron finishes running.

TODO:
- [x] some lua tests.
- [x] maybe rename `mcp.config_reload` to `mcp.schedule_config_reload()` to better indicate it doesn't immediately run the reload.

It's already been manually tested with the config:
```lua
if bcount == nil then
    bcount = 0
end

function set_crons()
    mcp.register_cron("foo",
        { every = 1, func = function()
            print("FOO function called")
        end })

    mcp.register_cron("bar",
        { every = 6, func = function()
            print("BAR function called: ", bcount)
            bcount = bcount + 1
        end })
    mcp.register_cron("reload",
        { every = 10, func = function()
            print("CONFIG RELOAD")
            -- signals to reload, does not immediately reload
            mcp.config_reload()
        end })

    -- will run once per reload.
    mcp.register_cron("once",
        { every = 2, rerun = false, func = function()
            print("NO RERUN!")
        end })
end

function mcp_config_pools()
    set_crons()
end

function mcp_config_routes()
    -- do nothing.
end
```

reloaded while commenting out `set_crons()` to confirm they unload/reload/etc. Will do some basic automated tests but I don't think it needs a lot.