### PR TITLE
proxy: `mcp.server_stats(subcmd)`

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1796,7 +1796,7 @@ void append_stat(const char *name, ADD_STAT add_stats, conn *c,
 }
 
 /* return server specific stats only */
-void server_stats(ADD_STAT add_stats, conn *c) {
+void server_stats(ADD_STAT add_stats, void *c) {
     pid_t pid = getpid();
     rel_time_t now = current_time;
 
@@ -1861,7 +1861,7 @@ void server_stats(ADD_STAT add_stats, conn *c) {
     APPEND_STAT("get_expired", "%llu", (unsigned long long)thread_stats.get_expired);
     APPEND_STAT("get_flushed", "%llu", (unsigned long long)thread_stats.get_flushed);
 #ifdef EXTSTORE
-    if (c->thread->storage) {
+    if (ext_storage) {
         APPEND_STAT("get_extstore", "%llu", (unsigned long long)thread_stats.get_extstore);
         APPEND_STAT("get_aborted_extstore", "%llu", (unsigned long long)thread_stats.get_aborted_extstore);
         APPEND_STAT("get_oom_extstore", "%llu", (unsigned long long)thread_stats.get_oom_extstore);

--- a/memcached.h
+++ b/memcached.h
@@ -1063,7 +1063,7 @@ void conn_set_state(conn *c, enum conn_states state);
 void out_of_memory(conn *c, char *ascii_error);
 void out_errstring(conn *c, const char *str);
 void write_and_free(conn *c, char *buf, int bytes);
-void server_stats(ADD_STAT add_stats, conn *c);
+void server_stats(ADD_STAT add_stats, void *c);
 void append_stats(const char *key, const uint16_t klen,
                   const char *val, const uint32_t vlen,
                   const void *cookie);

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -120,7 +120,7 @@ bool proxy_bufmem_checkadd(LIBEVENT_THREAD *t, int len) {
 }
 
 // see also: process_extstore_stats()
-void proxy_stats(void *arg, ADD_STAT add_stats, conn *c) {
+void proxy_stats(void *arg, ADD_STAT add_stats, void *c) {
     if (arg == NULL) {
        return;
     }
@@ -137,7 +137,7 @@ void proxy_stats(void *arg, ADD_STAT add_stats, conn *c) {
     STAT_UL(ctx);
 }
 
-void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c) {
+void process_proxy_stats(void *arg, ADD_STAT add_stats, void *c) {
     char key_str[STAT_KEY_LEN];
     struct proxy_int_stats istats = {0};
     uint64_t req_limit = 0;
@@ -225,7 +225,7 @@ void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c) {
     APPEND_STAT("cmd_replace", "%llu", (unsigned long long)istats.counters[CMD_REPLACE]);
 }
 
-void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c) {
+void process_proxy_funcstats(void *arg, ADD_STAT add_stats, void *c) {
     char key_str[STAT_KEY_LEN];
     if (!arg) {
         return;
@@ -261,7 +261,7 @@ void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c) {
     pthread_mutex_unlock(&ctx->sharedvm_lock);
 }
 
-void process_proxy_bestats(void *arg, ADD_STAT add_stats, conn *c) {
+void process_proxy_bestats(void *arg, ADD_STAT add_stats, void *c) {
     char key_str[STAT_KEY_LEN];
     if (!arg) {
         return;

--- a/proto_proxy.h
+++ b/proto_proxy.h
@@ -1,10 +1,10 @@
 #ifndef PROTO_PROXY_H
 #define PROTO_PROXY_H
 
-void proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
-void process_proxy_stats(void *arg, ADD_STAT add_stats, conn *c);
-void process_proxy_funcstats(void *arg, ADD_STAT add_stats, conn *c);
-void process_proxy_bestats(void *arg, ADD_STAT add_stats, conn *c);
+void proxy_stats(void *arg, ADD_STAT add_stats, void *c);
+void process_proxy_stats(void *arg, ADD_STAT add_stats, void *c);
+void process_proxy_funcstats(void *arg, ADD_STAT add_stats, void *c);
+void process_proxy_bestats(void *arg, ADD_STAT add_stats, void *c);
 
 /* proxy mode handlers */
 int try_read_command_proxy(conn *c);

--- a/storage.c
+++ b/storage.c
@@ -74,7 +74,7 @@ void storage_delete(void *e, item *it) {
 // but feels a little off being defined here.
 // At very least maybe "process_storage_stats" in line with making this more
 // of a generic wrapper module.
-void process_extstore_stats(ADD_STAT add_stats, conn *c) {
+void process_extstore_stats(ADD_STAT add_stats, void *c) {
     int i;
     char key_str[STAT_KEY_LEN];
     char val_str[STAT_VAL_LEN];
@@ -83,7 +83,7 @@ void process_extstore_stats(ADD_STAT add_stats, conn *c) {
 
     assert(add_stats);
 
-    void *storage = c->thread->storage;
+    void *storage = ext_storage;
     if (storage == NULL) {
         return;
     }
@@ -106,9 +106,9 @@ void process_extstore_stats(ADD_STAT add_stats, conn *c) {
 }
 
 // Additional storage stats for the main stats output.
-void storage_stats(ADD_STAT add_stats, conn *c) {
+void storage_stats(ADD_STAT add_stats, void *c) {
     struct extstore_stats st;
-    if (c->thread->storage) {
+    if (ext_storage) {
         STATS_LOCK();
         APPEND_STAT("extstore_compact_lost", "%llu", (unsigned long long)stats.extstore_compact_lost);
         APPEND_STAT("extstore_compact_rescues", "%llu", (unsigned long long)stats.extstore_compact_rescues);
@@ -116,7 +116,7 @@ void storage_stats(ADD_STAT add_stats, conn *c) {
         APPEND_STAT("extstore_compact_resc_old", "%llu", (unsigned long long)stats.extstore_compact_resc_old);
         APPEND_STAT("extstore_compact_skipped", "%llu", (unsigned long long)stats.extstore_compact_skipped);
         STATS_UNLOCK();
-        extstore_get_stats(c->thread->storage, &st);
+        extstore_get_stats(ext_storage, &st);
         APPEND_STAT("extstore_page_allocs", "%llu", (unsigned long long)st.page_allocs);
         APPEND_STAT("extstore_page_evictions", "%llu", (unsigned long long)st.page_evictions);
         APPEND_STAT("extstore_page_reclaims", "%llu", (unsigned long long)st.page_reclaims);

--- a/storage.h
+++ b/storage.h
@@ -12,8 +12,8 @@ void storage_delete(void *e, item *it);
 #endif
 
 // API.
-void storage_stats(ADD_STAT add_stats, conn *c);
-void process_extstore_stats(ADD_STAT add_stats, conn *c);
+void storage_stats(ADD_STAT add_stats, void *c);
+void process_extstore_stats(ADD_STAT add_stats, void *c);
 bool storage_validate_item(void *e, item *it);
 int storage_get_item(conn *c, item *it, mc_resp *resp);
 

--- a/t/proxyintstats.lua
+++ b/t/proxyintstats.lua
@@ -1,0 +1,74 @@
+function check_stats(cmd, min)
+    local s
+    if cmd then
+        s = mcp.server_stats(cmd)
+    else
+        s = mcp.server_stats()
+        cmd = "basic"
+    end
+
+    local count = 0
+    for k, v in pairs(s) do
+        count = count + 1
+    end
+
+    if min and count < min then
+        mcp.log("ERROR: ["..cmd.."] count too low: " .. count)
+    else
+        mcp.log("SUCCESS: " .. cmd)
+    end
+end
+
+function check_stats_sections(cmd, minsec, minval)
+    local s = mcp.server_stats(cmd)
+
+    local sec = 0
+    local val = 0
+    for k, v in pairs(s) do
+        if type(k) == "number" then
+            sec = sec + 1
+            for sk, sv in pairs(v) do
+                val = val + 1
+            end
+        else
+            -- not a section.
+        end
+    end
+
+    if minsec and sec < minsec then
+        mcp.log("ERROR: ["..cmd.."] section count too low: " .. count)
+        return
+    end
+
+    if minval and val < minval then
+        mcp.log("ERROR: ["..cmd.."] value count too low: " .. count)
+        return
+    end
+
+    mcp.log("SUCCESS: " .. cmd)
+end
+
+function mcp_config_pools()
+    -- ensure that ustats print without crash/etc
+    mcp.add_stat(1, "foo")
+    mcp.add_stat(2, "bar")
+    -- delay the stats run by a few seconds since some counters are weird
+    -- until initialization completes.
+    mcp.register_cron("stats", { every = 2, rerun = false, func = function()
+        check_stats(nil, 10)
+        check_stats("settings", 10)
+        check_stats_sections("conns", 1, 2)
+        check_stats("extstore")
+        check_stats("proxy", 1)
+        check_stats("proxyfuncs", 1)
+        check_stats("proxybe")
+        check_stats_sections("items", 1, 5)
+        check_stats_sections("slabs", 1, 5)
+    end })
+end
+
+function mcp_config_routes(c)
+    mcp.attach(mcp.CMD_ANY_STORAGE, function(r)
+        return mcp.internal(r)
+    end)
+end

--- a/t/proxyintstats.t
+++ b/t/proxyintstats.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyintstats.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+my $w = $p_srv->new_sock;
+print $w "watch proxyuser\n";
+is(<$w>, "OK\r\n", "watcher enabled");
+
+# store one value so items/slabs has data.
+print $ps "set foo 0 0 2\r\nhi\r\n";
+is(scalar <$ps>, "STORED\r\n", "test value stored");
+
+my @stats = qw/basic settings conns extstore proxy proxyfuncs proxybe items slabs/;
+
+for my $st (@stats) {
+    like(<$w>, qr/SUCCESS: $st/, "successfully ran $st");
+}
+
+pass("didn't crash");
+
+done_testing();


### PR DESCRIPTION
Allow accessing server stats from the configuration thread (useful for crons, checking start args, etc). Does not support cachedump or detail.

Returns a table of the results. The results are thus unordered.

---

Much smaller code change than I expected, though I have to rely on an unfortunate global variable until some further refactoring of the stats commands.

TODO:

- [x] Decide on if we want to order or add further structure to some of these.

It's not hard to parse the ordered outputs (items, conns, slabs) since you can just loop up until the numbers miss, but it might be more convenient to be able to loop the table directly sometimes. It would add a lot of code, I think?

How would that work? Detect :'s and make a sub-table until the # stops matching or the : goes away?

- [x] Add an `mcp.log` that works from config thread so the unit tests can check results. Among other uses...
- [x] Add some more explicit tests. Currently it's not bad since the stats will either output 100% of the time or crash, more or less...
- [x] Ensure ustats are tested or at least audited... have a bad feeling about the lock order there.