### PR TITLE
proxy: fix race condition leading to hang

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -753,6 +753,7 @@ typedef struct {
     pthread_mutex_t proxy_limit_lock;
     int proxy_vm_extra_kb;
     int proxy_vm_last_kb;
+    unsigned int proxy_vm_negative_delta;
     int proxy_vm_gcrunning;
     bool proxy_vm_needspoke;
     uint64_t proxy_active_req_limit;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -805,8 +805,10 @@ static void _proxy_run_tresp_to_resp(mc_resp *tresp, mc_resp *resp) {
     // So far all we fill is the wbuf and some iov's? so just copy
     // that + the UDP info?
     memcpy(resp->wbuf, tresp->wbuf, tresp->iov[0].iov_len);
+    resp->tosend = 0;
     for (int x = 0; x < tresp->iovcnt; x++) {
         resp->iov[x] = tresp->iov[x];
+        resp->tosend += tresp->iov[x].iov_len;
     }
     // resp->iov[x].iov_base needs to be updated if it's
     // pointing within its wbuf.

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -1749,7 +1749,7 @@ int mcplib_internal_run(mcp_rcontext_t *rctx) {
     // resp object is associated with the
     // response object, which is about a
     // kilobyte.
-    lua_gc(rctx->Lc, LUA_GCSTEP, 1);
+    t->proxy_vm_extra_kb++;
 
     if (resp->io_pending) {
         // TODO (v2): here we move the IO from the temporary resp to the top

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -951,8 +951,18 @@ static void _post_pending_write(struct mcp_backendconn_s *be, ssize_t sent) {
     } // for
 
     // resume the flush from this point.
-    if (io != NULL && !io->flushed) {
-        be->io_next = io;
+    if (io != NULL) {
+        if (!io->flushed) {
+            be->io_next = io;
+        } else {
+            // Check for incomplete list because we hit the iovcnt limit.
+            io_pending_proxy_t *nio = STAILQ_NEXT(io, io_next);
+            if (nio != NULL && !nio->flushed) {
+                be->io_next = io;
+            } else {
+                be->io_next = NULL;
+            }
+        }
     } else {
         be->io_next = NULL;
     }


### PR DESCRIPTION
If a lua function schedules extra requests after an initial set of requests, we need to use a workaround to ensure the second set of requests is actually submitted to the proxy backends.

This workaround was in the wrong place. If connections are being cut and reconnected between batches of requests it's possible for the workaround to trigger on a connection object that has since moved to another thread.

This patch tightens up the workaround to run before the client connection has a chance to resume.

---

TODO:
- [x] Passes unit test suite
- [x] Passes basic stability bench tests
- [x] Passes partial suite stability bench tests
- [x] Passes full suite full time stability bench tests