### PR TITLE
proxy: improve gc handling of mcp.request

### DIFF
--- a/proxy_request.c
+++ b/proxy_request.c
@@ -648,6 +648,7 @@ int mcplib_request(lua_State *L) {
         return 0;
     }
     mcp_request_t *rq = mcp_new_request(L, &pr, cmd, len);
+    t->proxy_vm_extra_kb++; // oversize the impact of request udata.
 
     if (val != NULL) {
         rq->pr.vlen = vlen;


### PR DESCRIPTION
Since userdata have to pass through the GC twice before being collected, we usually make their allocations look oversized to the GC. This wasn't being done with mcp.request() because I don't personally see it causing problems.