### PR TITLE
proxy: fix refcount leak in mcp.internal()

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -828,6 +828,7 @@ static void _proxy_run_tresp_to_resp(mc_resp *tresp, mc_resp *resp) {
     resp->request_addr = tresp->request_addr;
     resp->request_addr_size = tresp->request_addr_size;
     resp->item = tresp->item; // will be populated if not extstore fetch
+    tresp->item = NULL; // move ownership of the item to resp from tresp
     resp->skip = tresp->skip;
 }
 

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -308,7 +308,6 @@ static int mcplib_response_line(lua_State *L) {
 }
 
 void mcp_response_cleanup(LIBEVENT_THREAD *t, mcp_resp_t *r) {
-
     // On error/similar we might be holding the read buffer.
     // If the buf is handed off to mc_resp for return, this pointer is NULL
     if (r->buf != NULL) {
@@ -324,6 +323,10 @@ void mcp_response_cleanup(LIBEVENT_THREAD *t, mcp_resp_t *r) {
     if (r->cresp != NULL) {
         mc_resp *cresp = r->cresp;
         assert(r->thread != NULL);
+        if (cresp->item) {
+            item_remove(cresp->item);
+            cresp->item = NULL;
+        }
         resp_free(r->thread, cresp);
         r->cresp = NULL;
     }


### PR DESCRIPTION
If running a fetch request without returning the result upstream to the user, a successfully fetched item would leak its reference.