### PR TITLE
proxy: add mcp.backend_depth_limit(int)

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -157,6 +157,7 @@ void proxy_stats(void *arg, ADD_STAT add_stats, void *c) {
     APPEND_STAT("proxy_backend_total", "%llu", (unsigned long long)ctx->global_stats.backend_total);
     APPEND_STAT("proxy_backend_marked_bad", "%llu", (unsigned long long)ctx->global_stats.backend_marked_bad);
     APPEND_STAT("proxy_backend_failed", "%llu", (unsigned long long)ctx->global_stats.backend_failed);
+    APPEND_STAT("proxy_request_failed_depth", "%llu", (unsigned long long)ctx->global_stats.request_failed_depth);
     STAT_UL(ctx);
 }
 
@@ -340,6 +341,7 @@ void *proxy_init(bool use_uring, bool proxy_memprofile) {
     ctx->tunables.read.tv_sec = 3;
     ctx->tunables.flap_backoff_ramp = 1.5;
     ctx->tunables.flap_backoff_max = 3600;
+    ctx->tunables.backend_depth_limit = 0;
     ctx->tunables.max_ustats = MAX_USTATS_DEFAULT;
     ctx->tunables.use_iothread = false;
 

--- a/proxy.h
+++ b/proxy.h
@@ -200,12 +200,9 @@ struct proxy_global_stats {
     uint64_t config_cron_runs;
     uint64_t config_cron_fails;
     uint64_t backend_total;
-    uint64_t backend_disconn; // backends with no connections
-    uint64_t backend_requests; // reqs sent to backends
-    uint64_t backend_responses; // responses received from backends
-    uint64_t backend_errors; // errors from backends
     uint64_t backend_marked_bad; // backend set to autofail
     uint64_t backend_failed; // an error caused a backend reset
+    uint64_t request_failed_depth; // requests fast-failed due to be depth
 };
 
 struct proxy_tunables {
@@ -215,6 +212,7 @@ struct proxy_tunables {
     struct timeval flap; // need to stay connected this long or it's flapping
     float flap_backoff_ramp; // factorial for retry time
     uint32_t flap_backoff_max; // don't backoff longer than this.
+    int backend_depth_limit; // requests fast fail once depth over this limit
     int backend_failure_limit;
     int max_ustats; // limit the ustats index.
     bool tcp_keepalive;

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -444,11 +444,22 @@ static int mcplib_backend(lua_State *L) {
         if (lua_getfield(L, 1, "failurelimit") != LUA_TNIL) {
             int limit = luaL_checkinteger(L, -1);
             if (limit < 0) {
-                proxy_lua_error(L, "failure_limit must be >= 0");
+                proxy_lua_error(L, "failurelimit must be >= 0");
                 return 0;
             }
 
             be->tunables.backend_failure_limit = limit;
+        }
+        lua_pop(L, 1);
+
+        if (lua_getfield(L, 1, "depthlimit") != LUA_TNIL) {
+            int limit = luaL_checkinteger(L, -1);
+            if (limit < 0) {
+                proxy_lua_error(L, "depthlimit must be >= 0");
+                return 0;
+            }
+
+            be->tunables.backend_depth_limit = limit;
         }
         lua_pop(L, 1);
 
@@ -1125,6 +1136,22 @@ static int mcplib_backend_failure_limit(lua_State *L) {
     return 0;
 }
 
+static int mcplib_backend_depth_limit(lua_State *L) {
+    int limit = luaL_checkinteger(L, -1);
+    proxy_ctx_t *ctx = PROXY_GET_CTX(L);
+
+    if (limit < 0) {
+        proxy_lua_error(L, "backend_depth_limit must be >= 0");
+        return 0;
+    }
+
+    STAT_L(ctx);
+    ctx->tunables.backend_depth_limit = limit;
+    STAT_UL(ctx);
+
+    return 0;
+}
+
 static int mcplib_backend_connect_timeout(lua_State *L) {
     lua_Number secondsf = luaL_checknumber(L, -1);
     lua_Integer secondsi = (lua_Integer) secondsf;
@@ -1721,6 +1748,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"backend_retry_waittime", mcplib_backend_retry_waittime},
         {"backend_read_timeout", mcplib_backend_read_timeout},
         {"backend_failure_limit", mcplib_backend_failure_limit},
+        {"backend_depth_limit", mcplib_backend_depth_limit},
         {"backend_flap_time", mcplib_backend_flap_time},
         {"backend_flap_backoff_ramp", mcplib_backend_flap_backoff_ramp},
         {"backend_flap_backoff_max", mcplib_backend_flap_backoff_max},

--- a/t/proxydepthlim.lua
+++ b/t/proxydepthlim.lua
@@ -1,0 +1,22 @@
+function mcp_config_pools()
+    mcp.backend_depth_limit(3)
+    mcp.backend_connect_timeout(60)
+    mcp.backend_read_timeout(60)
+    mcp.backend_retry_timeout(60)
+    local b1 = mcp.backend('b1', '127.0.0.1', 12161)
+    return mcp.pool({b1})
+end
+
+-- not making requests, just opening/closing backends
+function mcp_config_routes(p)
+    local fg = mcp.funcgen_new()
+    local h = fg:new_handle(p)
+    fg:ready({
+        n = "depth", f = function(rctx)
+            return function(r)
+                return rctx:enqueue_and_wait(r, h)
+            end
+        end
+    })
+    mcp.attach(mcp.CMD_MG, fg)
+end

--- a/t/proxydepthlim.t
+++ b/t/proxydepthlim.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $t = Memcached::ProxyTest->new(servers => [12161]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxydepthlim.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+#$t->accept_backends();
+
+subtest 'over-depth' => sub {
+    my $holder = $p_srv->new_sock;
+    # enqueue some requests.
+    my $cmd = "mg foo s t v\r\n";
+    my $todo = '';
+    for (1..4) {
+        $todo .= $cmd;
+    }
+    print $holder $todo;
+    sleep 0.25; # ensure holder client is seen first
+    diag "foo";
+    # We never look at the backend in this test.
+    $t->c_send($cmd);
+    $t->c_recv("SERVER_ERROR backend failure\r\n", 'depth limit reached');
+
+    my $s = mem_stats($ps);
+    is($s->{proxy_request_failed_depth}, 1, "got a fast failure");
+};
+
+done_testing();


### PR DESCRIPTION
If a backend has a queue depth limt over this amount, fast-fail any further requests.

A global parallel request limit can mean a single slow or overloaded backend causes the entire proxy to stop working. As a first layer of defence the depth for a particular backend should be capped.

TODO:

~- [ ] might add a counter for failed-due-to-bad while I'm in here.~
~- [ ] might also add a tunable for fast-failing while be is connecting/validating. been meaning to do that forever.~

delaying further TODO's until after the TLS work is in testing.