### PR TITLE
proxy: backend TLS support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_luafgen.c \
 					 proxy_config.c proxy_ring_hash.c \
 					 proxy_internal.c \
+					 proxy_tls.c proxy_tls.h \
 					 md5.c md5.h
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,9 @@ AC_ARG_ENABLE(proxy,
 AC_ARG_ENABLE(proxy-uring,
   [AS_HELP_STRING([--enable-proxy-uring], [Enable proxy io_uring code EXPERIMENTAL])])
 
+AC_ARG_ENABLE(proxy-tls,
+  [AS_HELP_STRING([--enable-proxy-tls], [Enable proxy io_uring code EXPERIMENTAL])])
+
 AC_ARG_ENABLE(werror,
   [AS_HELP_STRING([--enable-werror], [Enable -Werror])])
 
@@ -255,6 +258,14 @@ if test "x$enable_proxy_uring" = "xyes"; then
     CPPFLAGS="-Ivendor/liburing/src/include $CPPFLAGS"
 fi
 
+if test "x$enable_proxy_tls" = "xyes"; then
+    if test "x$enable_tls" != "xyes"; then
+        AC_MSG_ERROR([--enable-proxy-tls requires --enable-tls])
+    else
+        AC_DEFINE([PROXY_TLS],1,[Set to nonzero if you want to enable proxy backend tls support])
+    fi
+fi
+
 if test "x$enable_large_client_flags" = "xyes"; then
     AC_DEFINE([LARGE_CLIENT_FLAGS],1,[Set to nonzero if you want 64bit client flags])
 fi
@@ -270,6 +281,7 @@ AM_CONDITIONAL([ENABLE_STATIC],[test "$enable_static" = "yes"])
 AM_CONDITIONAL([DISABLE_UNIX_SOCKET],[test "$enable_unix_socket" = "no"])
 AM_CONDITIONAL([ENABLE_PROXY],[test "$enable_proxy" = "yes"])
 AM_CONDITIONAL([ENABLE_PROXY_URING],[test "$enable_proxy_uring" = "yes"])
+AM_CONDITIONAL([ENABLE_PROXY_TLS],[test "$enable_proxy_tls" = "yes"])
 AM_CONDITIONAL([LARGE_CLIENT_FLAGS],[test "$enable_large_client_flags" = "yes"])
 
 

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -344,6 +344,7 @@ void *proxy_init(bool use_uring, bool proxy_memprofile) {
     ctx->tunables.backend_depth_limit = 0;
     ctx->tunables.max_ustats = MAX_USTATS_DEFAULT;
     ctx->tunables.use_iothread = false;
+    ctx->tunables.use_tls = false;
 
     STAILQ_INIT(&ctx->manager_head);
     lua_State *L = NULL;

--- a/proxy_tls.c
+++ b/proxy_tls.c
@@ -1,0 +1,257 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+#include "proxy_tls.h"
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#ifdef PROXY_TLS
+/* Notes on ERR_clear_error() and friends:
+ * - Errors from SSL calls leave errors on a thread-local "error stack"
+ * - If an error is received from an SSL call, the stack needs to be inspected
+ *   and cleared.
+ * - The error stack _must_ be clear before any SSL_get_error() calls, as it
+ *   may return garbage.
+ * - There may be _multiple_ errors queued after one SSL call, so just
+ *   checking the top level does not clear it.
+ * - ERR_clear_error() is not "free", so we would prefer to avoid calling it
+ *   before hotpath calls. Thus, we should ensure it's called _after_ any
+ *   hotpath call that receives any kind of error.
+ * - We should also call it _before_ any non-hotpath SSL calls (such as
+ *   SSL_connect()) for defense against bugs in our code or OpenSSL.
+ */
+
+int mcp_tls_init(proxy_ctx_t *ctx) {
+    if (ctx->tls_ctx) {
+        return MCP_TLS_OK;
+    }
+
+    // TODO: check for OpenSSL 1.1+ ? should be elsewhere in the code.
+    SSL_CTX *tctx = SSL_CTX_new(TLS_client_method());
+    if (tctx == NULL) {
+        return MCP_TLS_ERR;
+    }
+
+    // TODO: make configurable like main cache server
+    SSL_CTX_set_min_proto_version(tctx, TLS1_3_VERSION);
+    // reduce memory consumption of idle backends.
+    SSL_CTX_set_mode(tctx, SSL_MODE_RELEASE_BUFFERS);
+
+    ctx->tls_ctx = tctx;
+    return 0;
+}
+
+int mcp_tls_backend_init(proxy_ctx_t *ctx, struct mcp_backendconn_s *be) {
+    if (!be->be_parent->tunables.use_tls) {
+        return MCP_TLS_OK;
+    }
+
+    SSL *ssl = SSL_new(ctx->tls_ctx);
+    if (ssl == NULL) {
+        return MCP_TLS_ERR;
+    }
+
+    be->ssl = ssl;
+    // SSL_set_fd() will free a pre-existing BIO and allocate a new one
+    // so we set any file descriptor at connect time instead.
+
+    return MCP_TLS_OK;
+}
+
+int mcp_tls_shutdown(struct mcp_backendconn_s *be) {
+    if (!be->ssl) {
+        return MCP_TLS_OK;
+    }
+
+    // TODO: This may need to be called multiple times to "properly" shutdown
+    // a session. However we only ever call this when a backend is dead or not
+    // in used anymore. Unclear if checking for WANT_READ|WRITE is worth
+    // doing.
+    SSL_shutdown(be->ssl);
+
+    return MCP_TLS_OK;
+}
+
+int mcp_tls_cleanup(struct mcp_backendconn_s *be) {
+    if (!be->ssl) {
+        return MCP_TLS_OK;
+    }
+
+    SSL_free(be->ssl);
+    be->ssl = NULL;
+    return MCP_TLS_OK;
+}
+
+// Contrary to the name of this function, the underlying tcp socket must
+// already be connected.
+int mcp_tls_connect(struct mcp_backendconn_s *be) {
+    // TODO: check return code. can fail if BIO fails to alloc.
+    SSL_set_fd(be->ssl, mcmc_fd(be->client));
+
+    // TODO:
+    // if the backend is changing TLS version or some similar issue, we will
+    // be unable to reconnect as the SSL object "Caches" some information
+    // about the previous request (why doesn't clear work then???)
+    // This will normally be fine, but we should detect severe errors here and
+    // decide if we should free and re-alloc the SSL object.
+    // Allocating the SSL object can be pretty slow, so we should at least
+    // attempt to do not do this.
+    // Related: https://github.com/openssl/openssl/issues/20286
+    SSL_clear(be->ssl);
+    ERR_clear_error();
+    int n = SSL_connect(be->ssl);
+    int ret = MCP_TLS_OK;
+    // TODO: complete error handling.
+    if (n == 1) {
+        // Successfully established and handshake complete.
+        return ret;
+    }
+
+    int err = SSL_get_error(be->ssl, n);
+    if (n == 0) {
+        // Not successsful, but shut down normally.
+        ERR_clear_error();
+        ret = MCP_TLS_ERR;
+    } else if (n < 0) {
+        // Not successful. Check for temporary error.
+        if (err == SSL_ERROR_WANT_READ ||
+            err == SSL_ERROR_WANT_WRITE) {
+            ret = MCP_TLS_OK;
+        } else {
+            ret = MCP_TLS_ERR;
+        }
+        ERR_clear_error();
+    }
+
+    return ret;
+}
+
+int mcp_tls_handshake(struct mcp_backendconn_s *be) {
+    if (SSL_is_init_finished(be->ssl)) {
+        return MCP_TLS_OK;
+    }
+
+    // Non hot path, so clear errors before running.
+    ERR_clear_error();
+    int n = SSL_do_handshake(be->ssl);
+    if (n == 1) {
+        return MCP_TLS_OK;
+    }
+
+    int err = SSL_get_error(be->ssl, n);
+    // TODO: realistically we'll only ever get WANT_READ here, since OpenSSL
+    // is handling the fd and it will have written a small number of bytes.
+    // leaving this note just in case.
+    if (err == SSL_ERROR_WANT_READ ||
+        err == SSL_ERROR_WANT_WRITE) {
+        // So far as I can tell there would be an error on the queue here.
+        ERR_clear_error();
+        return MCP_TLS_NEEDIO;
+    } else {
+        // TODO: can get the full error message and give to the caller to log
+        // to proxyevents?
+        ERR_clear_error();
+        return MCP_TLS_ERR;
+    }
+}
+
+int mcp_tls_send_validate(struct mcp_backendconn_s *be) {
+    const char *str = "version\r\n";
+    const size_t len = strlen(str);
+
+    // Non hot path, clear errors.
+    ERR_clear_error();
+    int n = SSL_write(be->ssl, str, len);
+
+    // TODO: more detailed error checking.
+    if (n < 0 || n != len) {
+        ERR_clear_error();
+        return MCP_TLS_ERR;
+    }
+
+    return MCP_TLS_OK;
+}
+
+int mcp_tls_read(struct mcp_backendconn_s *be) {
+    int n = SSL_read(be->ssl, be->rbuf + be->rbufused, READ_BUFFER_SIZE - be->rbufused);
+
+    if (n < 0) {
+        int err = SSL_get_error(be->ssl, n);
+        if (err == SSL_ERROR_WANT_WRITE ||
+            err == SSL_ERROR_WANT_READ) {
+            ERR_clear_error();
+            return MCP_TLS_NEEDIO;
+        } else {
+            // TODO: log detailed error.
+            ERR_clear_error();
+            return MCP_TLS_ERR;
+        }
+    } else {
+        be->rbufused += n;
+        return n;
+    }
+
+    return 0;
+}
+
+// TODO: option.
+#define TLS_WBUF_SIZE 16 * 1024
+
+// We cache the temporary write buffer on the be's event thread.
+// This is actually required when retrying ops (WANT_WRITE/etc) unless
+// MOVING_BUFFERS flag is set in OpenSSL.
+int mcp_tls_writev(struct mcp_backendconn_s *be, int iovcnt) {
+    proxy_event_thread_t *et = be->event_thread;
+    // TODO: move this to event thread init to remove branch and move error
+    // handling to startup time.
+    // Actually we won't know if TLS is in use until a backend shows up and
+    // tries to write... so I'm not sure where to move this. TLS compiled in
+    // but not used would waste memory.
+    // Maybe can at least mark it unlikely()?
+    if (et->tls_wbuf_size == 0) {
+        et->tls_wbuf_size = TLS_WBUF_SIZE;
+        et->tls_wbuf = malloc(et->tls_wbuf_size);
+        if (et->tls_wbuf == NULL) {
+            return MCP_TLS_ERR;
+        }
+    }
+    size_t remain = et->tls_wbuf_size;
+    char *b = et->tls_wbuf;
+
+    // OpenSSL has no writev or TCP_CORK equivalent, so we have to pre-mempcy
+    // the iov's here.
+    for (int i = 0; i < iovcnt; i++) {
+        size_t len = be->write_iovs[i].iov_len;
+        size_t to_copy = len < remain ? len : remain;
+
+        memcpy(b, (char *)be->write_iovs[i].iov_base, to_copy);
+        remain -= to_copy;
+        b += to_copy;
+        if (remain == 0)
+            break;
+    }
+
+    int n = SSL_write(be->ssl, et->tls_wbuf, b - et->tls_wbuf);
+    if (n < 0) {
+        int err = SSL_get_error(be->ssl, n);
+        if (err == SSL_ERROR_WANT_WRITE ||
+            err == SSL_ERROR_WANT_READ) {
+            ERR_clear_error();
+            return MCP_TLS_NEEDIO;
+        }
+        ERR_clear_error();
+        return MCP_TLS_ERR;
+    }
+
+    return n;
+}
+
+#else // PROXY_TLS
+
+int mcp_tls_writev(struct mcp_backendconn_s *be, int iovcnt) {
+    (void)be;
+    (void)iovcnt;
+    return 0;
+}
+
+#endif // PROXY_TLS

--- a/proxy_tls.h
+++ b/proxy_tls.h
@@ -1,0 +1,39 @@
+#ifndef PROXY_TLS_H
+#define PROXY_TLS_H
+
+// Attempt to reduce ifdef soup within the larger code files by blanking out
+// or swapping these specialized functions.
+// I'm not being super smart about this: if usage of a function leads to a
+// compile error just adjust this as necessary. This is a bit less typing than
+// leaving the header empty and redefining everything in the .c file, but if
+// the balance changes we should switch to always doing that.
+
+enum mcp_tls_ret {
+    MCP_TLS_OK = 1,
+    MCP_TLS_NEEDIO = -1,
+    MCP_TLS_ERR = -2,
+};
+
+#ifdef PROXY_TLS
+int mcp_tls_init(proxy_ctx_t *ctx);
+int mcp_tls_backend_init(proxy_ctx_t *ctx, struct mcp_backendconn_s *be);
+int mcp_tls_shutdown(struct mcp_backendconn_s *be);
+int mcp_tls_cleanup(struct mcp_backendconn_s *be);
+int mcp_tls_connect(struct mcp_backendconn_s *be);
+int mcp_tls_handshake(struct mcp_backendconn_s *be);
+int mcp_tls_send_validate(struct mcp_backendconn_s *be);
+int mcp_tls_read(struct mcp_backendconn_s *be);
+int mcp_tls_writev(struct mcp_backendconn_s *be, int iovcnt);
+#else
+#define mcp_tls_init(ctx)
+#define mcp_tls_backend_init(ctx, be)
+#define mcp_tls_shutdown(be);
+#define mcp_tls_cleanup(be);
+#define mcp_tls_connect(be)
+#define mcp_tls_handshake(be) 0
+#define mcp_tls_send_validate(be) 0
+#define mcp_tls_read(be) 0
+int mcp_tls_writev(struct mcp_backendconn_s *be, int iovcnt);
+#endif // PROXY_TLS
+
+#endif


### PR DESCRIPTION
WIP. Connects, handshakes, and routes requests as of this commit. Needs further work before mergeable.

TODO:
- [x] Flesh out error handling. 
- [x] ~parameter for write buffer size~ de-scoping
- [x] Reduce the size of the code change in `proxy_network.c` by refactoring
- [x] Configure option for enabling support instead of hard coding
- [x] `proxy_tls.h` to blank out functions if TLS not enabled at compile time
- [x] enum for common return codes, vs the 0/-1/-2 currently in use
- [x] ~add some specific counters for handshake/tls errors~ de-scoping
- [x] SSL_shutdown and SSL_free() calls from gc are missing.
- [x] Move some initialization code to config thread.
- [x] Per-backend TLS option
- [x] Ensure all new TODO/FIXME notes are dealt with.

TODO MAYBE:
- [ ] Ship error detail to proxyevents log stream (not useful right now, may punt to next PR)

ETA: maybe a week? It does currently work, so it might not take long to finish.

GOALS:
- Enable TLS on a global or per-backend basis. Propagate errors properly.
- Minimize `#ifdef` soup and testing burden by using a shim for accessing OpenSSL and leaving some TLS related code always compiled in. The shim nulls itself out if TLS support is not compiled in.

FOR FUTURE PR's:
- Load and reload client certificates/keys
- Peer certificate validation
- sessions / session tickets
- maybe: sidethread for handshake calcs (if not reusing a session)
- io_uring preparedness.

I'm separating certificate work out of this PR so I can keep the change focused for initial validation. Tired of trying to waterfall every individual feature.

NOTES:
There is a companion PR to this work over in mcshredder: https://github.com/memcached/mcshredder/pull/5 - this is a much more complicated approach that would be necessary to add `io_uring` back to the proxy. Since we're not currently using io_uring I used a simpler approach that lets OpenSSL handle the socket fd and run syscalls itself.

Since `proxy_network.c` was already structured to abstract out the read and write socket calls into just two small functions, this allowed the PR to be much less invasive than it would be otherwise.

However, if you are naive you might think: "why aren't you using a function ptr for read/write and modify even less?" - well, OpenSSL is way more complicated than that and we need to change how we interact with the event loop based on what the _library_ returns vs what any underlying socket thinks. It sucks.