### PR TITLE
proxy: str = rctx:tls_peer_cn()

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -789,6 +789,7 @@ int mcplib_rcontext_res_any(lua_State *L);
 int mcplib_rcontext_res_ok(lua_State *L);
 int mcplib_rcontext_result(lua_State *L);
 int mcplib_rcontext_cfd(lua_State *L);
+int mcplib_rcontext_tls_peer_cn(lua_State *L);
 int mcplib_rcontext_sleep(lua_State *L);
 int mcplib_funcgenbare_new(lua_State *L);
 int mcplib_funcgen_new(lua_State *L);

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1673,6 +1673,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"res_any", mcplib_rcontext_res_any},
         {"result", mcplib_rcontext_result},
         {"cfd", mcplib_rcontext_cfd},
+        {"tls_peer_cn", mcplib_rcontext_tls_peer_cn},
         //{"sleep", mcplib_rcontext_sleep}, see comments on function
         {NULL, NULL}
     };

--- a/tls.h
+++ b/tls.h
@@ -8,6 +8,7 @@
 
 #ifdef TLS
 void *ssl_accept(conn *c, int sfd, bool *fail);
+const unsigned char *ssl_get_peer_cn(conn *c, int *len);
 int ssl_init(void);
 void ssl_init_settings(void);
 void ssl_init_conn(conn *c, void *ssl);


### PR DESCRIPTION
Returns a string copy of the TLS peer CN entry. Returns nil if none exists or unable to parse the certificate.

---

Untested but compiles.

TODO:

- [ ] Test it a bit.