### PR TITLE
proxy: ustats internal refactor

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -184,8 +184,9 @@ void process_proxy_stats(void *arg, ADD_STAT add_stats, void *c) {
     buffer_memory_limit = ctx->buffer_memory_limit;
 
     // prepare aggregated counters.
-    struct proxy_user_stats *us = &ctx->user_stats;
-    uint64_t counters[us->num_stats];
+    struct proxy_user_stats_entry *us = ctx->user_stats;
+    int stats_num = ctx->user_stats_num;
+    uint64_t counters[stats_num];
     memset(counters, 0, sizeof(counters));
 
     // TODO (v3): more globals to remove and/or change API method.
@@ -200,8 +201,8 @@ void process_proxy_stats(void *arg, ADD_STAT add_stats, void *c) {
         }
         istats.vm_gc_runs += is->vm_gc_runs;
         istats.vm_memory_kb += is->vm_memory_kb;
-        if (tus && tus->num_stats >= us->num_stats) {
-            for (int i = 0; i < us->num_stats; i++) {
+        if (tus && tus->num_stats >= stats_num) {
+            for (int i = 0; i < stats_num; i++) {
                 counters[i] += tus->counters[i];
             }
         }
@@ -212,10 +213,31 @@ void process_proxy_stats(void *arg, ADD_STAT add_stats, void *c) {
     }
 
     // return all of the user generated stats
-    for (int x = 0; x < us->num_stats; x++) {
-        if (us->names[x] && us->names[x][0]) {
-            snprintf(key_str, STAT_KEY_LEN-1, "user_%s", us->names[x]);
-            APPEND_STAT(key_str, "%llu", (unsigned long long)counters[x]);
+    if (ctx->user_stats_namebuf) {
+        char vbuf[INCR_MAX_STORAGE_LEN];
+        char *e = NULL; // ptr into vbuf
+        const char *pfx = "user_";
+        const size_t pfxlen = strlen(pfx);
+        for (int x = 0; x < stats_num; x++) {
+            if (us[x].cname) {
+                char *name = ctx->user_stats_namebuf + us[x].cname;
+                size_t nlen = strlen(name);
+                if (nlen > STAT_KEY_LEN-6) {
+                    // impossible, but for paranoia.
+                    nlen = STAT_KEY_LEN-6;
+                }
+                // avoiding an snprintf call for some performance ("user_%s")
+                memcpy(key_str, pfx, pfxlen);
+                memcpy(key_str+pfxlen, name, nlen);
+                key_str[pfxlen+nlen] = '\0';
+
+                // APPEND_STAT() calls another snprintf, which calls our
+                // add_stats argument. Lets skip yet another snprintf with
+                // some unrolling.
+                e = itoa_u64(counters[x], vbuf);
+                *(e+1) = '\0';
+                add_stats(key_str, pfxlen+nlen, vbuf, e-vbuf, c);
+            }
         }
     }
 

--- a/t/proxyustats.t
+++ b/t/proxyustats.t
@@ -179,13 +179,15 @@ subtest 'ustats incr/decr and perseverance over reload' => sub {
     $p_srv->reload();
     wait_reload($watcher);
 
-    # subtract 2 at idx 2.
-    print $ps "mg -2\r\n";
-    is(scalar <$ps>, "HD\r\n", "mg -2 hit");
+    # add 2 at idx 2.
+    print $ps "mg 2\r\n";
+    is(scalar <$ps>, "HD\r\n", "mg 2 hit");
 
     $stats = mem_stats($ps, 'proxy');
+    # carried over since name did not change
     is($stats->{user_a1}, 1, "user_a1 is 1");
-    is($stats->{user_b2}, 2, "user_b2 is 2");
+    # index 2 changed names, so should be reset.
+    is($stats->{user_b2}, 2, "user_b2 is 2 instead of 4");
     is($stats->{user_b3}, 0, "user_b3 is 0");
     is($stats->{user_b4}, 0, "user_b4 is 0");
 };


### PR DESCRIPTION
If a ustat changes name for the same index, its value is reset to 0.

Cleans up some confusing code around how ustats are handled; the global ctx and worker threads now use different structures with different intent, instead of different sides of the same struct.

Also reorders the entries in the global ctx so the most frequently accessed ones are clustered toward the front of the struct.