### PR TITLE
Proxy API: req/res accessors and inspector object

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_await.c proxy_ustats.c \
 					 proxy_ratelim.c \
 					 proxy_jump_hash.c proxy_request.c \
+					 proxy_result.c proxy_inspector.c \
 					 proxy_network.c proxy_lua.c \
 					 proxy_luafgen.c \
 					 proxy_config.c proxy_ring_hash.c \

--- a/proxy.h
+++ b/proxy.h
@@ -813,6 +813,7 @@ int mcplib_request_token(lua_State *L);
 int mcplib_request_ntokens(lua_State *L);
 int mcplib_request_has_flag(lua_State *L);
 int mcplib_request_flag_token(lua_State *L);
+int mcplib_request_flag_token_int(lua_State *L);
 int mcplib_request_flag_add(lua_State *L);
 int mcplib_request_flag_set(lua_State *L);
 int mcplib_request_flag_replace(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -810,6 +810,7 @@ int mcplib_request_key(lua_State *L);
 int mcplib_request_ltrimkey(lua_State *L);
 int mcplib_request_rtrimkey(lua_State *L);
 int mcplib_request_token(lua_State *L);
+int mcplib_request_token_int(lua_State *L);
 int mcplib_request_ntokens(lua_State *L);
 int mcplib_request_has_flag(lua_State *L);
 int mcplib_request_flag_token(lua_State *L);

--- a/proxy.h
+++ b/proxy.h
@@ -492,6 +492,7 @@ enum mcp_resp_mode {
 #define RESP_CMD_MAX 8
 typedef struct {
     mcmc_resp_t resp;
+    mcmc_tokenizer_t tok; // optional tokenization of res
     char *buf; // response line + potentially value.
     mc_resp *cresp; // client mc_resp object during extstore fetches.
     LIBEVENT_THREAD *thread; // cresp's owner thread needed for extstore cleanup.
@@ -773,6 +774,8 @@ struct mcp_rcontext_s {
     struct mcp_rqueue_s qslots[]; // queueable slots.
 };
 
+#define mcp_is_flag_invalid(f) (f < 65 || f > 122)
+
 void mcp_run_rcontext_handle(mcp_rcontext_t *rctx, int handle);
 void mcp_process_rctx_wait(mcp_rcontext_t *rctx, int handle);
 int mcp_process_rqueue_return(mcp_rcontext_t *rctx, int handle, mcp_resp_t *res);
@@ -824,8 +827,24 @@ int mcplib_request_match_res(lua_State *L);
 void mcp_request_cleanup(LIBEVENT_THREAD *t, mcp_request_t *rq);
 
 // response interface
+int mcplib_response_elapsed(lua_State *L);
+int mcplib_response_ok(lua_State *L);
+int mcplib_response_hit(lua_State *L);
+int mcplib_response_vlen(lua_State *L);
+int mcplib_response_code(lua_State *L);
+int mcplib_response_line(lua_State *L);
+int mcplib_response_flag_blank(lua_State *L);
+
+// inspector interface
+int mcplib_req_inspector_new(lua_State *L);
+int mcplib_res_inspector_new(lua_State *L);
+int mcplib_inspector_gc(lua_State *L);
+int mcplib_inspector_call(lua_State *L);
+
 void mcp_response_cleanup(LIBEVENT_THREAD *t, mcp_resp_t *r);
 void mcp_set_resobj(mcp_resp_t *r, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t);
+int mcplib_response_gc(lua_State *L);
+int mcplib_response_close(lua_State *L);
 
 int mcplib_open_dist_jump_hash(lua_State *L);
 int mcplib_open_dist_ring_hash(lua_State *L);
@@ -837,6 +856,7 @@ int mcp_request_render(mcp_request_t *rq, int idx, char flag, const char *tok, s
 int mcp_request_append(mcp_request_t *rq, const char flag, const char *tok, size_t len);
 int mcp_request_find_flag_index(mcp_request_t *rq, const char flag);
 int mcp_request_find_flag_token(mcp_request_t *rq, const char flag, const char **token, size_t *len);
+int mcp_request_find_flag_tokenint64(mcp_request_t *rq, const char flag, int64_t *token);
 void proxy_lua_error(lua_State *L, const char *s);
 #define proxy_lua_ferror(L, fmt, ...) \
     do { \

--- a/proxy_inspector.c
+++ b/proxy_inspector.c
@@ -1,0 +1,674 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+
+enum mcp_ins_type {
+    INS_REQ = 1,
+    INS_RES,
+};
+
+enum mcp_ins_steptype {
+    mcp_ins_step_none = 0,
+    mcp_ins_step_sepkey,
+    mcp_ins_step_keybegin,
+    mcp_ins_step_keyis,
+    mcp_ins_step_hasflag,
+    mcp_ins_step_flagtoken,
+    mcp_ins_step_flagint,
+    mcp_ins_step_flagis,
+    mcp_ins_step_final, // not used.
+};
+
+// START STEP STRUCTS
+
+struct mcp_ins_sepkey {
+    char sep;
+    int pos;
+    int mapref;
+};
+
+struct mcp_ins_string {
+    unsigned int str; // arena offset for match string.
+    unsigned int len;
+};
+
+struct mcp_ins_flag {
+    uint64_t bit; // flag converted for bitmask test
+    char f;
+};
+
+// TODO: it might make more sense to flatten the structs into the ins_step
+// struct. It wouldn't take much more space if we can be careful with
+// alignment.
+struct mcp_ins_flagstr {
+    unsigned int str;
+    unsigned int len;
+    uint64_t bit; // flag bit
+    char f;
+};
+
+struct mcp_ins_step {
+    enum mcp_ins_steptype type;
+    union {
+        struct mcp_ins_sepkey sepkey;
+        struct mcp_ins_string string;
+        struct mcp_ins_flag flag;
+        struct mcp_ins_flagstr flagstr;
+    } c;
+};
+
+// END STEP STRUCTS
+
+struct mcp_inspector {
+    enum mcp_ins_type type;
+    int scount;
+    unsigned int aused; // arena memory used
+    unsigned int rcount; // number of results to expect
+    char *arena; // string/data storage for steps
+    struct mcp_ins_step steps[];
+};
+
+// PRIVATE INTERFACE
+
+// COMMON ARG HANDLERS
+
+// multiple step types only take 'flag' as an argument.
+static int mcp_inspector_flag_c_g(lua_State *L, int tidx) {
+    if (lua_getfield(L, tidx, "flag") != LUA_TNIL) {
+        size_t len = 0;
+        const char *flag = lua_tolstring(L, -1, &len);
+        if (len != 1) {
+            proxy_lua_ferror(L, "inspector step %d: 'flag' must be a single character", tidx);
+        }
+        if (mcp_is_flag_invalid(flag[0])) {
+            proxy_lua_ferror(L, "inspect step %d: 'flag' must be alphanumeric", tidx);
+        }
+    } else {
+        proxy_lua_ferror(L, "inspector step %d: must provide 'flag' argument", tidx);
+    }
+    lua_pop(L, 1); // val or nil
+    return 0;
+}
+
+static int mcp_inspector_flag_i_g(lua_State *L, int tidx, int sc, struct mcp_inspector *ins) {
+    struct mcp_ins_step *s = &ins->steps[sc];
+    struct mcp_ins_flag *c = &s->c.flag;
+
+    if (lua_getfield(L, tidx, "flag") != LUA_TNIL) {
+        const char *flag = lua_tostring(L, -1);
+        c->f = flag[0];
+        c->bit = (uint64_t)1 << (c->f - 65);
+    }
+    lua_pop(L, 1); // val or nil
+
+    return 0;
+}
+
+static int mcp_inspector_string_c_g(lua_State *L, int tidx) {
+    size_t len = 0;
+
+    if (lua_getfield(L, tidx, "str") != LUA_TNIL) {
+        lua_tolstring(L, -1, &len);
+        if (len < 1) {
+            proxy_lua_ferror(L, "inspector step %d: 'str' must have nonzero length", tidx);
+        }
+    } else {
+        proxy_lua_ferror(L, "inspector step %d: must provide 'str' argument", tidx);
+    }
+    lua_pop(L, 1); // val or nil
+
+    return len;
+}
+
+static int mcp_inspector_string_i_g(lua_State *L, int tidx, int sc, struct mcp_inspector *ins) {
+    struct mcp_ins_step *s = &ins->steps[sc];
+    struct mcp_ins_string *c = &s->c.string;
+    size_t len = 0;
+
+    // store our match string in the arena space that we reserved before.
+    if (lua_getfield(L, tidx, "str") != LUA_TNIL) {
+        const char *str = lua_tolstring(L, -1, &len);
+        c->str = ins->aused;
+        c->len = len;
+        char *a = ins->arena + ins->aused;
+        memcpy(a, str, len);
+        ins->aused += len;
+    }
+    lua_pop(L, 1); // val or nil
+
+    return len;
+}
+
+// END COMMMON ARG HANDLERS
+
+static int mcp_inspector_sepkey_c(lua_State *L, int tidx) {
+    if (lua_getfield(L, tidx, "sep") != LUA_TNIL) {
+        size_t len = 0;
+        lua_tolstring(L, -1, &len);
+        if (len != 1) {
+            proxy_lua_ferror(L, "inspector step %d: separator must be one character", tidx);
+        }
+    }
+    lua_pop(L, 1); // val or nil
+
+    if (lua_getfield(L, tidx, "pos") != LUA_TNIL) {
+        luaL_checktype(L, -1, LUA_TNUMBER);
+    }
+    lua_pop(L, 1); // val or nil
+
+    if (lua_getfield(L, tidx, "map") != LUA_TNIL) {
+        luaL_checktype(L, -1, LUA_TTABLE);
+    }
+    lua_pop(L, 1); // val or nil
+
+    return 0;
+}
+
+// initializer. arguments already checked, so just fill out the slot.
+static int mcp_inspector_sepkey_i(lua_State *L, int tidx, int sc, struct mcp_inspector *ins) {
+    struct mcp_ins_step *s = &ins->steps[sc];
+    struct mcp_ins_sepkey *c = &s->c.sepkey;
+
+    if (lua_getfield(L, tidx, "sep") != LUA_TNIL) {
+        const char *sep = lua_tostring(L, -1);
+        c->sep = sep[0];
+    } else {
+        // default separator
+        c->sep = '/';
+    }
+    lua_pop(L, 1); // val or nil
+
+    if (lua_getfield(L, tidx, "pos") != LUA_TNIL) {
+        c->pos = lua_tointeger(L, -1);
+    } else {
+        c->pos = 1;
+    }
+    lua_pop(L, 1);
+
+    if (lua_getfield(L, tidx, "map") != LUA_TNIL) {
+        c->mapref = luaL_ref(L, LUA_REGISTRYINDEX);
+    } else {
+        c->mapref = 0;
+        lua_pop(L, 1);
+    }
+    // ref was popped
+
+    return 0;
+}
+
+// TODO: abstract out the token-position-finder
+static int mcp_inspector_sepkey_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    mcp_request_t *rq = arg;
+    struct mcp_ins_sepkey *c = &s->c.sepkey;
+
+    const char *key = MCP_PARSER_KEY(rq->pr);
+    const char *end = key + rq->pr.klen;
+    char sep = c->sep;
+    int pos = c->pos;
+
+    // skip initial separators
+    while (key != end) {
+        if (*key == sep) {
+            key++;
+        } else {
+            break;
+        }
+    }
+    const char *token = key;
+    int tlen = 0;
+
+    while (key != end) {
+        if (*key == sep) {
+            // measure token length and stop if at position.
+            if (--pos == 0) {
+                tlen = key - token;
+                break;
+            } else {
+                // NOTE: this could point past the end of the key, but unless
+                // it's the token we want we won't look at it.
+                token = key+1;
+            }
+        }
+        key++;
+    }
+
+    // either the separator was never found, or we ended before finding
+    // another one, which gives us an end token.
+    if (pos == 1) {
+        tlen = key - token;
+    }
+
+    // now have *token and tlen
+    if (tlen != 0) {
+        if (c->mapref) {
+            // look up this string against the map.
+            // NOTE: this still ends up creating a garbage string. However,
+            // since the map is internal we can optimize this later by moving
+            // the map lookup op to C.
+            lua_rawgeti(L, LUA_REGISTRYINDEX, c->mapref);
+            lua_pushlstring(L, token, tlen);
+            lua_rawget(L, -2); // pops string.
+            lua_remove(L, -2); // removes map, shifts lookup result down.
+            // stack should be clean: just the result.
+        } else {
+            // no map, return the actual token.
+            lua_pushlstring(L, token, tlen);
+        }
+    } else {
+        lua_pushnil(L); // not found.
+    }
+
+    return 1;
+}
+
+static int mcp_inspector_keybegin_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    mcp_request_t *rq = arg;
+    struct mcp_ins_string *c = &s->c.string;
+
+    const char *key = MCP_PARSER_KEY(rq->pr);
+    int klen = rq->pr.klen;
+    const char *str = ins->arena + c->str;
+
+    if (c->len < klen && strncmp(key, str, c->len) == 0) {
+        lua_pushboolean(L, 1);
+    } else {
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
+static int mcp_inspector_keyis_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    mcp_request_t *rq = arg;
+    struct mcp_ins_string *c = &s->c.string;
+
+    const char *key = MCP_PARSER_KEY(rq->pr);
+    int klen = rq->pr.klen;
+    const char *str = ins->arena + c->str;
+
+    if (c->len == klen && strncmp(key, str, c->len) == 0) {
+        lua_pushboolean(L, 1);
+    } else {
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
+static int mcp_inspector_hasflag_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    struct mcp_ins_flag *c = &s->c.flag;
+    if (ins->type == INS_REQ) {
+        mcp_request_t *rq = arg;
+        // requests should always be tokenized, so we can just check the bit.
+        if (rq->pr.t.meta.flags & c->bit) {
+            lua_pushboolean(L, 1);
+        } else {
+            lua_pushboolean(L, 0);
+        }
+    } else {
+        mcp_resp_t *res = arg;
+        if (res->resp.type == MCMC_RESP_META) {
+            // result object may not be tokenized. this will do so if not
+            // already. any future hits agains the same object will use the
+            // cached tokenizer struct.
+            mcmc_tokenize_res(res->buf, res->resp.reslen, &res->tok);
+            if (mcmc_token_has_flag_bit(&res->tok, c->bit) == MCMC_OK) {
+                lua_pushboolean(L, 1);
+            } else {
+                lua_pushboolean(L, 0);
+            }
+        } else {
+            proxy_lua_error(L, "inspector error: response is not meta protocol");
+        }
+    }
+    return 1;
+}
+
+// This mirrors `bool, (str|nil) = r:flag_token("T")`
+static int mcp_inspector_flagtoken_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    struct mcp_ins_flag *c = &s->c.flag;
+    if (ins->type == INS_REQ) {
+        mcp_request_t *rq = arg;
+
+        if (rq->pr.t.meta.flags & c->bit) {
+            lua_pushboolean(L, 1); // flag exists
+            const char *tok = NULL;
+            size_t tlen = 0;
+            mcp_request_find_flag_token(rq, c->f, &tok, &tlen);
+            lua_pushlstring(L, tok, tlen); // flag's token
+            return 2;
+        }
+    } else {
+        mcp_resp_t *res = arg;
+        if (res->resp.type == MCMC_RESP_META) {
+            mcmc_tokenize_res(res->buf, res->resp.reslen, &res->tok);
+            if (mcmc_token_has_flag_bit(&res->tok, c->bit) == MCMC_OK) {
+                lua_pushboolean(L, 1); // flag exists
+                int tlen = 0;
+                const char *tok = mcmc_token_get_flag(res->buf, &res->tok, c->f, &tlen);
+                lua_pushlstring(L, tok, tlen); // flag's token
+                return 2;
+            }
+        }
+    }
+    lua_pushboolean(L, 0);
+    lua_pushnil(L);
+
+    return 2;
+}
+
+// TODO: flaguint variant?
+// still stuck as signed in lua but would reject signed tokens
+static int mcp_inspector_flagint_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    struct mcp_ins_flag *c = &s->c.flag;
+    if (ins->type == INS_REQ) {
+        mcp_request_t *rq = arg;
+
+        if (rq->pr.t.meta.flags & c->bit) {
+            lua_pushboolean(L, 1); // flag exists
+            int64_t tok = 0;
+            if (mcp_request_find_flag_tokenint64(rq, c->f, &tok) == 0) {
+                lua_pushinteger(L, tok);
+            } else {
+                lua_pushnil(L);
+            }
+            return 2;
+        }
+    } else {
+        mcp_resp_t *res = arg;
+        if (res->resp.type == MCMC_RESP_META) {
+            mcmc_tokenize_res(res->buf, res->resp.reslen, &res->tok);
+            if (mcmc_token_has_flag_bit(&res->tok, c->bit) == MCMC_OK) {
+                lua_pushboolean(L, 1); // flag exists
+                int64_t tok = 0;
+                if (mcmc_token_get_flag_64(res->buf, &res->tok, c->f, &tok) == MCMC_OK) {
+                    lua_pushinteger(L, tok);
+                } else {
+                    lua_pushnil(L); // token couldn't be converted
+                }
+                return 2;
+            }
+        }
+    }
+    lua_pushboolean(L, 0);
+    lua_pushnil(L);
+
+    return 2;
+}
+
+static int mcp_inspector_flagstr_c(lua_State *L, int tidx) {
+    mcp_inspector_flag_c_g(L, tidx);
+    int size = mcp_inspector_string_c_g(L, tidx);
+    return size;
+}
+
+static int mcp_inspector_flagstr_i(lua_State *L, int tidx, int sc, struct mcp_inspector *ins) {
+    // TODO: if we never use mcp_ins_step we can remove it and just pass parts
+    // of the relevant structs down into these functions.
+    struct mcp_ins_step *s = &ins->steps[sc];
+    struct mcp_ins_flagstr *c = &s->c.flagstr;
+    size_t len = 0;
+
+    if (lua_getfield(L, tidx, "flag") != LUA_TNIL) {
+        const char *flag = lua_tostring(L, -1);
+        c->f = flag[0];
+        c->bit = (uint64_t)1 << (c->f - 65);
+    }
+    lua_pop(L, 1); // val or nil
+
+    if (lua_getfield(L, tidx, "str") != LUA_TNIL) {
+        const char *str = lua_tolstring(L, -1, &len);
+        c->str = ins->aused;
+        c->len = len;
+        char *a = ins->arena + ins->aused;
+        memcpy(a, str, len);
+        ins->aused += len;
+    }
+    lua_pop(L, 1); // val or nil
+
+    return len;
+}
+
+// FIXME: size_t vs int consistency for tlen would shorten the code.
+static int mcp_inspector_flagis_r(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg) {
+    struct mcp_ins_flagstr *c = &s->c.flagstr;
+    const char *str = ins->arena + c->str;
+    if (ins->type == INS_REQ) {
+        mcp_request_t *rq = arg;
+
+        if (rq->pr.t.meta.flags & c->bit) {
+            lua_pushboolean(L, 1); // flag exists
+            const char *tok = NULL;
+            size_t tlen = 0;
+            mcp_request_find_flag_token(rq, c->f, &tok, &tlen);
+            if (tlen == c->len && strncmp(tok, str, c->len) == 0) {
+                lua_pushboolean(L, 1);
+            } else {
+                lua_pushboolean(L, 0);
+            }
+            return 2;
+        }
+    } else {
+        mcp_resp_t *res = arg;
+        if (res->resp.type == MCMC_RESP_META) {
+            mcmc_tokenize_res(res->buf, res->resp.reslen, &res->tok);
+            if (mcmc_token_has_flag_bit(&res->tok, c->bit) == MCMC_OK) {
+                lua_pushboolean(L, 1); // flag exists
+                int tlen = 0;
+                const char *tok = mcmc_token_get_flag(res->buf, &res->tok, c->f, &tlen);
+                if (tlen == c->len && strncmp(tok, str, c->len) == 0) {
+                    lua_pushboolean(L, 1);
+                } else {
+                    lua_pushboolean(L, 0);
+                }
+                return 2;
+            }
+        }
+    }
+    lua_pushboolean(L, 0);
+    lua_pushnil(L);
+
+    return 2;
+}
+
+// END STEPS
+
+typedef int (*mcp_ins_c)(lua_State *L, int tidx);
+typedef int (*mcp_ins_i)(lua_State *L, int tidx, int sc, struct mcp_inspector *ins);
+typedef int (*mcp_ins_r)(lua_State *L, struct mcp_inspector *ins, struct mcp_ins_step *s, void *arg);
+
+struct mcp_ins_entry {
+    const char *s; // string name
+    mcp_ins_c c;
+    mcp_ins_i i;
+    mcp_ins_r r;
+    unsigned int t; // allowed object types
+    int n; // number of results to expect
+};
+
+static const struct mcp_ins_entry mcp_ins_entries[] = {
+    [mcp_ins_step_none] = {NULL, NULL, NULL, NULL, 0, 0},
+    [mcp_ins_step_sepkey] = {"sepkey", mcp_inspector_sepkey_c, mcp_inspector_sepkey_i, mcp_inspector_sepkey_r, INS_REQ, 1},
+    [mcp_ins_step_keybegin] = {"keybegin", mcp_inspector_string_c_g, mcp_inspector_string_i_g, mcp_inspector_keybegin_r, INS_REQ, 1},
+    [mcp_ins_step_keyis] = {"keyis", mcp_inspector_string_c_g, mcp_inspector_string_i_g, mcp_inspector_keyis_r, INS_REQ, 1},
+    [mcp_ins_step_hasflag] = {"hasflag", mcp_inspector_flag_c_g, mcp_inspector_flag_i_g, mcp_inspector_hasflag_r, INS_REQ|INS_RES, 1},
+    [mcp_ins_step_flagtoken] = {"flagtoken", mcp_inspector_flag_c_g, mcp_inspector_flag_i_g, mcp_inspector_flagtoken_r, INS_REQ|INS_RES, 2},
+    [mcp_ins_step_flagint] = {"flagint", mcp_inspector_flag_c_g, mcp_inspector_flag_i_g, mcp_inspector_flagint_r, INS_REQ|INS_RES, 2},
+    [mcp_ins_step_flagis] = {"flagis", mcp_inspector_flagstr_c, mcp_inspector_flagstr_i, mcp_inspector_flagis_r, INS_REQ|INS_RES, 2},
+};
+
+// call with type string on top
+static enum mcp_ins_steptype mcp_inspector_steptype(lua_State *L) {
+    const char *type = luaL_checkstring(L, -1);
+    for (int x = 0; x < mcp_ins_step_final; x++) {
+        const struct mcp_ins_entry *e = &mcp_ins_entries[x];
+        if (e->s && strcmp(type, e->s) == 0) {
+            return x;
+        }
+    }
+    return mcp_ins_step_none;
+}
+
+// - arguments given as list of tables:
+//   { t = "type", arg = "bar", etc },
+//   { etc }
+//   - can take table-of-tables via: mcp.req_inspector_new(table.unpack(args))
+// NOTES:
+// - can we inline necessary strings/etc via extra allocated memory?
+// - can we get mcp.inspector metatable into the upvalue of the _call and _gc
+// funcs for fast-compare?
+static int mcp_inspector_new(lua_State *L, enum mcp_ins_type type) {
+    int argc = lua_gettop(L);
+    size_t size = 0;
+    int scount = 0;
+
+    // loop argument tables once for validation and pre-calculations.
+    for (int x = 1; x <= argc; x++) {
+        luaL_checktype(L, x, LUA_TTABLE);
+        if (lua_getfield(L, x, "t") != LUA_TNIL) {
+            enum mcp_ins_steptype st = mcp_inspector_steptype(L);
+            const struct mcp_ins_entry *e = &mcp_ins_entries[st];
+            if (!(e->t & type)) {
+                proxy_lua_ferror(L, "inspector step %d: step incompatible with inspector type", x);
+            }
+            if ((st == mcp_ins_step_none) || e->c == NULL) {
+                proxy_lua_ferror(L, "inspector step %d: unknown step type", x);
+            }
+            size += e->c(L, x);
+        }
+        lua_pop(L, 1); // drop 't' or nil
+        scount++;
+    }
+
+    // we now know the size and number of steps. allocate some flat memory.
+
+    // TODO: we need memory for steps + arbitrary step data. (ie; string stems
+    // and the like)
+    // - now: single extra malloc, divvy out the buffer as requested
+    // - later: if alignment of the flexible step array can be reliably
+    // determined (C11 alignas or etc), inline memory can be used instead.
+    size_t extsize = sizeof(struct mcp_ins_step) * scount;
+    struct mcp_inspector *ins = lua_newuserdatauv(L, sizeof(*ins) + extsize, 1);
+    memset(ins, 0, sizeof(*ins));
+
+    ins->arena = malloc(size);
+    if (ins->arena == NULL) {
+        proxy_lua_error(L, "mcp.req_inspector_new: failed to allocate memory");
+    }
+
+    luaL_setmetatable(L, "mcp.inspector");
+    switch (type) {
+        case INS_REQ:
+            luaL_getmetatable(L, "mcp.request");
+            break;
+        case INS_RES:
+            luaL_getmetatable(L, "mcp.response");
+            break;
+    }
+    // set metatable to the upvalue for a fast comparison during __call
+    lua_setiuservalue(L, -2, 1);
+    ins->type = type;
+
+    // loop the arg tables again to fill in the steps
+    // skip checks since we did that during the first loop.
+    scount = 0;
+    for (int x = 1; x <= argc; x++) {
+        if (lua_getfield(L, x, "t") != LUA_TNIL) {
+            enum mcp_ins_steptype st = mcp_inspector_steptype(L);
+            ins->steps[scount].type = st;
+            mcp_ins_entries[st].i(L, x, scount, ins);
+            ins->rcount += mcp_ins_entries[st].n;
+        }
+        lua_pop(L, 1); // drop t or nil
+        scount++;
+    }
+
+    if (size != ins->aused) {
+        proxy_lua_error(L, "inspector failed to properly initialize, memory not filled correctly");
+    }
+    ins->scount = scount;
+
+    return 1;
+}
+
+static int mcp_ins_run(lua_State *L, struct mcp_inspector *ins, void *arg) {
+    int ret = 0;
+
+    for (int x = 0; x < ins->scount; x++) {
+        struct mcp_ins_step *s = &ins->steps[x];
+        assert(s->type != mcp_ins_step_none);
+        ret += mcp_ins_entries[s->type].r(L, ins, s, arg);
+    }
+
+    return ret;
+}
+
+// PUBLIC INTERFACE
+
+int mcplib_req_inspector_new(lua_State *L) {
+    return mcp_inspector_new(L, INS_REQ);
+}
+
+int mcplib_res_inspector_new(lua_State *L) {
+    return mcp_inspector_new(L, INS_RES);
+}
+
+// walk each step and free references/memory/etc
+int mcplib_inspector_gc(lua_State *L) {
+    struct mcp_inspector *ins = lua_touserdata(L, 1);
+
+    if (ins->arena) {
+        free(ins->arena);
+        ins->arena = NULL;
+    }
+
+    for (int x = 0; x < ins->scount; x++) {
+        struct mcp_ins_step *s = &ins->steps[x];
+        switch (s->type) {
+            case mcp_ins_step_sepkey:
+                if (s->c.sepkey.mapref) {
+                    luaL_unref(L, LUA_REGISTRYINDEX, s->c.sepkey.mapref);
+                    s->c.sepkey.mapref = 0;
+                }
+                break;
+            case mcp_ins_step_keybegin:
+            case mcp_ins_step_keyis:
+            case mcp_ins_step_hasflag:
+            case mcp_ins_step_flagtoken:
+            case mcp_ins_step_flagint:
+            case mcp_ins_step_flagis:
+            case mcp_ins_step_none:
+            case mcp_ins_step_final:
+                break;
+        }
+    }
+
+    return 0;
+}
+
+// - iterate steps, call function callbacks with as context arg
+// TODO:
+// - second arg _may_ be a table: in which case we fill the results into this
+//   table rather than return them directly.
+//   - do this via a different run function that pops each step result?
+int mcplib_inspector_call(lua_State *L) {
+    // since we're here from a __call, assume the type is correct.
+    struct mcp_inspector *ins = lua_touserdata(L, 1);
+    luaL_checktype(L, 2, LUA_TUSERDATA);
+    if (lua_checkstack(L, ins->rcount) == 0) {
+        proxy_lua_error(L, "inspector ran out of stack space for results");
+    }
+
+    // luaL_checkudata() is slow. Trying a new method here where we pull the
+    // metatable from a reference then compare it against the meta table of
+    // the argument object.
+    lua_getmetatable(L, 2); // put arg metatable on stack
+    lua_getiuservalue(L, 1, 1); // put stashed metatable on stack
+    luaL_argcheck(L, lua_rawequal(L, -1, -2), 2,
+            "invalid argument to inspector object");
+    lua_pop(L, 2); // toss both metatables
+
+    // we're valid now. run the steps
+    void *arg = lua_touserdata(L, 2);
+    return mcp_ins_run(L, ins, arg);
+}

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -1726,7 +1726,7 @@ int mcplib_internal_run(mcp_rcontext_t *rctx) {
     // wrap the main commands with something that decorates r->resp directly
     // instead of going through a parser to save some CPU.
     // Either way this is a lot less code.
-    mcmc_bare_parse_buf(resp->iov[0].iov_base, resp->iov[0].iov_len, &r->resp);
+    mcmc_parse_buf(resp->iov[0].iov_base, resp->iov[0].iov_len, &r->resp);
 
     if (rq->ascii_multiget) {
         if (r->resp.type == MCMC_RESP_GET) {

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1720,6 +1720,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"ltrimkey", mcplib_request_ltrimkey},
         {"rtrimkey", mcplib_request_rtrimkey},
         {"token", mcplib_request_token},
+        {"token_int", mcplib_request_token_int},
         {"ntokens", mcplib_request_ntokens},
         {"has_flag", mcplib_request_has_flag},
         {"flag_token", mcplib_request_flag_token},

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1723,6 +1723,7 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         {"ntokens", mcplib_request_ntokens},
         {"has_flag", mcplib_request_has_flag},
         {"flag_token", mcplib_request_flag_token},
+        {"flag_token_int", mcplib_request_flag_token_int},
         {"flag_add", mcplib_request_flag_add},
         {"flag_set", mcplib_request_flag_set},
         {"flag_replace", mcplib_request_flag_replace},

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -504,7 +504,7 @@ static int proxy_backend_drive_machine(struct mcp_backendconn_s *be) {
             break;
         case mcp_backend_parse:
             r = p->client_resp;
-            r->status = mcmc_parse_buf(be->client, be->rbuf, be->rbufused, &r->resp);
+            r->status = mcmc_parse_buf(be->rbuf, be->rbufused, &r->resp);
 
             // Quick check if we need more data.
             if (r->resp.code == MCMC_WANT_READ) {
@@ -1089,7 +1089,7 @@ static void proxy_bevalidate_tls_handler(const int fd, const short which, void *
         if (read > 0) {
             mcmc_resp_t r;
 
-            int status = mcmc_parse_buf(be->client, be->rbuf, be->rbufused, &r);
+            int status = mcmc_parse_buf(be->rbuf, be->rbufused, &r);
             if (status == MCMC_ERR) {
                 // Needed more data for a version line, somehow. I feel like
                 // this should set off some alarms, but it is possible.
@@ -1259,7 +1259,7 @@ static void proxy_beconn_handler(const int fd, const short which, void *arg) {
             mcmc_resp_t r;
             be->rbufused += read;
 
-            int status = mcmc_parse_buf(be->client, be->rbuf, be->rbufused, &r);
+            int status = mcmc_parse_buf(be->rbuf, be->rbufused, &r);
             if (status == MCMC_ERR) {
                 // Needed more data for a version line, somehow. I feel like
                 // this should set off some alarms, but it is possible.

--- a/proxy_request.c
+++ b/proxy_request.c
@@ -1104,14 +1104,14 @@ int mcplib_request_match_res(lua_State *L) {
 
     // requests all have keys. check for an opaque.
     mcp_request_find_flag_token(rq, 'O', &opaque_token, &opaque_len);
-    mcmc_bare_parse_buf(rs->buf, rs->blen, &reresp);
+    mcmc_parse_buf(rs->buf, rs->blen, &reresp);
 
     // scan the response line for tokens, since we don't have a reciprocal API
     // yet. When we do this code will be replaced with a function call like
     // the above.
     const char *p = reresp.rline;
     // TODO: Think this is an off-by-one in mcmc.
-    const char *e = p + reresp.rlen - 1;
+    const char *e = p + reresp.rlen;
     if (!p) {
         // happens if the result line is blank (ie; 'HD\r\n')
         lua_pushboolean(L, 0);

--- a/proxy_result.c
+++ b/proxy_result.c
@@ -1,0 +1,166 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+#include "proxy.h"
+
+int mcplib_response_elapsed(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+    lua_pushinteger(L, r->elapsed);
+    return 1;
+}
+
+// resp:ok()
+int mcplib_response_ok(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    if (r->status == MCMC_OK) {
+        lua_pushboolean(L, 1);
+    } else {
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
+int mcplib_response_hit(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    if (r->status == MCMC_OK && r->resp.code != MCMC_CODE_END) {
+        lua_pushboolean(L, 1);
+    } else {
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
+// Caller needs to discern if a vlen is 0 because of a failed response or an
+// OK response that was actually zero. So we always return an integer value
+// here.
+int mcplib_response_vlen(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    // We do remove the "\r\n" from the value length, so if you're actually
+    // processing the value nothing breaks.
+    if (r->resp.vlen >= 2) {
+        lua_pushinteger(L, r->resp.vlen-2);
+    } else {
+        lua_pushinteger(L, 0);
+    }
+
+    return 1;
+}
+
+// Refer to MCMC_CODE_* defines.
+int mcplib_response_code(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    lua_pushinteger(L, r->resp.code);
+
+    return 1;
+}
+
+// Get the unparsed response line for handling in lua.
+int mcplib_response_line(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+
+    if (r->resp.rline != NULL) {
+        lua_pushlstring(L, r->resp.rline, r->resp.rlen);
+    } else {
+        lua_pushnil(L);
+    }
+
+    return 1;
+}
+
+int mcplib_response_flag_blank(lua_State *L) {
+    mcp_resp_t *r = luaL_checkudata(L, 1, "mcp.response");
+    mcmc_resp_t reresp;
+    size_t len = 0;
+    const char *flagstr = luaL_checklstring(L, 2, &len);
+
+    if (len != 1) {
+        proxy_lua_error(L, "request: meta flag must be a single character");
+        return 0;
+    }
+    if (flagstr[0] < 65 || flagstr[0] > 122) {
+        proxy_lua_error(L, "request: invalid flag, must be A-Z,a-z");
+        return 0;
+    }
+
+    mcmc_parse_buf(r->buf, r->blen, &reresp);
+
+    if (reresp.type == MCMC_RESP_META) {
+        // r->resp.rline is the start of the meta line... rlen is the length.
+        // we cast away the const and do evil here.
+        char *pos = (char *) reresp.rline;
+        size_t rlen = reresp.rlen;
+
+        char *end = pos + rlen;
+        char flag = flagstr[0];
+
+        while (pos != end) {
+            // either flag is at the start of the line or it has a space
+            // immediately before it.
+            if (*pos == flag && (pos == reresp.rline || *(pos-1) == ' ')) {
+                while (pos != end && !isspace(*pos)) {
+                    *pos = ' ';
+                    pos++;
+                }
+                lua_pushboolean(L, 1); // found and blanked.
+                return 1;
+            } else {
+                pos++;
+            }
+        }
+
+        // TODO: blank out r->tok?
+    }
+    lua_pushboolean(L, 0); // not found or not done.
+    return 1;
+}
+
+void mcp_response_cleanup(LIBEVENT_THREAD *t, mcp_resp_t *r) {
+    // On error/similar we might be holding the read buffer.
+    // If the buf is handed off to mc_resp for return, this pointer is NULL
+    if (r->buf != NULL) {
+        pthread_mutex_lock(&t->proxy_limit_lock);
+        t->proxy_buffer_memory_used -= r->blen + r->extra;
+        pthread_mutex_unlock(&t->proxy_limit_lock);
+
+        free(r->buf);
+        r->buf = NULL;
+    }
+
+    // release our temporary mc_resp sub-object.
+    if (r->cresp != NULL) {
+        mc_resp *cresp = r->cresp;
+        assert(r->thread != NULL);
+        if (cresp->item) {
+            item_remove(cresp->item);
+            cresp->item = NULL;
+        }
+        resp_free(r->thread, cresp);
+        r->cresp = NULL;
+    }
+}
+
+int mcplib_response_gc(lua_State *L) {
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+    mcp_resp_t *r = luaL_checkudata(L, -1, "mcp.response");
+    mcp_response_cleanup(t, r);
+
+    return 0;
+}
+
+// Note that this can be called multiple times for a single object, as opposed
+// to _gc. The cleanup routine is armored against repeat accesses by NULL'ing
+// th efields it checks.
+int mcplib_response_close(lua_State *L) {
+    LIBEVENT_THREAD *t = PROXY_GET_THR(L);
+    mcp_resp_t *r = luaL_checkudata(L, 1, "mcp.response");
+    mcp_response_cleanup(t, r);
+
+    return 0;
+}
+
+

--- a/t/proxyins.lua
+++ b/t/proxyins.lua
@@ -1,0 +1,141 @@
+function mcp_config_pools()
+    local b1 = mcp.backend('b1', '127.0.0.1', 12172)
+    return mcp.pool({b1})
+end
+
+function mcp_config_routes(p)
+    local mgsepkey = mcp.funcgen_new()
+    local mgsepkeyh = mgsepkey:new_handle(p)
+
+    local mgsepkey_ins = mcp.req_inspector_new(
+        { t = "sepkey", sep = "/", pos = 2, map = {
+            foo = 1, bar = 2,
+        }},
+        { t = "keybegin", str = "sepkey" }
+    )
+
+    local mgsepkeynomap_ins = mcp.req_inspector_new(
+        { t = "sepkey", sep = "/", pos = 2 }
+    )
+
+    local mgsepkey1_ins = mcp.req_inspector_new(
+        { t = "sepkey", sep = "/", pos = 1, map = {
+            baz = 1, foo = 2, sepkey = 3,
+        }}
+    )
+
+    local mgsepkey2_ins = mcp.req_inspector_new(
+        { t = "sepkey", sep = "/", pos = 2, map = {
+            baz = 1, foo = 2,
+        }}
+    )
+
+    local mgsepkey3_ins = mcp.req_inspector_new(
+        { t = "sepkey", sep = "/", pos = 3, map = {
+            baz = 1, foo = 2, three = 3,
+        }}
+    )
+
+    mgsepkey:ready({
+        n = "sepkey", f = function(rctx)
+            return function(r)
+                local key = r:key()
+                if key == "sepkey/baz" then
+                    local idx = mgsepkey2_ins(r)
+                    return string.format("SERVER_ERROR idx: %q\r\n", idx)
+                elseif key == "sepkey/nomap" then
+                    local str = mgsepkeynomap_ins(r)
+                    return string.format("SERVER_ERROR str: %s\r\n", str)
+                elseif key == "sepkey/one/two" then
+                    local idx = mgsepkey1_ins(r)
+                    return string.format("SERVER_ERROR idx: %q\r\n", idx)
+                elseif key == "sepkey/two/three" then
+                    local idx = mgsepkey3_ins(r)
+                    return string.format("SERVER_ERROR idx: %q\r\n", idx)
+                else
+                    local idx, b = mgsepkey_ins(r)
+                    local begin = "false"
+                    if b then
+                        begin = "true"
+                    end
+                    if idx == nil then
+                        return "SERVER_ERROR nil index\r\n"
+                    else
+                        return string.format("SERVER_ERROR idx: %d %s\r\n", idx, begin)
+                    end
+                end
+            end
+        end
+    })
+
+    local mgreshasf = mcp.funcgen_new()
+    local mgreshasfh = mgreshasf:new_handle(p)
+
+    local mgreshasf_ins = mcp.res_inspector_new(
+        { t = "hasflag", flag = "f" },
+        { t = "hasflag", flag = "t" }
+    )
+    -- TODO: also test req version
+    local mgresflaga_ins = mcp.res_inspector_new(
+        { t = "flagtoken", flag = "O" },
+        { t = "flagint", flag = "t" }
+    )
+
+    local mgreqflaga_ins = mcp.req_inspector_new(
+        { t = "flagtoken", flag = "O" },
+        { t = "flagint", flag = "T" }
+    )
+
+    local mgresflagis_ins = mcp.res_inspector_new(
+        { t = "flagis", flag = "O", str = "baz" }
+    )
+    mgreshasf:ready({
+        n = "reshasflag", f = function(rctx)
+            return function(r)
+                local key = r:key()
+                local res = rctx:enqueue_and_wait(r, mgreshasfh)
+                if key == "reshasf/flagis" then
+                    local exists, matches = mgresflagis_ins(res)
+                    return string.format("SERVER_ERROR exists[%q] matches[%q]\r\n", exists, matches)
+                elseif key == "reshasf/tokenint" then
+                    local has_O, O, has_t, t = mgresflaga_ins(res)
+                    return string.format("SERVER_ERROR O[%q]: %s t[%q]: %q\r\n",
+                        has_O, O, has_t, t)
+                elseif key == "reshasf/reqhasf" then
+                    local has_O, O, has_T, T = mgreqflaga_ins(r)
+                    return string.format("SERVER_ERROR O[%q]: %s T[%q]: %q\r\n",
+                        has_O, O, has_T, T)
+                else
+                    local f, t = mgreshasf_ins(res)
+                    return "SERVER_ERROR f: " .. tostring(f) .. " t: " .. tostring(t) .. "\r\n"
+                end
+            end
+        end
+    })
+
+    local mgreqkey = mcp.funcgen_new()
+    local mgreqkeyh = mgreqkey:new_handle(p)
+
+    local mgreqkeyis_ins = mcp.req_inspector_new(
+        { t = "keyis", str = "reqkey/one" },
+        { t = "keyis", str = "reqkey/two" },
+        { t = "keyis", str = "reqkey/three" }
+    )
+
+    mgreqkey:ready({
+        n = "reqkey", f = function(rctx)
+            return function(r)
+                local one, two, three = mgreqkeyis_ins(r)
+                return string.format("SERVER_ERROR one[%q] two[%q] three[%q]\r\n",
+                    one, two, three)
+            end
+        end
+    })
+
+    local mgr = mcp.router_new({ map = {
+        sepkey = mgsepkey,
+        reshasf = mgreshasf,
+        reqkey = mgreqkey,
+    }})
+    mcp.attach(mcp.CMD_MG, mgr)
+end

--- a/t/proxyins.t
+++ b/t/proxyins.t
@@ -1,0 +1,157 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $t = Memcached::ProxyTest->new(servers => [12172]);
+
+my $p_srv = new_memcached('-o proxy_config=./t/proxyins.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+my $w = $p_srv->new_sock;
+print $w "watch proxyevents\r\n";
+is(<$w>, "OK\r\n");
+
+{
+    test_mgreq();
+    test_mgres();
+}
+
+sub test_mgreq {
+    note 'test ins with mg req object';
+
+    subtest 'sepkey with map' => sub {
+        $t->c_send("mg sepkey/bar/restofkey s t v\r\n");
+        $t->c_recv("SERVER_ERROR idx: 2 true\r\n");
+        $t->clear();
+    };
+
+    subtest 'sepkey onesep' => sub {
+        $t->c_send("mg sepkey/baz s t v\r\n");
+        $t->c_recv("SERVER_ERROR idx: 1\r\n");
+        $t->clear();
+    };
+
+    subtest 'sepkey nomap' => sub {
+        $t->c_send("mg sepkey/nomap s t v\r\n");
+        $t->c_recv("SERVER_ERROR str: nomap\r\n");
+        $t->clear();
+    };
+
+    subtest 'sepkey one' => sub {
+        $t->c_send("mg sepkey/one/two s t v\r\n");
+        $t->c_recv("SERVER_ERROR idx: 3\r\n");
+        $t->clear();
+    };
+
+    subtest 'sepkey three' => sub {
+        $t->c_send("mg sepkey/two/three s t v\r\n");
+        $t->c_recv("SERVER_ERROR idx: 3\r\n");
+        $t->clear();
+    };
+
+    subtest 'keyis one' => sub {
+        $t->c_send("mg reqkey/one s t v\r\n");
+        $t->c_recv("SERVER_ERROR one[true] two[false] three[false]\r\n");
+        $t->clear();
+    };
+
+    subtest 'keyis two' => sub {
+        $t->c_send("mg reqkey/two s t v\r\n");
+        $t->c_recv("SERVER_ERROR one[false] two[true] three[false]\r\n");
+        $t->clear();
+    };
+
+    subtest 'keyis three' => sub {
+        $t->c_send("mg reqkey/three s t v\r\n");
+        $t->c_recv("SERVER_ERROR one[false] two[false] three[true]\r\n");
+        $t->clear();
+    };
+
+    subtest 'keyis none' => sub {
+        $t->c_send("mg reqkey/twoo s t v\r\n");
+        $t->c_recv("SERVER_ERROR one[false] two[false] three[false]\r\n");
+        $t->clear();
+    };
+
+}
+
+sub test_mgres {
+    note 'test ins with mg res object';
+
+    subtest 'has flags' => sub {
+        $t->c_send("mg reshasf/foo f t s\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD f1234 t9995\r\n");
+        $t->c_recv("SERVER_ERROR f: true t: true\r\n");
+        $t->clear();
+    };
+
+    subtest 'one flag' => sub {
+        $t->c_send("mg reshasf/foo f t s\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD f1234 Oasdf\r\n");
+        $t->c_recv("SERVER_ERROR f: true t: false\r\n");
+        $t->clear();
+    };
+
+    subtest 'flagtoken and flagint' => sub {
+        $t->c_send("mg reshasf/tokenint f t s Omoo\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD f5678 t60 s300 Omoo\r\n");
+        $t->c_recv("SERVER_ERROR O[true]: moo t[true]: 60\r\n");
+        $t->clear();
+    };
+
+    subtest 'flagtoken and flagint req' => sub {
+        $t->c_send("mg reshasf/reqhasf Obar T333 s\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD Obar s300\r\n");
+        $t->c_recv("SERVER_ERROR O[true]: bar T[true]: 333\r\n");
+        $t->clear();
+    };
+
+    subtest 'flagtoken and flagint miss' => sub {
+        $t->c_send("mg reshasf/tokenint f t s Omoo\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD f5678 s300\r\n");
+        $t->c_recv("SERVER_ERROR O[false]: nil t[false]: nil\r\n");
+        $t->clear();
+    };
+
+    subtest 'flagis' => sub {
+        $t->c_send("mg reshasf/flagis Obaz\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD f Obaz\r\n");
+        $t->c_recv("SERVER_ERROR exists[true] matches[true]\r\n");
+        $t->clear();
+    };
+
+    subtest 'flagisnt' => sub {
+        $t->c_send("mg reshasf/flagis Obar\r\n");
+        $t->be_recv_c(0);
+        $t->be_send(0, "HD f Obaz\r\n");
+        $t->c_recv("SERVER_ERROR exists[true] matches[true]\r\n");
+        $t->clear();
+    };
+
+}
+
+done_testing();

--- a/t/proxyrequest.lua
+++ b/t/proxyrequest.lua
@@ -66,6 +66,18 @@ function mcp_config_routes(p)
                 r:flag_del("O")
                 return rctx:enqueue_and_wait(r, h)
             end
+
+            if k == "fint" then
+                -- avoids creating string junk if we only need to treat this
+                -- token as an integer.
+                local found, token = r:flag_token_int("F")
+                if type(token) ~= "number" then
+                    error("token wasn't converted to a number")
+                end
+                token = token * 10 + 1
+                r:flag_set("F", token)
+                return rctx:enqueue_and_wait(r, h)
+            end
         end
     end})
 

--- a/t/proxyrequest.t
+++ b/t/proxyrequest.t
@@ -143,4 +143,13 @@ subtest 'req:flag_token_int()' => sub {
     $t->clear();
 };
 
+subtest 'req:token_int()' => sub {
+    $t->c_send("set setints 8 10 2\r\nhi\r\n");
+    $t->be_recv(0, "set setints 20 10 2\r\n");
+    $t->be_recv(0, "hi\r\n");
+    $t->be_send(0, "STORED\r\n");
+    $t->c_recv_be("setints fetched and modified data");
+    $t->clear();
+};
+
 done_testing();

--- a/t/proxyrequest.t
+++ b/t/proxyrequest.t
@@ -133,7 +133,14 @@ subtest 'req:flag_del()' => sub {
     $t->be_send(0, "HD\r\n");
     $t->c_recv_be('got del1 tokenless removal');
     $t->clear();
+};
 
+subtest 'req:flag_token_int()' => sub {
+    $t->c_send("mg fint F59\r\n");
+    $t->be_recv(0, "mg fint F591\r\n");
+    $t->be_send(0, "HD\r\n");
+    $t->c_recv_be("fint converted and adjusted");
+    $t->clear();
 };
 
 done_testing();

--- a/t/proxyunits.lua
+++ b/t/proxyunits.lua
@@ -282,10 +282,13 @@ function mcp_config_routes(zones)
             return "ERROR expect MCMC_CODE_END, but got " .. code .. "\r\n"
         elseif key == "/response/line" then
             local line = res:line()
-            if line == "v c123\r\n" then
+            if line == "v c123" then
                 return res
             end
             return "ERROR unexpected line, got [" .. line .. "]\r\n"
+        elseif key == "/response/blank" then
+            res:flag_blank("O")
+            return res
         end
         return "ERROR unhandled key\r\n"
     end
@@ -302,7 +305,7 @@ function mcp_config_routes(zones)
             return "ERROR expect MCMC_CODE_OK, but got " .. code .. "\r\n"
         elseif key == "/response/line" then
             local line = res:line()
-            if line == "O123 C123\r\n" then
+            if line == "O123 C123" then
                 return res
             end
             return "ERROR unexpected line, got [" .. line .. "]\r\n"

--- a/t/proxyunits.t
+++ b/t/proxyunits.t
@@ -1047,26 +1047,32 @@ check_sanity($ps);
         );
     };
 
-    SKIP: {
-        skip "response:line() is broken";
-        subtest 'response:line()' => sub {
-            # ps_recv must not receive an error
-            my $cmd = "mg /response/line v\r\n";
-            proxy_test(
-                ps_send => $cmd,
-                be_recv => {0 => [$cmd]},
-                be_send => {0 => ["VA 1 v c123\r\n", "a\r\n"]},
-                ps_recv => ["VA 1 v c123\r\n", "a\r\n"],
-            );
+    subtest 'response:line()' => sub {
+        # ps_recv must not receive an error
+        my $cmd = "mg /response/line v\r\n";
+        proxy_test(
+            ps_send => $cmd,
+            be_recv => {0 => [$cmd]},
+            be_send => {0 => ["VA 1 v c123\r\n", "a\r\n"]},
+            ps_recv => ["VA 1 v c123\r\n", "a\r\n"],
+        );
 
-            # ps_recv must not receive an error
-            proxy_test(
-                ps_send => "ms /response/line 2\r\nab\r\n",
-                be_recv => {0 => ["ms /response/line 2\r\n", "ab\r\n"]},
-                be_send => {0 => ["HD O123 C123\r\n"]},
-                ps_recv => ["HD O123 C123\r\n"],
-            );
-        };
+        # ps_recv must not receive an error
+        proxy_test(
+            ps_send => "ms /response/line 2\r\nab\r\n",
+            be_recv => {0 => ["ms /response/line 2\r\n", "ab\r\n"]},
+            be_send => {0 => ["HD O123 C123\r\n"]},
+            ps_recv => ["HD O123 C123\r\n"],
+        );
+    };
+
+    subtest 'response:flag_blank()' => sub {
+        proxy_test(
+            ps_send => "mg /response/blank f Ofoo t\r\n",
+            be_recv => {0 => ["mg /response/blank f Ofoo t\r\n"]},
+            be_send => {0 => ["HD f1234 Ofoo t999\r\n"]},
+            ps_recv => ["HD f1234      t999\r\n"],
+        );
     };
 }
 

--- a/vendor/mcmc/example.c
+++ b/vendor/mcmc/example.c
@@ -23,7 +23,7 @@ static void show_response_buffer(void *c, char *rbuf, size_t bufsize) {
 
         // need to know how far to advance the buffer.
         // resp->reslen + resp->vlen_read works, but feels awkward.
-        status = mcmc_parse_buf(c, rbuf, bread, &resp);
+        status = mcmc_parse_buf(rbuf, bread, &resp);
     } while (resp.code == MCMC_WANT_READ);
 
     if (status == MCMC_ERR) {

--- a/vendor/mcmc/mcmc.c
+++ b/vendor/mcmc/mcmc.c
@@ -516,6 +516,14 @@ MCMC_STATIC int mcmc_toktou64(const char *t, size_t len, uint64_t *out) {
     return MCMC_OK;
 }
 
+// TODO: these funcs aren't defending against len == 0
+// note that the command strings _must_ end in a \n so it _should_ be
+// impossible to land after the buffer.
+// However this should be adjusted next time I work on it:
+// - instead of len, calculate end.
+// - only do '-' check if pos != end
+// - check pos against end in the while loop and just incr pos
+
 MCMC_STATIC int mcmc_tokto32(const char *t, size_t len, int32_t *out) {
     int32_t sum = 0;
     const char *pos = t;
@@ -634,11 +642,10 @@ X(mcmc_token_get_64, int64_t, mcmc_tokto64)
 #undef X
 
 int mcmc_token_has_flag(const char *l, mcmc_tokenizer_t *t, char flag) {
-    flag -= 65;
-    if (flag < 0 || flag > 57) {
+    if (flag < 65 || flag > 122) {
         return MCMC_ERR;
     }
-    uint64_t flagbit = (uint64_t)1 << flag;
+    uint64_t flagbit = (uint64_t)1 << (flag-65);
     if (t->metaflags & flagbit) {
         return MCMC_OK;
     } else {

--- a/vendor/mcmc/mcmc.h
+++ b/vendor/mcmc/mcmc.h
@@ -4,7 +4,16 @@
 #include <sys/uio.h>
 #include <stdint.h>
 
+// Allow exposing normally static functions to a test suite running in a
+// different module.
+#ifdef MCMC_TEST
+#define MCMC_STATIC
+#else
+#define MCMC_STATIC static
+#endif
+
 #define MCMC_OK 0
+#define MCMC_NOK -2
 #define MCMC_ERR -1
 #define MCMC_NOT_CONNECTED 1
 #define MCMC_CONNECTED 2
@@ -51,7 +60,12 @@
 #define MCMC_ERROR_CODE_MAX 32
 #define MCMC_ERROR_MSG_MAX 512
 
-typedef struct {
+#define MCMC_TOKTO_OK 0
+#define MCMC_TOKTO_ERANGE -1
+#define MCMC_TOKTO_ELONG -2
+#define MCMC_TOKTO_EINVALID -3
+
+typedef struct mcmc_resp_s {
     short type;
     short code;
     char *value; // pointer to start of value in buffer.
@@ -61,12 +75,12 @@ typedef struct {
     union {
         // META response
         struct {
-            char *rline; // start of meta response line.
+            const char *rline; // start of meta response line.
             size_t rlen;
         };
         // GET response
         struct {
-            char *key;
+            const char *key;
             size_t klen;
             uint32_t flags;
             uint64_t cas;
@@ -74,19 +88,41 @@ typedef struct {
         };
         // STAT response
         struct {
-            char *sname;
+            const char *sname;
             size_t snamelen;
-            char *stat;
+            const char *stat;
             size_t statlen;
         };
     };
 } mcmc_resp_t;
 
+#define MCMC_PARSER_MAX_TOKENS 24
+#define MCMC_PARSER_MFLAG_HAS_SPACE (1)
+#define MCMC_PARSER_MFLAG_NOREPLY (1<<1)
+
+typedef struct mcmc_tokenizer_s {
+    uint8_t ntokens;
+    uint8_t mstart; // token where meta flags begin
+    uint16_t tokens[MCMC_PARSER_MAX_TOKENS]; // offsets for start of each token
+    uint64_t metaflags;
+} mcmc_tokenizer_t;
+
+typedef struct mcmc_req_s {
+    const char *request;
+    uint8_t command;
+    uint8_t cmd_type; // command class.
+    // FIXME: see if we can map this from command or CMD_TYPE
+    uint8_t keytoken; // because GAT. sigh. also cmds without a key.
+    uint8_t klen; // length of key.
+    uint8_t modeflags; // special indicators (noreply/etc)
+    int16_t llen; // full length of the protocol line
+    int32_t vlen; // length of the value if there is one
+} mcmc_req_t;
+
 int mcmc_fd(void *c);
 size_t mcmc_size(int options);
 size_t mcmc_min_buffer_size(int options);
-int mcmc_parse_buf(void *c, char *buf, size_t read, mcmc_resp_t *r);
-int mcmc_bare_parse_buf(char *buf, size_t read, mcmc_resp_t *r);
+int mcmc_parse_buf(const char *buf, size_t read, mcmc_resp_t *r);
 int mcmc_connect(void *c, char *host, char *port, int options);
 int mcmc_check_nonblock_connect(void *c, int *err);
 int mcmc_send_request(void *c, const char *request, int len, int count);
@@ -96,4 +132,35 @@ int mcmc_request_writev(void *c, const struct iovec *iov, int iovcnt, ssize_t *s
 int mcmc_disconnect(void *c);
 void mcmc_get_error(void *c, char *code, size_t clen, char *msg, size_t mlen);
 
+// TODO: experimental interface. high chance of changing.
+// all meta results are of format "XX m e t a", so if we know it's a result we
+// know where to start on the meta tokens.
+// For full usage this should probably also be supplied with a "mcmc_res_t" so
+// it can figure out what to call.
+int mcmc_tokenize_res(const char *l, size_t len, mcmc_tokenizer_t *t);
+#define mcmc_token_count(t) (t->ntokens)
+const char *mcmc_token_get(const char *l, mcmc_tokenizer_t *t, int idx, int *len);
+int mcmc_token_get_u32(const char *l, mcmc_tokenizer_t *t, int idx, uint32_t *val);
+int mcmc_token_get_u64(const char *l, mcmc_tokenizer_t *t, int idx, uint64_t *val);
+int mcmc_token_get_32(const char *l, mcmc_tokenizer_t *t, int idx, int32_t *val);
+int mcmc_token_get_64(const char *l, mcmc_tokenizer_t *t, int idx, int64_t *val);
+int mcmc_token_has_flag(const char *l, mcmc_tokenizer_t *t, char flag);
+#define mcmc_token_has_flag_bit(t, f) (((t)->metaflags & f) ? MCMC_OK : MCMC_NOK)
+const char *mcmc_token_get_flag(const char *l, mcmc_tokenizer_t *t, char flag, int *len);
+int mcmc_token_get_flag_u32(const char *l, mcmc_tokenizer_t *t, char flag, uint32_t *val);
+int mcmc_token_get_flag_u64(const char *l, mcmc_tokenizer_t *t, char flag, uint64_t *val);
+int mcmc_token_get_flag_32(const char *l, mcmc_tokenizer_t *t, char flag, int32_t *val);
+int mcmc_token_get_flag_64(const char *l, mcmc_tokenizer_t *t, char flag, int64_t *val);
+int mcmc_token_get_flag_idx(const char *l, mcmc_tokenizer_t *t, char flag);
+
+#ifdef MCMC_TEST
+int mcmc_toktou32(const char *t, size_t len, uint32_t *out);
+int mcmc_toktou64(const char *t, size_t len, uint64_t *out);
+int mcmc_tokto32(const char *t, size_t len, int32_t *out);
+int mcmc_tokto64(const char *t, size_t len, int64_t *out);
+int _mcmc_tokenize_meta(mcmc_tokenizer_t *t, const char *line, size_t len, const int mstart, const int max);
+int _mcmc_token_len(const char *line, mcmc_tokenizer_t *t, size_t token);
+const char *_mcmc_token(const char *line, mcmc_tokenizer_t *t, size_t token, int *len);
 #endif
+
+#endif // MCMC_HEADER


### PR DESCRIPTION
Adds interfaces for inspecting request and response objects without or with minimal allocations and argument checking overhead.

Simple extensions:
```lua
-- directly converts token at offset n into a lua integer. avoids string -> num round tripping
-- used for standard ascii commands (ie; set)
int = req:token_int(n)
```

```lua
-- returns "exists", then an int conversion of a token directly.
-- if the flag exists but the token could not be converted to a number, returns 'true, nil'
bool, int = req:flag_token_int("f")
```

```lua
-- Replaces the flag and associated token with blank spaces. This removes the flag without fully
-- rewriting the result.
res:flag_blank("O")
```

### req and res inspector objects

```lua
-- inspectors are pre-configured objects that can be applied to a request or result to make
-- one or more queries against said object.
-- This example splits a key by the "/" character and checks the second (pos = 2) token against the
-- supplied 'map' table. It then returns the result of that map.
-- If map is not supplied, it returns the token as a string
ins = mcp.req_inspector_new(
  { t = "sepkey", sep = "/", pos = 2, map = {
    foo = 1, bar = 2
  }}
)

-- later...
result = ins(req)

-- an inspector with multiple steps:
ins = mcp.res_inspector_new(
  { t = "hasflag", flag = "N" },
  { t = "hasflag", flag = "c" }
)

-- later...
has_N, has_c = ins(result)
```

### More complete example

```lua
local fgen = mcp.funcgen_new()
-- The inspector object pre-validates arguments from lua, so we can avoid some overhead at request time.
-- EX: we don't have to check that 'flag' exists, has a string attached to it, is a correct "flag" string, etc.
ins = mcp.res_inspector_new(
    { t = "hasflag", flag = "f" },
    { t = "hasflag", flag = "t" }
)

-- the inspector object is created _once_ for the entire function generator, and shared among all slots.
-- this saves some memory and improves CPU cache hit rate.
fgen:ready({
  f = function(rctx)
    return function(r)
        local res = rctx:etc()
        -- Function calls in lua have some fixed overhead. By having multi-step inspectors we gain speed by
        -- turning two function calls (and any runtime arg validation) into one.
        -- This style also lets us avoid more kinds of memory allocation.
        local has_f, has_t = ins(res)
        -- do logic
       return res
    end
  end
}
```

### Inspector features

```lua
-- split and tokenize request key. ie: `foo/bar/baz`, position 2. check against map
-- if no map supplied, returns the token as a string
{ t = "sepkey", sep = "/", pos = 2, map = {
    foo = 1, bar = 2, 
}},

-- check if key begins with `string`
{ t = "keybegin", str = "sepkey" }

-- check if key is `string`
-- in this example you can check if a key is one of three strings quickly in one call.
ins = mcp.req_inspector_new(
    { t = "keyis", str = "reqkey/one" },
    { t = "keyis", str = "reqkey/two" },
    { t = "keyis", str = "reqkey/three" }
)
is_one, is_two, is_three = ins(req)

-- check if meta flag exists (req or res)
{ t = "hasflag", flag = "f" }

-- get meta flag token as a string (if exists) (req or res)
{ t = "flagtoken", flag = "O" }

-- get meta flag as an integer (64bit signed, as per lua restrictions) (req or res)
{ t = "flagint", flag = "t" }

-- check if flag token matches `string`
{ t = "flagis", flag = "O", str = "baz" }
```

Planned:

- check if flag token starts or ends with `string`
- split tokenizer for flag tokens, same as request key above
- more...

### Future `mcp.(req|res)_mutator`

A similar multi-step pre-configured object is planned for mutating request and response objects.

Except instead of mutating the existing object they will be primarily aimed at making new objects from old objects. IE: existing request and response objects should be immutable if they already contain data.

API is planned but not implemented yet.

### TODO

- I have a planned mode of: `ins(req|res, output_table)` where instead of directly returning the results, they are put into the `output_table` as an array. I might delay this until later so I can get to the mutator sooner.

This would allow you to inspect something from a function and pass the results around a little easier. Users _should_ pre-allocate and re-use the output tables to avoid allocations where possible.