### PR TITLE
tls: per-listener cert validation

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -834,7 +834,7 @@ struct conn {
     bool close_after_write; /** flush write then move to close connection */
     bool rbuf_malloced; /** read buffer was malloc'ed for ascii mget, needs free() */
     bool item_malloced; /** item for conn_nread state is a temporary malloc */
-    bool ssl_enabled;
+    uint8_t ssl_enabled;
 #ifdef TLS
     void    *ssl;
     char   *ssl_wbuf;

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -506,6 +506,19 @@ sub new_sock {
     }
 }
 
+# needed for a specific test
+sub new_nocert_tls_sock {
+    my $self = shift;
+    if (MemcachedTest::enabled_tls_testing()) {
+        my $port = shift;
+        my $ssl_version = shift;
+        return eval qq{ IO::Socket::SSL->new(PeerAddr => "$self->{host}:$port",
+                                    SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,
+                                    SSL_version => '$ssl_version');
+                                    };
+    }
+}
+
 sub new_udp_sock {
     my $self = shift;
     return IO::Socket::INET->new(PeerAddr => '127.0.0.1',

--- a/t/ssl_ports.t
+++ b/t/ssl_ports.t
@@ -15,8 +15,9 @@ if (!enabled_tls_testing()) {
 
 my $tcp_port = free_port();
 my $ssl_port = free_port();
+my $mtls_port = free_port();
 
-my $server = new_memcached("-l notls:127.0.0.1:$tcp_port,127.0.0.1:$ssl_port", $ssl_port);
+my $server = new_memcached("-l notls:127.0.0.1:$tcp_port,127.0.0.1:$ssl_port,mtls:127.0.0.1:$mtls_port", $ssl_port);
 my $sock = $server->sock;
 
 # Make sure we can talk over SSL
@@ -27,5 +28,13 @@ is(scalar <$sock>, "STORED\r\n", "stored foo");
 #.. and TCP
 my $tcp_sock = IO::Socket::INET->new(PeerAddr => "127.0.0.1:$tcp_port");
 mem_get_is($tcp_sock, "foo:123", "foo set over SSL");
+
+# verify mTLS failure
+# not trying very hard but: if the above works and this doesn't, it's going to
+# be the peer cert. If someone wants to tryhard you can try inspecting
+# $SSL_ERROR and/or checking `watch connevents` stream
+my $mtls_sock = $server->new_nocert_tls_sock($mtls_port, 'TLSv1_3');
+print $mtls_sock "version\r\n";
+is(scalar <$mtls_sock>, undef, "failed to connect without peer cert");
 
 done_testing()

--- a/tls.c
+++ b/tls.c
@@ -61,6 +61,15 @@ void *ssl_accept(conn *c, int sfd, bool *fail) {
             return NULL;
         }
         SSL_set_fd(ssl, sfd);
+
+        if (c->ssl_enabled == MC_SSL_ENABLED_NOPEER) {
+            // Don't enforce peer certs for this socket.
+            SSL_set_verify(ssl, SSL_VERIFY_NONE, NULL);
+        } else if (c->ssl_enabled == MC_SSL_ENABLED_PEER) {
+            // Force peer validation for this socket.
+            SSL_set_verify(ssl, SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+        }
+
         ERR_clear_error();
         int ret = SSL_accept(ssl);
         if (ret <= 0) {

--- a/tls.h
+++ b/tls.h
@@ -1,6 +1,11 @@
 #ifndef TLS_H
 #define TLS_H
 
+#define MC_SSL_DISABLED 0
+#define MC_SSL_ENABLED_DEFAULT 1
+#define MC_SSL_ENABLED_NOPEER 2
+#define MC_SSL_ENABLED_PEER 3
+
 #ifdef TLS
 void *ssl_accept(conn *c, int sfd, bool *fail);
 int ssl_init(void);


### PR DESCRIPTION
For the -l arguments with 'notls:ip:port' we now have 'btls:ip:port' and 'mtls:ip:port'

'btls' disables peer certificate verify on this listener, if it was enabled globally by `ssl_verify_peer`.
'mtls' enables peer certificate verify on this listener. This is the same as setting ssl_verify_peer to 'require'

NOTES:

This is basically the line before needing to move to a more complex system. IE: if a user sees this and wants to have different server certs per listener that would require a completely new feature.

TODO:

The tests for peer verification are pretty basic, so I want to spend a little effort to see if it's worth improving that.

If a peer cert verify fails it _should_ show up as an error in `watch connevents` already.

I'm also trying to figure out if I can add a counter for times certs are validated vs failed but the information doesn't seem to be exposed. Looking to see if the verify callback can be used without making a mess.