### PR TITLE
proxy: embed routelib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,8 @@ memcached_SOURCES += proto_proxy.c proto_proxy.h vendor/mcmc/mcmc.h \
 					 proxy_config.c proxy_ring_hash.c \
 					 proxy_internal.c \
 					 proxy_tls.c proxy_tls.h \
-					 md5.c md5.h
+					 md5.c md5.h \
+					 vendor/routelib/routelib.h
 endif
 
 if ENABLE_EXTSTORE
@@ -151,6 +152,7 @@ EXTRA_DIST = doc scripts t memcached.spec memcached_dtrace.d version.m4 README.m
 EXTRA_DIST += vendor/Makefile vendor/lua/doc/* vendor/lua/Makefile vendor/lua/README
 EXTRA_DIST += vendor/lua/src/*.c vendor/lua/src/*.h vendor/lua/src/Makefile
 EXTRA_DIST += vendor/mcmc/LICENSE vendor/mcmc/Makefile vendor/mcmc/README.md vendor/mcmc/*.c vendor/mcmc/*.h
+EXTRA_DIST += vendor/routelib/*.h vendor/routelib/*.lua
 
 if ENABLE_PROXY
 SUBDIRS += vendor

--- a/memcached.c
+++ b/memcached.c
@@ -4176,8 +4176,11 @@ static void usage(void) {
     verify_default("ext_item_age", settings.ext_item_age == UINT_MAX);
 #endif
 #ifdef PROXY
-    printf("   - proxy_config:        path to lua library file. separate with ':' for multiple files\n");
-    printf("   - proxy_arg:           string to pass to lua library\n");
+    printf("   - proxy_config:        path to lua library file. separate with ':' for multiple files\n"
+           "                          use proxy_config=routelib to use built-in library\n"
+            );
+    printf("   - proxy_arg:           argument string (file path) to pass to proxy config\n"
+            );
 #endif
     ssl_help();
     printf("-N, --napi_ids            number of napi ids. see doc/napi_ids.txt for more details\n");

--- a/proxy_config.c
+++ b/proxy_config.c
@@ -3,6 +3,7 @@
 // TODO (v2): move worker thread related code back out of here.
 
 #include "proxy.h"
+#include "vendor/routelib/routelib.h"
 
 // not using queue.h becuase those require specific storage for HEAD.
 // it's not possible to have the HEAD simply be in the proxy context because
@@ -455,7 +456,11 @@ static int proxy_load_files(proxy_ctx_t *ctx) {
         memset(db->buf, 0, db->size);
         db->used = 0;
 
-        res = luaL_loadfile(L, db->fname);
+        if (strcmp(db->fname, "routelib") == 0) {
+            res = luaL_loadbuffer(L, routelib_lua, routelib_lua_len, "routelib");
+        } else {
+            res = luaL_loadfile(L, db->fname);
+        }
         if (res != LUA_OK) {
             fprintf(stderr, "ERROR: Failed to load proxy_startfile: %s\n", lua_tostring(L, -1));
             return -1;

--- a/t/proxyroutelib.lua
+++ b/t/proxyroutelib.lua
@@ -1,0 +1,12 @@
+-- Minimal configuration.
+pools{
+    main = {
+        backends = {
+            "127.0.0.1:12181",
+        }
+    }
+}
+
+routes{
+    default = route_direct{ child = "main" }
+}

--- a/t/proxyroutelib.t
+++ b/t/proxyroutelib.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use Carp qw(croak);
+use MemcachedTest;
+use IO::Socket qw(AF_INET SOCK_STREAM);
+use IO::Select;
+use Data::Dumper qw/Dumper/;
+
+if (!supports_proxy()) {
+    plan skip_all => 'proxy not enabled';
+    exit 0;
+}
+
+my $t = Memcached::ProxyTest->new(servers => [12181]);
+
+my $p_srv = new_memcached('-o proxy_config=routelib,proxy_arg=./t/proxyroutelib.lua -t 1');
+my $ps = $p_srv->sock;
+$ps->autoflush(1);
+
+$t->set_c($ps);
+$t->accept_backends();
+
+my $w = $p_srv->new_sock;
+print $w "watch proxyevents\r\n";
+is(<$w>, "OK\r\n");
+
+# We don't intend to test routelib here, just ensure that the embedding works
+# and this obviously routelib config starts.
+
+subtest 'basic' => sub {
+    $t->c_send("mg test\r\n");
+    $t->be_recv(0, "mg test\r\n");
+    $t->be_send(0, "HD\r\n");
+    $t->c_recv_be();
+    $t->clear();
+};
+
+done_testing();


### PR DESCRIPTION
`-o proxy_config=routelib` will use the binary-distributed routelib library

Not thrilled about including a mystery data file in the vendor directory.
Don't want to make `xxd` part of the build requirements for proxy either?

Maybe the plan is:
- Start with this so we have something.
- Include the routelib.lua file in here too.
- Soon write my own minimal bin2c that lives in the tree somewhere
- Remove the distributed .h and somehow get the build system to build and run the bin2c first
- Have the .h as a build artifact.

You can just ld files but it's not portable either.

TODO:
- [x] Minimal perl test.
- [x] Test reloads?
- [x] help output?