### PR TITLE
Proxy mutator object continuation

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -653,7 +653,7 @@ struct mcp_funcgen_s {
     int self_ref; // self-reference if we're attached anywhere
     int argument_ref; // reference to an argument to pass to generator
     int max_queues; // how many queue slots rctx's have
-    int extra_queues; // how many extra queue slots for object storage we have
+    int uobj_queues; // how many extra queue slots for object storage we have
     unsigned int refcount; // reference counter
     unsigned int total; // total contexts managed
     unsigned int free; // free contexts
@@ -748,7 +748,7 @@ struct mcp_rcontext_s {
     int conn_fd; // fd of the originating client, as *c can become invalid
     enum mcp_rqueue_e wait_mode;
     uint8_t lua_narg; // number of responses to push when yield resuming.
-    uint8_t obj_count; // number of extra tracked req/res objects.
+    uint8_t uobj_count; // number of extra tracked req/res objects.
     bool first_queue; // HACK
     lua_State *Lc; // coroutine thread pointer.
     mcp_request_t *request; // ptr to the above reference.

--- a/proxy.h
+++ b/proxy.h
@@ -653,6 +653,7 @@ struct mcp_funcgen_s {
     int self_ref; // self-reference if we're attached anywhere
     int argument_ref; // reference to an argument to pass to generator
     int max_queues; // how many queue slots rctx's have
+    int extra_queues; // how many extra queue slots for object storage we have
     unsigned int refcount; // reference counter
     unsigned int total; // total contexts managed
     unsigned int free; // free contexts
@@ -702,12 +703,16 @@ struct mcp_funcgen_router {
 #define RQUEUE_TYPE_NONE 0
 #define RQUEUE_TYPE_POOL 1
 #define RQUEUE_TYPE_FGEN 2
+#define RQUEUE_TYPE_UOBJ 3 // user tracked object types past this point
+#define RQUEUE_TYPE_UOBJ_REQ 4
+#define RQUEUE_TYPE_UOBJ_RES 5
 #define RQUEUE_ASSIGNED (1<<0)
 #define RQUEUE_R_RESUME (1<<1)
 #define RQUEUE_R_GOOD (1<<3)
 #define RQUEUE_R_OK (1<<4)
 #define RQUEUE_R_ANY (1<<5)
 #define RQUEUE_R_ERROR (1<<7)
+#define RQUEUE_UOBJ_MAX UINT8_MAX
 
 enum mcp_rqueue_state {
     RQUEUE_IDLE = 0,
@@ -735,7 +740,6 @@ struct mcp_rcontext_s {
     int request_ref; // top level request for this context.
     int function_ref; // ref to the created route function.
     int coroutine_ref; // ref to our encompassing coroutine.
-    unsigned int async_pending; // legacy async handling
     int pending_reqs; // pending requests and sub-requests
     unsigned int wait_count;
     unsigned int wait_done; // TODO: change these variables to uint8's
@@ -744,6 +748,7 @@ struct mcp_rcontext_s {
     int conn_fd; // fd of the originating client, as *c can become invalid
     enum mcp_rqueue_e wait_mode;
     uint8_t lua_narg; // number of responses to push when yield resuming.
+    uint8_t obj_count; // number of extra tracked req/res objects.
     bool first_queue; // HACK
     lua_State *Lc; // coroutine thread pointer.
     mcp_request_t *request; // ptr to the above reference.

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -110,8 +110,8 @@ static void mcp_rcontext_cleanup(lua_State *L, mcp_funcgen_t *fgen, mcp_rcontext
     }
 
     // look for rctx-local objects.
-    if (rctx->obj_count) {
-        int lim = fgen->max_queues + rctx->obj_count;
+    if (rctx->uobj_count) {
+        int lim = fgen->max_queues + rctx->uobj_count;
         for (int x = fgen->max_queues; x < lim; x++) {
             struct mcp_rqueue_s *rqu = &rctx->qslots[x];
             // Don't need to look at the type:
@@ -220,7 +220,7 @@ static int _mcplib_funcgen_gencall(lua_State *L) {
     mcp_funcgen_t *fgen = luaL_checkudata(L, -2, "mcp.funcgen");
     int fgen_idx = lua_absindex(L, -2);
     // create the ctx object.
-    int total_queues = fgen->max_queues + fgen->extra_queues;
+    int total_queues = fgen->max_queues + fgen->uobj_queues;
     size_t rctx_len = sizeof(mcp_rcontext_t) + sizeof(struct mcp_rqueue_s) * total_queues;
     mcp_rcontext_t *rc = lua_newuserdatauv(L, rctx_len, 0);
     memset(rc, 0, rctx_len);
@@ -384,8 +384,8 @@ static void _mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
     }
 
     // look for rctx-local objects.
-    if (rctx->obj_count) {
-        int lim = fgen->max_queues + rctx->obj_count;
+    if (rctx->uobj_count) {
+        int lim = fgen->max_queues + rctx->uobj_count;
         for (int x = fgen->max_queues; x < lim; x++) {
             struct mcp_rqueue_s *rqu = &rctx->qslots[x];
             if (rqu->obj_type == RQUEUE_TYPE_UOBJ_REQ) {
@@ -740,12 +740,12 @@ int mcplib_funcgen_ready(lua_State *L) {
     }
 
     if (lua_getfield(L, 2, "u") == LUA_TNUMBER) {
-        int extra_queues = luaL_checkinteger(L, -1);
-        if (extra_queues < 1 || extra_queues > RQUEUE_UOBJ_MAX) {
+        int uobj_queues = luaL_checkinteger(L, -1);
+        if (uobj_queues < 1 || uobj_queues > RQUEUE_UOBJ_MAX) {
             proxy_lua_ferror(L, "user obj ('u') in fgen:ready must be between 1 and %d", RQUEUE_UOBJ_MAX);
             return 0;
         }
-        fgen->extra_queues = extra_queues;
+        fgen->uobj_queues = uobj_queues;
     }
     lua_pop(L, 1);
 
@@ -1489,11 +1489,22 @@ int mcplib_rcontext_tls_peer_cn(lua_State *L) {
     return 1;
 }
 
+// call with uobj on top of stack
+static void _mcplib_rcontext_ref_uobj(lua_State *L, mcp_rcontext_t *rctx, void *obj, int otype) {
+    lua_pushvalue(L, -1); // dupe rq for the rqueue slot
+    struct mcp_rqueue_s *rqu = &rctx->qslots[rctx->fgen->max_queues + rctx->uobj_count];
+    rctx->uobj_count++;
+    // hold the request reference into the rctx for memory management.
+    rqu->obj_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    rqu->obj_type = otype;
+    rqu->obj = obj;
+}
+
 // Creates request object that's tracked by request context so we can call
 // cleanup routines post-run.
 int mcplib_rcontext_request_new(lua_State *L) {
     mcp_rcontext_t *rctx = lua_touserdata(L, 1);
-    if (rctx->obj_count == rctx->fgen->extra_queues) {
+    if (rctx->uobj_count == rctx->fgen->uobj_queues) {
         proxy_lua_error(L, "rctx request new: object count limit reached");
         return 0;
     }
@@ -1502,20 +1513,13 @@ int mcplib_rcontext_request_new(lua_State *L) {
     mcp_parser_t pr = {0};
     mcp_request_t *rq = mcp_new_request(L, &pr, " ", 1);
 
-    lua_pushvalue(L, -1); // dupe rq for the rqueue slot
-    struct mcp_rqueue_s *rqu = &rctx->qslots[rctx->fgen->max_queues + rctx->obj_count];
-    rctx->obj_count++;
-    // hold the request reference into the rctx for memory management.
-    rqu->obj_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-    rqu->obj_type = RQUEUE_TYPE_UOBJ_REQ;
-    rqu->obj = rq;
-
+    _mcplib_rcontext_ref_uobj(L, rctx, rq, RQUEUE_TYPE_UOBJ_REQ);
     return 1;
 }
 
 int mcplib_rcontext_response_new(lua_State *L) {
     mcp_rcontext_t *rctx = lua_touserdata(L, 1);
-    if (rctx->obj_count == rctx->fgen->extra_queues) {
+    if (rctx->uobj_count == rctx->fgen->uobj_queues) {
         proxy_lua_error(L, "rctx request new: object count limit reached");
         return 0;
     }
@@ -1525,13 +1529,7 @@ int mcplib_rcontext_response_new(lua_State *L) {
     luaL_getmetatable(L, "mcp.response");
     lua_setmetatable(L, -2);
 
-    lua_pushvalue(L, -1); // dupe rq for the rqueue slot
-    struct mcp_rqueue_s *rqu = &rctx->qslots[rctx->fgen->max_queues + rctx->obj_count];
-    rctx->obj_count++;
-    // hold the request reference into the rctx for memory management.
-    rqu->obj_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-    rqu->obj_type = RQUEUE_TYPE_UOBJ_RES;
-    rqu->obj = r;
+    _mcplib_rcontext_ref_uobj(L, rctx, r, RQUEUE_TYPE_UOBJ_RES);
     return 1;
 }
 

--- a/proxy_mutator.c
+++ b/proxy_mutator.c
@@ -960,6 +960,12 @@ static int mcp_mut_run(struct mcp_mut_run *run) {
     // ensure space and/or allocate memory then seed our destination pointer.
     if (mut->type == MUT_REQ) {
         mcp_request_t *rq = run->arg;
+        if (rq->pr.vbuf) {
+            // FIXME: maybe NULL rq->pr.request in cleanup phase and test that
+            // instead? this check will only fire if req had a vbuf.
+            proxy_lua_error(run->L, "mutator: request has already been rendered");
+            return 0;
+        }
         // future.. should be able to dynamically assign request buffer.
         if (total > MCP_REQUEST_MAXLEN) {
             proxy_lua_error(run->L, "mutator: new request is too long");
@@ -989,6 +995,10 @@ static int mcp_mut_run(struct mcp_mut_run *run) {
         }
     } else {
         mcp_resp_t *rs = run->arg;
+        if (rs->buf) {
+            proxy_lua_error(run->L, "mutator: result has already been rendered");
+            return 0;
+        }
 
         // value is inlined in result buffers. future intention to allow more
         // complex objects so we can refcount values.

--- a/proxy_mutator.c
+++ b/proxy_mutator.c
@@ -955,8 +955,6 @@ static int mcp_mut_run(struct mcp_mut_run *run) {
     // ensure space and/or allocate memory then seed our destination pointer.
     if (mut->type == MUT_REQ) {
         mcp_request_t *rq = run->arg;
-        // FIXME: cleanup should be managed by slot rctx.
-        mcp_request_cleanup(t, rq);
         // future.. should be able to dynamically assign request buffer.
         if (total > MCP_REQUEST_MAXLEN) {
             proxy_lua_error(run->L, "mutator: new request is too long");
@@ -986,8 +984,6 @@ static int mcp_mut_run(struct mcp_mut_run *run) {
         }
     } else {
         mcp_resp_t *rs = run->arg;
-        // FIXME: cleanup should be managed by slot rctx.
-        mcp_response_cleanup(t, rs);
 
         rs->buf = malloc(total);
         if (rs->buf == NULL) {

--- a/proxy_mutator.c
+++ b/proxy_mutator.c
@@ -209,10 +209,6 @@ static inline void _mut_checkudata(lua_State *L, unsigned int idx, mcp_request_t
 
 // START STEPS
 
-// FIXME: decide on if this should take an mcp.CMD_etc instead, or at least
-// optionally.
-// we could also parse this into the int to avoid copying a string here.
-// FIXME: track step progress and validate we're the first one.
 mut_step_c(cmdset) {
     size_t len = 0;
 
@@ -264,7 +260,6 @@ mut_step_r(cmdset) {
     run->d_pos += c->len;
 }
 
-// TODO: validate we're at the right stage to copy a command (no command set)
 mut_step_c(cmdcopy) {
     _mut_check_idx(L, tidx);
     return 0;
@@ -282,7 +277,8 @@ mut_step_i(cmdcopy) {
 
 mut_step_n(cmdcopy) {
     unsigned idx = s->idx;
-    // TODO: validate metatable matches or pull from cached entry
+    // TODO: use flagcopy/valcopy method here, vs assuming it's another
+    // request object.
     mcp_request_t *srq = lua_touserdata(run->L, idx);
 
     // command must be at the start
@@ -311,7 +307,6 @@ mut_step_c(keycopy) {
     return 0;
 }
 
-// FIXME: idx_i_g?
 mut_step_i(keycopy) {
     struct mcp_mut_step *s = &mut->steps[sc];
     if (lua_getfield(L, tidx, "idx") != LUA_TNIL) {
@@ -323,7 +318,7 @@ mut_step_i(keycopy) {
 
 mut_step_n(keycopy) {
     unsigned idx = s->idx;
-    // TODO: validate metatable table matches or pull from cached entry
+    // TODO: copy valcopy/flagcopy routine
     mcp_request_t *srq = lua_touserdata(run->L, idx);
 
     p->src = MCP_PARSER_KEY(srq->pr);
@@ -337,7 +332,6 @@ mut_step_r(keycopy) {
     run->d_pos += p->slen;
 }
 
-// TODO: check we're okay to set a key
 mut_step_c(keyset) {
     size_t len = 0;
 
@@ -388,7 +382,6 @@ mut_step_r(keyset) {
     run->d_pos += c->len;
 }
 
-// TODO: ensure step is first
 // TODO: pre-validate that it's an accepted code?
 mut_step_c(rescodeset) {
     return _mut_check_strlen(L, tidx, "val");
@@ -427,7 +420,6 @@ mut_step_r(rescodeset) {
     run->d_pos += c->len;
 }
 
-// TODO: check we're the first step
 mut_step_c(rescodecopy) {
     _mut_check_idx(L, tidx);
     return 0;
@@ -445,7 +437,7 @@ mut_step_i(rescodecopy) {
 
 mut_step_n(rescodecopy) {
     unsigned idx = s->idx;
-    // TODO: validate metatable matches or pull from cached entry
+    // TODO: use valcopy/flagcopy routine
     mcp_resp_t *srs = lua_touserdata(run->L, idx);
 
     // TODO: can't recover the exact code from the mcmc resp object, so lets make
@@ -466,7 +458,6 @@ mut_step_n(rescodecopy) {
     return len;
 }
 
-// TODO: take a string or number from that position.
 mut_step_r(rescodecopy) {
     memcpy(run->d_pos, p->src, p->slen);
     run->d_pos += p->slen;
@@ -613,7 +604,6 @@ mut_step_n(flagset) {
     return c->str.len + 1; // room for flag
 }
 
-// TODO: validate we're okay to set flags.
 // FIXME: triple check that this is actually the same code for req vs res?
 // seems like it is.
 mut_step_r(flagset) {
@@ -629,7 +619,6 @@ mut_step_r(flagset) {
         memcpy(run->d_pos, str, len);
         run->d_pos += len;
     }
-
 }
 
 mut_step_c(flagcopy) {

--- a/proxy_mutator.c
+++ b/proxy_mutator.c
@@ -341,13 +341,13 @@ mut_step_r(keycopy) {
 mut_step_c(keyset) {
     size_t len = 0;
 
-    if (lua_getfield(L, tidx, "str") != LUA_TNIL) {
+    if (lua_getfield(L, tidx, "val") != LUA_TNIL) {
         lua_tolstring(L, -1, &len);
         if (len < 1) {
-            proxy_lua_ferror(L, "mutator step %d: 'str' must have nonzero length", tidx);
+            proxy_lua_ferror(L, "mutator step %d: 'val' must have nonzero length", tidx);
         }
     } else {
-        proxy_lua_ferror(L, "mutator step %d: must provide 'str' argument", tidx);
+        proxy_lua_ferror(L, "mutator step %d: must provide 'val' argument", tidx);
     }
     lua_pop(L, 1); // val or nil
 
@@ -360,7 +360,7 @@ mut_step_i(keyset) {
     size_t len = 0;
 
     // store our match string in the arena space that we reserved before.
-    if (lua_getfield(L, tidx, "str") != LUA_TNIL) {
+    if (lua_getfield(L, tidx, "val") != LUA_TNIL) {
         const char *str = lua_tolstring(L, -1, &len);
         c->str = mut->aused;
         c->len = len;
@@ -391,7 +391,7 @@ mut_step_r(keyset) {
 // TODO: ensure step is first
 // TODO: pre-validate that it's an accepted code?
 mut_step_c(rescodeset) {
-    return _mut_check_strlen(L, tidx, "str");
+    return _mut_check_strlen(L, tidx, "val");
 }
 
 mut_step_i(rescodeset) {
@@ -399,7 +399,7 @@ mut_step_i(rescodeset) {
     struct mcp_mut_string *c = &s->c.string;
     size_t len = 0;
 
-    if (lua_getfield(L, tidx, "str") != LUA_TNIL) {
+    if (lua_getfield(L, tidx, "val") != LUA_TNIL) {
         const char *str = lua_tolstring(L, -1, &len);
         c->str = mut->aused;
         c->len = len;

--- a/proxy_mutator.c
+++ b/proxy_mutator.c
@@ -947,6 +947,10 @@ static int mcp_mut_run(struct mcp_mut_run *run) {
     struct mcp_mut_part parts[mut->scount];
 
     // first accumulate the length tally
+    // FIXME: noticed off-by-one's sometimes.
+    // maybe add a debug assert to verify the written total (d_pos - etc)
+    // matches total?
+    // This isn't critical so long as total is > actual, which it has been
     int total = _mcp_mut_run_total(run, parts);
     if (total < 0) {
         lua_pushboolean(run->L, 0);
@@ -986,7 +990,9 @@ static int mcp_mut_run(struct mcp_mut_run *run) {
     } else {
         mcp_resp_t *rs = run->arg;
 
-        rs->buf = malloc(total);
+        // value is inlined in result buffers. future intention to allow more
+        // complex objects so we can refcount values.
+        rs->buf = malloc(total + run->vlen);
         if (rs->buf == NULL) {
             proxy_lua_error(run->L, "mutator: failed to allocate result buffer");
             return 0;

--- a/proxy_mutator.c
+++ b/proxy_mutator.c
@@ -140,8 +140,8 @@ static void _mut_check_idx(lua_State *L, int tidx) {
         if (!isnum) {
             proxy_lua_ferror(L, "mutator step %d: must provide 'idx' argument as an integer", tidx);
         }
-        if (i < 2) {
-            proxy_lua_ferror(L, "mutator step %d: 'idx' argument must be greater than 1", tidx);
+        if (i < 1) {
+            proxy_lua_ferror(L, "mutator step %d: 'idx' argument must be greater than 0", tidx);
         }
     } else {
         proxy_lua_ferror(L, "mutator step %d: must provide 'idx' argument", tidx);
@@ -880,7 +880,8 @@ static int mcp_mutator_new(lua_State *L, enum mcp_mut_type type) {
             // around the much larger mcp_mut_entries at runtime.
             mut->steps[scount].n = mcp_mut_entries[st].n;
             mut->steps[scount].r = mcp_mut_entries[st].r;
-            mut->steps[scount].idx++; // actual args are "self, etc, etc"
+            // actual args are "self, dst, args". start user idx's at 3
+            mut->steps[scount].idx += 2;
         }
         lua_pop(L, 1); // drop t or nil
         scount++;

--- a/t/proxymut.lua
+++ b/t/proxymut.lua
@@ -51,7 +51,7 @@ function mcp_config_routes(p)
     )
 
     mgfg:ready({
-        n = "mgtest", f = function(rctx)
+        n = "mgtest", u = 2, f = function(rctx)
             -- make blank request objects for handing to mutator
 
             -- these objects must be made per slot (rctx)
@@ -90,7 +90,7 @@ function mcp_config_routes(p)
     })
 
     msfg:ready({
-        n = "mstest", f = function(rctx)
+        n = "mstest", u = 2, f = function(rctx)
             return function(r)
                 local key = r:key()
                 -- test tree

--- a/t/proxymut.lua
+++ b/t/proxymut.lua
@@ -19,13 +19,13 @@ function mcp_config_routes(p)
     -- basic; no flags at all.
     local mut_mgreq = mcp.req_mutator_new(
         { t = "cmdset", cmd = "mg" },
-        { t = "keyset", str = "override" }
+        { t = "keyset", val = "override" }
     )
 
     -- set a bunch of flags
     local mut_mgflagreq = mcp.req_mutator_new(
         { t = "cmdset", cmd = "mg" },
-        { t = "keyset", str = "override" },
+        { t = "keyset", val = "override" },
         { t = "flagset", flag = "s" },
         { t = "flagset", flag = "t" },
         { t = "flagset", flag = "O", val = "opaque" },
@@ -34,18 +34,18 @@ function mcp_config_routes(p)
 
     -- basic res: no flags.
     local mut_mgres = mcp.res_mutator_new(
-        { t = "rescodeset", str = "HD" }
+        { t = "rescodeset", val = "HD" }
     )
 
     -- res with value.
     local mut_mgresval = mcp.res_mutator_new(
-        { t = "rescodeset", str = "VA" },
-        { t = "valcopy", idx = 1, arg = "string" }
+        { t = "rescodeset", val = "VA" },
+        { t = "valcopy", idx = 1 }
     )
 
     -- res with flags.
     local mut_mgresflag = mcp.res_mutator_new(
-        { t = "rescodeset", str = "HD" },
+        { t = "rescodeset", val = "HD" },
         { t = "flagset", flag = "t", val = "37" },
         { t = "flagcopy", flag = "O", idx = 1 }
     )

--- a/t/proxymut.lua
+++ b/t/proxymut.lua
@@ -22,6 +22,11 @@ function mcp_config_routes(p)
         { t = "keyset", val = "override" }
     )
 
+    local mut_mgreqcopy = mcp.req_mutator_new(
+        { t = "cmdcopy", idx = 1 },
+        { t = "keycopy", idx = 2 }
+    )
+
     -- set a bunch of flags
     local mut_mgflagreq = mcp.req_mutator_new(
         { t = "cmdset", cmd = "mg" },
@@ -39,8 +44,8 @@ function mcp_config_routes(p)
 
     -- res with value.
     local mut_mgresval = mcp.res_mutator_new(
-        { t = "rescodeset", val = "VA" },
-        { t = "valcopy", idx = 1 }
+        { t = "rescodecopy", idx = 1 },
+        { t = "valcopy", idx = 2 }
     )
 
     -- res with flags.
@@ -48,6 +53,11 @@ function mcp_config_routes(p)
         { t = "rescodeset", val = "HD" },
         { t = "flagset", flag = "t", val = "37" },
         { t = "flagcopy", flag = "O", idx = 1 }
+    )
+
+    -- error res.
+    local mut_reserr = mcp.res_mutator_new(
+        { t = "reserr", code = "server", msg = "teapot" }
     )
 
     mgfg:ready({
@@ -70,11 +80,14 @@ function mcp_config_routes(p)
                 elseif key == "mgflagreq" then
                     local ret = mut_mgflagreq(nreq)
                     return rctx:enqueue_and_wait(nreq, mgfgh)
+                elseif key == "mgreqcopy" then
+                    local ret = mut_mgreqcopy(nreq, "md", "differentkey")
+                    return rctx:enqueue_and_wait(nreq, mgfgh)
                 elseif key == "mgres" then
                     local ret = mut_mgres(nres)
                     return nres
                 elseif key == "mgresval" then
-                    local ret = mut_mgresval(nres, "example value\r\n")
+                    local ret = mut_mgresval(nres, "VA", "example value\r\n")
                     return nres
                 elseif key == "mgresflag" then
                     local res = rctx:enqueue_and_wait(r, mgfgh)
@@ -83,6 +96,9 @@ function mcp_config_routes(p)
                 elseif key == "mgresflag2" then
                     local res = rctx:enqueue_and_wait(r, mgfgh)
                     local ret = mut_mgresflag(nres, "toast")
+                    return nres
+                elseif key == "mgresteapot" then
+                    local res = mut_reserr(nres)
                     return nres
                 end
             end

--- a/t/proxymut.lua
+++ b/t/proxymut.lua
@@ -80,6 +80,10 @@ function mcp_config_routes(p)
                     local res = rctx:enqueue_and_wait(r, mgfgh)
                     local ret = mut_mgresflag(nres, res)
                     return nres
+                elseif key == "mgresflag2" then
+                    local res = rctx:enqueue_and_wait(r, mgfgh)
+                    local ret = mut_mgresflag(nres, "toast")
+                    return nres
                 end
             end
         end

--- a/t/proxymut.lua
+++ b/t/proxymut.lua
@@ -40,14 +40,14 @@ function mcp_config_routes(p)
     -- res with value.
     local mut_mgresval = mcp.res_mutator_new(
         { t = "rescodeset", str = "VA" },
-        { t = "valcopy", idx = 2, arg = "string" }
+        { t = "valcopy", idx = 1, arg = "string" }
     )
 
     -- res with flags.
     local mut_mgresflag = mcp.res_mutator_new(
         { t = "rescodeset", str = "HD" },
         { t = "flagset", flag = "t", val = "37" },
-        { t = "flagcopy", flag = "O", idx = 2 }
+        { t = "flagcopy", flag = "O", idx = 1 }
     )
 
     mgfg:ready({

--- a/t/proxymut.t
+++ b/t/proxymut.t
@@ -75,6 +75,14 @@ sub test_mg {
         $t->c_recv("HD t37 Omgresflag\r\n");
         $t->clear();
     };
+
+    subtest 'mgresflag2' => sub {
+        $t->c_send("mg mgresflag2\r\n");
+        $t->be_recv(0, "mg mgresflag2\r\n");
+        $t->be_send(0, "HD s2 Omgresflag2 f3\r\n");
+        $t->c_recv("HD t37 Otoast\r\n");
+        $t->clear();
+    };
 }
 
 done_testing();

--- a/t/proxymut.t
+++ b/t/proxymut.t
@@ -52,6 +52,14 @@ sub test_mg {
         $t->clear();
     };
 
+    subtest 'mgreqcopy' => sub {
+        $t->c_send("mg mgreqcopy\r\n");
+        $t->be_recv(0, "md differentkey\r\n");
+        $t->be_send(0, "NF\r\n");
+        $t->c_recv_be();
+        $t->clear();
+    };
+
     subtest 'mgres' => sub {
         $t->c_send("mg mgres\r\n");
         $t->c_recv("HD\r\n");
@@ -81,6 +89,12 @@ sub test_mg {
         $t->be_recv(0, "mg mgresflag2\r\n");
         $t->be_send(0, "HD s2 Omgresflag2 f3\r\n");
         $t->c_recv("HD t37 Otoast\r\n");
+        $t->clear();
+    };
+
+    subtest 'mgreserr' => sub {
+        $t->c_send("mg mgresteapot\r\n");
+        $t->c_recv("SERVER_ERROR teapot\r\n");
         $t->clear();
     };
 }


### PR DESCRIPTION
The goal of this PR is to stabilize the mutator object for production use. Additional steps will most likely be in future PR's.

Tasks:

- [x] Fix error handling for totalling. Don't allow errors in copy phase.
- [x] Replace assert()'s with error handling
- [x] Fix dynamic argument handling for valcopy/flagcopy/etc (take a string or a req or a res or etc)
- [x] Track req/res objects and free their data when the rctx is freed, instead of at the next use
- [x] user idx of args should start at 1 insead of 2.
- [x] check the naming consistency of arguments: str vs arg vs token vs etc
- [x] support value handling for result objects (might be later)
- [ ] ~~inherit starttime/elapsed from copied objects (is this an explicit step?)~~
- [x] address/evaluate remaining TODO/FIXME's.
- [x] other keycopy/rescodecopy/cmdcopy need code from valcopy/flagcopy

Result handling might have to wait for another PR, pending fixes to mcmc to use relative offsets vs full fixed pointers. This is causing us to need to re-parse results every time we look at them.

Delayed:
- [ ] Support copying values off of source result objects (requires mcmc fix or hack)
- [ ] don't allow specifying steps out of order (cmd -> key -> flags -> etc)