### PR TITLE
Do conn_release_items when a TRANSMIT_HARD_ERROR occurs in the UDP protocol

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -2903,6 +2903,7 @@ static enum transmit_result transmit_udp(conn *c) {
     if (settings.verbose > 0)
         perror("Failed to write, and not due to blocking");
 
+    conn_release_items(c);
     conn_set_state(c, conn_read);
     return TRANSMIT_HARD_ERROR;
 }


### PR DESCRIPTION
In the UDP protocol, when an error other than EAGAIN or EWOULDBLOCK occurs during a transmit operation, it is switched to conn_read without any additional handling. I think this could lead to a situation where IO wraps and any half-uploaded items are not freed.