### PR TITLE
Changing the proxy GC default ratio from 1.9 to 2.0

### DIFF
--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -13,7 +13,7 @@
 #define PROCESS_MULTIGET true
 #define PROCESS_NORMAL false
 #define PROXY_GC_BACKGROUND_SECONDS 4
-#define PROXY_GC_DEFAULT_RATIO 1.9
+#define PROXY_GC_DEFAULT_RATIO 2.0
 static void proxy_process_command(conn *c, char *command, size_t cmdlen, bool multiget);
 static void *mcp_profile_alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 


### PR DESCRIPTION
Updating the proxy GC default ratio from `1.9` to `2.0` to reduce its aggressiveness. This adjustment aligns with the GC algorithm fix introduced in [commit d164eb1](https://github.com/memcached/memcached/commit/d164eb151af58f3835b63a83bb38e8d42892e669) and has been verified to perform well during tests.
