### PR TITLE
proxy: internal backend for V2 API

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -521,6 +521,7 @@ struct _io_pending_proxy_t {
     // original struct ends here
 
     mcp_rcontext_t *rctx; // pointer to request context.
+    mcp_resp_t *client_resp; // reference (currently pointing to a lua object)
     int queue_handle; // queue slot to return this result to
     bool ascii_multiget; // passed on from mcp_r_t
     union {
@@ -541,7 +542,6 @@ struct _io_pending_proxy_t {
             struct iovec iov[2]; // request string + tail buffer
             int iovcnt; // 1 or 2...
             unsigned int iovbytes; // total bytes in the iovec
-            mcp_resp_t *client_resp; // reference (currently pointing to a lua object)
             bool flushed; // whether we've fully written this request to a backend.
             bool background; // dummy IO for backgrounded awaits
         };
@@ -608,6 +608,7 @@ io_pending_proxy_t *mcp_queue_rctx_io(mcp_rcontext_t *rctx, mcp_request_t *rq, m
 // internal request interface
 int mcplib_internal(lua_State *L);
 int mcplib_internal_run(mcp_rcontext_t *rctx);
+void *mcp_rcontext_internal(mcp_rcontext_t *rctx, mcp_request_t *rq, mcp_resp_t *r);
 
 // user stats interface
 #define MAX_USTATS_DEFAULT 1024
@@ -697,10 +698,11 @@ struct mcp_funcgen_router {
 
 #define RQUEUE_TYPE_NONE 0
 #define RQUEUE_TYPE_POOL 1
-#define RQUEUE_TYPE_FGEN 2
-#define RQUEUE_TYPE_UOBJ 3 // user tracked object types past this point
-#define RQUEUE_TYPE_UOBJ_REQ 4
-#define RQUEUE_TYPE_UOBJ_RES 5
+#define RQUEUE_TYPE_INT  2
+#define RQUEUE_TYPE_FGEN 3
+#define RQUEUE_TYPE_UOBJ 4 // user tracked object types past this point
+#define RQUEUE_TYPE_UOBJ_REQ 5
+#define RQUEUE_TYPE_UOBJ_RES 6
 #define RQUEUE_ASSIGNED (1<<0)
 #define RQUEUE_R_RESUME (1<<1)
 #define RQUEUE_R_GOOD (1<<3)

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -1801,6 +1801,10 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
         luaL_newmetatable(L, "mcp.funcgen");
         lua_pop(L, 1);
 
+        // mt for magical null wrapper for using internal cache as backend
+        luaL_newmetatable(L, "mcp.internal_be");
+        lua_pop(L, 1);
+
         luaL_newlibtable(L, mcplib_f_routes);
     } else {
         // Change the extra space override for the configuration VM to just point
@@ -1833,6 +1837,12 @@ int proxy_register_libs(void *ctx, LIBEVENT_THREAD *t, void *state) {
 
         luaL_newlibtable(L, mcplib_f_config);
     }
+
+    // Create magic empty value to pass as an internal backend.
+    lua_newuserdatauv(L, 1, 0);
+    luaL_getmetatable(L, "mcp.internal_be");
+    lua_setmetatable(L, -2);
+    lua_setfield(L, -2, "internal_handler");
 
     // create main library table.
     //luaL_newlib(L, mcplib_f);

--- a/t/proxyinternal.t
+++ b/t/proxyinternal.t
@@ -91,6 +91,9 @@ note "ascii basic";
     # non-multiget get mode.
     print $ps "get /b/miss\r\n";
     is(scalar <$ps>, "END\r\n", "basic miss");
+    print $ps "get /sub/miss\r\n";
+    is(scalar <$ps>, "END\r\n", "basic subrctx miss");
+
     check_version($ps);
 }
 
@@ -108,8 +111,16 @@ note "ascii basic";
 {
     print $ps "set /b/foo 0 0 2\r\nhi\r\n";
     is(scalar <$ps>, "STORED\r\n", "int set");
+    print $ps "set /sub/foo 0 0 2\r\nhi\r\n";
+    is(scalar <$ps>, "STORED\r\n", "int set");
+
     print $ps "get /b/foo\r\n";
     is(scalar <$ps>, "VALUE /b/foo 0 2\r\n", "get response");
+    is(scalar <$ps>, "hi\r\n", "get value");
+    is(scalar <$ps>, "END\r\n", "get END");
+
+    print $ps "get /sub/foo\r\n";
+    is(scalar <$ps>, "VALUE /sub/foo 0 2\r\n", "get response");
     is(scalar <$ps>, "hi\r\n", "get value");
     is(scalar <$ps>, "END\r\n", "get END");
     check_version($ps);
@@ -149,10 +160,19 @@ subtest 'fetch from extstore' => sub {
     my $data = 'x' x 1000;
     print $ps "set /b/ext 0 0 1000\r\n$data\r\n";
     is(scalar <$ps>, "STORED\r\n", "int set for extstore");
+
+    print $ps "set /sub/ext 0 0 1000\r\n$data\r\n";
+    is(scalar <$ps>, "STORED\r\n", "int set for subrctx extstore");
+
     wait_ext_flush($ps);
 
     print $ps "get /b/ext\r\n";
     is(scalar <$ps>, "VALUE /b/ext 0 1000\r\n", "get response from extstore");
+    is(scalar <$ps>, "$data\r\n", "got data from extstore");
+    is(scalar <$ps>, "END\r\n", "get END");
+
+    print $ps "get /sub/ext\r\n";
+    is(scalar <$ps>, "VALUE /sub/ext 0 1000\r\n", "get response from subrctx extstore");
     is(scalar <$ps>, "$data\r\n", "got data from extstore");
     is(scalar <$ps>, "END\r\n", "get END");
 };

--- a/t/proxyinternal3.lua
+++ b/t/proxyinternal3.lua
@@ -1,0 +1,15 @@
+function mcp_config_pools()
+    return true
+end
+
+function mcp_config_routes(p)
+    local fg = mcp.funcgen_new()
+    local h = fg:new_handle(mcp.internal_handler)
+    fg:ready({ n = "internal", f = function(rctx)
+        return function(r)
+            return rctx:enqueue_and_wait(r, h)
+        end
+    end})
+
+    mcp.attach(mcp.CMD_ANY_STORAGE, fg)
+end


### PR DESCRIPTION
Replaces `res = mcp.internal(req)` with the standard V2 API flow. Create a handle for an fgen using `mcp.internal_backend` as an argument, then call wait against it like a normal pool.

- [x] rebase on `io_refactor` branch and complete code
- [x] write tests for memory and extstore calls via a subrctx
- [x] complete missing error handling code
- [x] performance audit. seems to still be causing GC runs? why?
- [x] code audit? what else is missing?
- [x] burn-in suite run (started)
- [x] triple check that refcounts don't leak for results that weren't returned to the user.
- [ ] rename `mcp.internal_backend` to `mcp.internal_pool` (update in shredders suite too)

Terrible thought: am I naming this wrong?

`mcp.internal_backend` -> `mcp.internal_pool`

because you can't actually add it as a pool backend. it _could_ be nice if that worked but I think it would get people into more trouble than it's worth.