### PR TITLE
proxy: speed up per-worker backend IO

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -544,7 +544,6 @@ struct _io_pending_proxy_t {
             mcp_resp_t *client_resp; // reference (currently pointing to a lua object)
             bool flushed; // whether we've fully written this request to a backend.
             bool background; // dummy IO for backgrounded awaits
-            bool qcount_incr; // HACK.
         };
     };
 };
@@ -745,7 +744,6 @@ struct mcp_rcontext_s {
     enum mcp_rqueue_e wait_mode;
     uint8_t lua_narg; // number of responses to push when yield resuming.
     uint8_t uobj_count; // number of extra tracked req/res objects.
-    bool first_queue; // HACK
     lua_State *Lc; // coroutine thread pointer.
     mcp_request_t *request; // ptr to the above reference.
     mcp_rcontext_t *parent; // parent rctx in the call graph

--- a/proxy_luafgen.c
+++ b/proxy_luafgen.c
@@ -332,7 +332,6 @@ static void _mcp_funcgen_return_rctx(mcp_rcontext_t *rctx) {
     }
     rctx->wait_mode = QWAIT_IDLE;
     rctx->resp = NULL;
-    rctx->first_queue = false; // HACK
     if (rctx->request) {
         mcp_request_cleanup(fgen->thread, rctx->request);
     }

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -463,10 +463,13 @@ static void _drive_machine_next(struct mcp_backendconn_s *be, io_pending_proxy_t
     assert(be->pending_read > -1);
 
     mcp_resp_set_elapsed(p->client_resp);
-    // have to do the q->count-- and == 0 and redispatch_conn()
-    // stuff here. The moment we call return_io here we
+    // The moment we call return_io here we
     // don't own *p anymore.
-    return_io_pending((io_pending_t *)p);
+    if (!be->be_parent->use_io_thread) {
+        conn_io_queue_return((io_pending_t *)p);
+    } else {
+        return_io_pending((io_pending_t *)p);
+    }
     be->state = mcp_backend_read;
 }
 


### PR DESCRIPTION
Uses a shorter return path for completed IO objects, resulting in 5%+ performance bump.

Also cleans up some of the remaining hack code from before the IO subsystem fix.

---

TODO:
- [x] performance suite pass to confirm deltas in more scenarios.
- [x] stability suite burn-in pass.