### PR TITLE
Remove "Override the size of each slab page" from the man page for the -I, --max-item-size option

### DIFF
--- a/doc/memcached.1
+++ b/doc/memcached.1
@@ -139,9 +139,8 @@ specify the protocol clients must speak.  Possible options are "auto"
 (the default, autonegotiation behavior), "ascii" and "binary".
 .TP
 .B \-I, --max-item-size=<size>
-Override the default size of each slab page. The default size is 1mb. Default
-value for this parameter is 1m, minimum is 1k, max is 1G (1024 * 1024 * 1024).
-Adjusting this value changes the item size limit.
+Adjusting this value changes the item size limit. The default value
+for this parameter is 1m, minimum is 1k, max is 1G (1024 * 1024 * 1024).
 .TP
 .B \-S, --enable-sasl
 Turn on SASL authentication. This option is only meaningful if memcached was


### PR DESCRIPTION
https://github.com/memcached/memcached/issues/1196
 
I think since version 1.4.29 , released on 2016 July 13th, pages are fixed at 1mb in size and the maximum slab chunk size is no longer tied to the maximum item size.
 
"Override the size of each slab page" was removed from the --help in https://github.com/memcached/memcached/commit/3f3e1379368753e540a332f90f996a3eb7ab8e9e