### PR TITLE
proxy: per-backend automatic logging

### DIFF
--- a/logger.h
+++ b/logger.h
@@ -129,6 +129,7 @@ struct logentry_conn_event {
 struct logentry_proxy_req {
     unsigned short type;
     unsigned short code;
+    uint8_t flag;
     int status;
     int conn_fd;
     uint32_t reqlen;

--- a/proto_proxy.c
+++ b/proto_proxy.c
@@ -1196,8 +1196,6 @@ mcp_resp_t *mcp_prep_bare_resobj(lua_State *L, LIBEVENT_THREAD *t) {
 
 void mcp_set_resobj(mcp_resp_t *r, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t) {
     memset(r, 0, sizeof(mcp_resp_t));
-    r->buf = NULL;
-    r->blen = 0;
     r->thread = t;
     assert(r->thread != NULL);
     gettimeofday(&r->start, NULL);
@@ -1224,20 +1222,7 @@ void mcp_set_resobj(mcp_resp_t *r, mcp_request_t *rq, mcp_backend_t *be, LIBEVEN
     }
 
     r->cmd = rq->pr.command;
-
-    strncpy(r->be_name, be->name, MAX_NAMELEN+1);
-    strncpy(r->be_port, be->port, MAX_PORTLEN+1);
-
-}
-
-mcp_resp_t *mcp_prep_resobj(lua_State *L, mcp_request_t *rq, mcp_backend_t *be, LIBEVENT_THREAD *t) {
-    mcp_resp_t *r = lua_newuserdatauv(L, sizeof(mcp_resp_t), 0);
-    mcp_set_resobj(r, rq, be, t);
-
-    luaL_getmetatable(L, "mcp.response");
-    lua_setmetatable(L, -2);
-
-    return r;
+    r->be = be;
 }
 
 void mcp_resp_set_elapsed(mcp_resp_t *r) {

--- a/proxy_internal.c
+++ b/proxy_internal.c
@@ -1718,10 +1718,6 @@ static inline int _mcplib_internal_run(LIBEVENT_THREAD *t, mcp_request_t *rq, mc
         }
     }
 
-    // in case someone logs this response it should make sense.
-    memcpy(r->be_name, "internal", strlen("internal"));
-    memcpy(r->be_port, "0", 1);
-
     // TODO: r-> will need status/code/mode copied from resp.
     r->cresp = resp;
     r->thread = t;

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -285,7 +285,56 @@ static int mcplib_backend_wrap_gc(lua_State *L) {
 }
 
 static int mcplib_backend_gc(lua_State *L) {
-    return 0; // no-op.
+    mcp_backend_label_t *be = lua_touserdata(L, 1);
+    if (be->logging.detail)
+        free(be->logging.detail);
+
+    return 0;
+}
+
+static int _mcplib_backend_log(lua_State *L, mcp_backend_label_t *be) {
+    be->use_logging = true;
+
+    if (lua_getfield(L, -1, "deadline") != LUA_TNIL) {
+        int deadline = luaL_checkinteger(L, -1);
+        if (deadline < 0) {
+            proxy_lua_error(L, "backend log deadline must be >= 0");
+        }
+        // convert to milliseconds.
+        be->logging.deadline = deadline * 1000;
+    }
+    lua_pop(L, 1);
+
+    if (lua_getfield(L, -1, "rate") != LUA_TNIL) {
+        int rate = luaL_checkinteger(L, -1);
+        if (rate < 0) {
+            proxy_lua_error(L, "backend log sample rate must be >= 0");
+        }
+        be->logging.rate = rate;
+    }
+    lua_pop(L, 1);
+
+    if (lua_getfield(L, -1, "errors") != LUA_TNIL) {
+        luaL_checktype(L, -1, LUA_TBOOLEAN);
+        int errors = lua_toboolean(L, -1);
+        if (errors) {
+            be->logging.all_errors = true;
+        } else {
+            be->logging.all_errors = false;
+        }
+    }
+    lua_pop(L, 1);
+
+    if (lua_getfield(L, -1, "tag") != LUA_TNIL) {
+        size_t tlen = 0;
+        const char *tag = luaL_checklstring(L, -1, &tlen);
+        be->logging.detail = malloc(tlen+1);
+        memcpy(be->logging.detail, tag, tlen);
+        be->logging.detail[tlen] = '\0';
+    }
+    lua_pop(L, 1);
+
+    return 0;
 }
 
 // backend label object; given to pools which then find or create backend
@@ -298,15 +347,18 @@ static int mcplib_backend(lua_State *L) {
     size_t llen = 0;
     size_t nlen = 0;
     size_t plen = 0;
-    proxy_ctx_t *ctx = PROXY_GET_CTX(L);
-    mcp_backend_label_t *be = lua_newuserdatauv(L, sizeof(mcp_backend_label_t), 0);
-    memset(be, 0, sizeof(*be));
     const char *label;
     const char *name;
     const char *port;
+    proxy_ctx_t *ctx = PROXY_GET_CTX(L);
+    mcp_backend_label_t *be = lua_newuserdatauv(L, sizeof(mcp_backend_label_t), 0);
+    memset(be, 0, sizeof(*be));
     // copy global defaults for tunables.
     memcpy(&be->tunables, &ctx->tunables, sizeof(be->tunables));
     be->conncount = 1; // one connection per backend as default.
+    // set the metatable early so the GC handler can free partial allocations
+    luaL_getmetatable(L, "mcp.backend");
+    lua_setmetatable(L, -2); // set metatable to userdata.
 
     if (lua_istable(L, 1)) {
 
@@ -455,6 +507,14 @@ static int mcplib_backend(lua_State *L) {
         }
         lua_pop(L, 1);
 
+        if (lua_getfield(L, 1, "log") != LUA_TNIL) {
+            if (lua_istable(L, -1)) {
+                _mcplib_backend_log(L, be);
+            } else {
+                proxy_lua_error(L, "backend log option must be a table");
+            }
+        }
+        lua_pop(L, 1);
     } else {
         label = luaL_checklstring(L, 1, &llen);
         name = luaL_checklstring(L, 2, &nlen);
@@ -486,8 +546,6 @@ static int mcplib_backend(lua_State *L) {
     if (lua_istable(L, 1)) {
         lua_pop(L, 3); // drop label, name, port.
     }
-    luaL_getmetatable(L, "mcp.backend");
-    lua_setmetatable(L, -2); // set metatable to userdata.
 
     return 1; // return be object.
 }
@@ -530,12 +588,21 @@ static mcp_backend_wrap_t *_mcplib_make_backendconn(lua_State *L, mcp_backend_la
         proxy_lua_error(L, "out of memory allocating backend connection");
         return NULL;
     }
+
     bew->be = be;
 
     strncpy(be->name, bel->name, MAX_NAMELEN+1);
     strncpy(be->port, bel->port, MAX_PORTLEN+1);
     strncpy(be->label, bel->label, MAX_LABELLEN+1);
     memcpy(&be->tunables, &bel->tunables, sizeof(bel->tunables));
+    memcpy(&be->logging, &bel->logging, sizeof(bel->logging));
+    be->use_logging = bel->use_logging;
+    // TODO: check for errors.
+    // not really going to happen and if it does the tag just blanks out..
+    if (bel->logging.detail) {
+        be->logging.detail = strdup(bel->logging.detail);
+    }
+
     be->conncount = bel->conncount;
     STAILQ_INIT(&be->iop_head);
 
@@ -1397,15 +1464,28 @@ static int mcplib_log_req(lua_State *L) {
         rtype = rs->resp.type;
         rcode = rs->resp.code;
         rstatus = rs->status;
-        rname = rs->be_name;
-        rport = rs->be_port;
+        if (rs->be) {
+            rname = rs->be->name;
+            rport = rs->be->port;
+        } else {
+            rname = "internal";
+            rport = "0";
+        }
         elapsed = rs->elapsed;
     }
     size_t dlen = 0;
     const char *detail = luaL_optlstring(L, 3, NULL, &dlen);
     int cfd = luaL_optinteger(L, 4, 0);
+    uint8_t flag = RQUEUE_R_ANY;
+    if (rstatus == MCMC_OK) {
+        if (rcode != MCMC_CODE_END) {
+            flag = RQUEUE_R_GOOD;
+        } else {
+            flag = RQUEUE_R_OK;
+        }
+    }
 
-    logger_log(l, LOGGER_PROXY_REQ, NULL, rq->pr.request, rq->pr.reqlen, elapsed, rtype, rcode, rstatus, cfd, detail, dlen, rname, rport);
+    logger_log(l, LOGGER_PROXY_REQ, NULL, rq->pr.request, rq->pr.reqlen, elapsed, rtype, rcode, rstatus, flag, cfd, detail, dlen, rname, rport);
 
     return 0;
 }
@@ -1432,6 +1512,45 @@ static uint32_t _mcp_nextrand(uint32_t *s) {
     return result;
 }
 
+void mcplib_rqu_log(mcp_request_t *rq, mcp_resp_t *rs, int flag, int cfd) {
+    LIBEVENT_THREAD *t = rs->thread;
+    logger *l = t->l;
+
+    long elapsed = 0;
+
+    int rtype = rs->resp.type;
+    int rcode = rs->resp.code;
+    int rstatus = rs->status;
+    elapsed = rs->elapsed;
+
+    bool do_log = false;
+    struct proxy_logging *pl = &rs->be->logging;
+    if (pl->all_errors && rstatus != MCMC_OK) {
+        do_log = true;
+    } else if (pl->deadline > 0 && elapsed > pl->deadline) {
+        do_log = true;
+    } else if (pl->rate > 0) {
+        // slightly biased random-to-rate without adding a loop, which is
+        // completely fine for this use case.
+        uint32_t rnd = (uint64_t)_mcp_nextrand(t->proxy_rng) * (uint64_t)pl->rate >> 32;
+        if (rnd == 0) {
+            do_log = true;
+        }
+    }
+
+    if (do_log) {
+        char *rname = rs->be->name;
+        char *rport = rs->be->port;
+        size_t dlen = 0;
+        const char *detail = rs->be->logging.detail;
+
+        if (detail) {
+            dlen = strlen(detail);
+        }
+
+        logger_log(l, LOGGER_PROXY_REQ, NULL, rq->pr.request, rq->pr.reqlen, elapsed, rtype, rcode, rstatus, flag, cfd, detail, dlen, rname, rport);
+    }
+}
 
 // (milliseconds, sample_rate, allerrors, request, resp, "detail")
 static int mcplib_log_reqsample(lua_State *L) {
@@ -1459,8 +1578,13 @@ static int mcplib_log_reqsample(lua_State *L) {
         rtype = rs->resp.type;
         rcode = rs->resp.code;
         rstatus = rs->status;
-        rname = rs->be_name;
-        rport = rs->be_port;
+        if (rs->be) {
+            rname = rs->be->name;
+            rport = rs->be->port;
+        } else {
+            rname = "internal";
+            rport = "0";
+        }
         elapsed = rs->elapsed;
     }
     size_t dlen = 0;
@@ -1480,9 +1604,17 @@ static int mcplib_log_reqsample(lua_State *L) {
             do_log = true;
         }
     }
+    uint8_t flag = RQUEUE_R_ANY;
+    if (rstatus == MCMC_OK) {
+        if (rcode != MCMC_CODE_END) {
+            flag = RQUEUE_R_GOOD;
+        } else {
+            flag = RQUEUE_R_OK;
+        }
+    }
 
     if (do_log) {
-        logger_log(l, LOGGER_PROXY_REQ, NULL, rq->pr.request, rq->pr.reqlen, elapsed, rtype, rcode, rstatus, cfd, detail, dlen, rname, rport);
+        logger_log(l, LOGGER_PROXY_REQ, NULL, rq->pr.request, rq->pr.reqlen, elapsed, rtype, rcode, rstatus, flag, cfd, detail, dlen, rname, rport);
     }
 
     return 0;

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -171,6 +171,13 @@ static void _proxy_event_handler_dequeue(proxy_event_thread_t *t) {
 }
 
 static void _cleanup_backend(mcp_backend_t *be) {
+    if (be->use_logging) {
+        if (be->logging.detail) {
+            free(be->logging.detail);
+            be->logging.detail = NULL;
+        }
+    }
+
     for (int x = 0; x < be->conncount; x++) {
         struct mcp_backendconn_s *bec = &be->be[x];
         // remove any pending events.

--- a/t/proxyinternal.lua
+++ b/t/proxyinternal.lua
@@ -24,7 +24,13 @@ function mcp_config_routes(zones)
             if string.find(k, "^/sub/") then
                 return rctx:enqueue_and_wait(r, hsub)
             else
-                return rctx:enqueue_and_wait(r, h)
+                if k == "log" then
+                    local res = rctx:enqueue_and_wait(r, h)
+                    mcp.log_req(r, res, "testing")
+                    return res
+                else
+                    return rctx:enqueue_and_wait(r, h)
+                end
             end
         end
     end})

--- a/t/proxyinternal.t
+++ b/t/proxyinternal.t
@@ -217,6 +217,16 @@ subtest 'watch deletions' => sub {
         "meta-delete command logged with correct size");
 };
 
+subtest 'log' => sub {
+    my $watcher = $p_srv->new_sock;
+    print $watcher "watch proxyreqs\n";
+    is(<$watcher>, "OK\r\n", "watcher enabled");
+
+    print $ps "mg log v\r\n";
+    is(scalar <$ps>, "EN\r\n", "miss received");
+    like(<$watcher>, qr/detail=testing/, "got log line");
+};
+
 done_testing();
 
 END {

--- a/t/proxyunits.t
+++ b/t/proxyunits.t
@@ -1127,7 +1127,7 @@ check_sanity($ps);
     is(scalar <$be>, $cmd, "got passthru for log");
     print $be "END\r\n";
     is(scalar <$ps>, "END\r\n", "got END from log test");
-    like(<$watcher>, qr/ts=(\S+) gid=\d+ type=proxy_req elapsed=\d+ type=105 code=17 status=0 cfd=\d+ be=127.0.0.1:11411 detail=logreqtest req=get \/logreqtest\/a/, "found request log entry");
+    like(<$watcher>, qr/ts=(\S+) gid=\d+ type=proxy_req elapsed=\d+ type=105 code=17 status=0 res=ok cfd=\d+ be=127.0.0.1:11411 detail=logreqtest req=get \/logreqtest\/a/, "found request log entry");
 
     # test log_req with nil res (should be 0's in places)
     # log_reqsample()
@@ -1145,7 +1145,7 @@ check_sanity($ps);
     sleep 0.3;
     print $be "END\r\n";
     is(scalar <$ps>, "END\r\n", "got END from log test");
-    like(<$watcher>, qr/ts=(\S+) gid=\d+ type=proxy_req elapsed=\d+ type=105 code=17 status=0 cfd=\d+ be=127.0.0.1:11411 detail=logsampletest req=get \/logreqstest\/b/, "only got b request from log sample");
+    like(<$watcher>, qr/ts=(\S+) gid=\d+ type=proxy_req elapsed=\d+ type=105 code=17 status=0 res=ok cfd=\d+ be=127.0.0.1:11411 detail=logsampletest req=get \/logreqstest\/b/, "only got b request from log sample");
 }
 
 # Test out of spec commands from client


### PR DESCRIPTION
Options similar to mcp.log_reqsample() are applied to responses as they're read off the network.

Can be a lot faster than relying on callbacks to do logging, if you're not doing logging inline with a route handler. Also simpler in some cases (ie routelib).

This code also leverages the removal of V1 and cuts 250 bytes from every res object, resulting in less memory used per "request slot", and an extra minor speedup on _all_ requests from less time in memset and not copying the backend host/port onto every response.

TODO:
- [x] Fix for `internal` response logging since we've removed the response-inline label.
- [x] Additional tests. (with/without detail, error/no error, rate check, etc)
- [x] Double check the tag/detail logic for HIT logs. It might print HIT's too often.