### PR TITLE
stats: Update time_since_server_cert_refresh to prevent showing underflow result

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1885,7 +1885,7 @@ void server_stats(ADD_STAT add_stats, void *c) {
         }
         APPEND_STAT("ssl_handshake_errors", "%llu", (unsigned long long)stats.ssl_handshake_errors);
         APPEND_STAT("ssl_proto_errors", "%llu", (unsigned long long)stats.ssl_proto_errors);
-        APPEND_STAT("time_since_server_cert_refresh", "%u", now - settings.ssl_last_cert_refresh_time);
+        APPEND_STAT("time_since_server_cert_refresh", "%u", (now >= settings.ssl_last_cert_refresh_time) ? (now - settings.ssl_last_cert_refresh_time) : 0);
     }
 #endif
     APPEND_STAT("unexpected_napi_ids", "%llu", (unsigned long long)stats.unexpected_napi_ids);


### PR DESCRIPTION
#### Issue
* Memcached version 1.6.17

We received a case that the stats `time_since_server_cert_refresh` shows unreasonable number

```
STAT uptime 21323273
STAT time 1734085745
STAT rusage_user 941.709452
STAT rusage_system 1270.867859
STAT time_since_server_cert_refresh 1864631599
``` 
`APPEND_STAT("time_since_server_cert_refresh", "%u", now - settings.ssl_last_cert_refresh_time);`

This seems like an edge case lead to underflow related to known current_time issue: https://github.com/memcached/memcached/issues/679.

Since we have customers monitoring this metric, and considering this known issue has no signs of change in the upcoming plans. Raise this PR to prevent showing edge case number in stats response. 