### PR TITLE
Free `temp_portnumber_filename` before function exits

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -6110,6 +6110,7 @@ int main (int argc, char **argv) {
             } else {
                 vperror("failed to listen on one of interface(s) %s", settings.inter);
             }
+            free(temp_portnumber_filename);
             exit(EX_OSERR);
         }
 
@@ -6129,6 +6130,7 @@ int main (int argc, char **argv) {
             } else {
                 vperror("failed to listen on one of interface(s) %s", settings.inter);
             }
+            free(temp_portnumber_filename);
             exit(EX_OSERR);
         }
 


### PR DESCRIPTION
This is the second commit in PR #1203 

A memory is allocated and stored in pointer `temp_portnumber_filename`

`temp_portnumber_filename = malloc(len);`

It is not freed when the function exits at exception branches.

