### PR TITLE
Release memory in function _evict_page

### DIFF
--- a/extstore.c
+++ b/extstore.c
@@ -460,6 +460,7 @@ static void _evict_page(store_engine *e, unsigned int bucket,
     if (low_version != ULLONG_MAX) {
         extstore_evict_page(e, low_page, low_version);
     }
+    free(st.page_data);
 }
 
 // call with *e locked


### PR DESCRIPTION
In function `_evict_page`, the memory allocated at line 432 and assigned to `st.page_data` is passed to the function extstore_get_page_data at line 433, but it's never freed before the function returns. Since `st` is a local variable and `st.page_data` is not referenced by other pointers, this memory is leaked when the function exits.
```c
static void _evict_page(store_engine *e, unsigned int bucket,
        unsigned int free_bucket) {
    struct extstore_stats st;
    st.page_data = calloc(e->page_count, sizeof(struct extstore_page_data));
    extstore_get_page_data(e, &st);
    uint64_t low_version = ULLONG_MAX;
    unsigned int low_page = 0;
    ......
    // not freed
}
``` 

Thus, we add a free operation before the function exits.