### PR TITLE
Release memory in function proxy_init_startfiles

### DIFF
--- a/proxy_config.c
+++ b/proxy_config.c
@@ -418,6 +418,7 @@ static int proxy_init_startfiles(proxy_ctx_t *ctx, const char *files) {
         struct _mcp_luafile *db = calloc(sizeof(struct _mcp_luafile), 1);
         if (db == NULL) {
             fprintf(stderr, "ERROR: failed to allocate memory for parsing proxy_startfile\n");
+            free(flist);
             return -1;
         }
         db->size = MCP_LUAFILE_SIZE;
@@ -425,6 +426,10 @@ static int proxy_init_startfiles(proxy_ctx_t *ctx, const char *files) {
         db->fname = strdup(p);
         if (db->buf == NULL || db->fname == NULL) {
             fprintf(stderr, "ERROR: failed to allocate memory while parsing proxy_startfile\n");
+            free(flist);
+            free(db->buf);
+            free(db->fname);
+            free(db);
             return -1;
         }
 


### PR DESCRIPTION
In the function `proxy_init_startfiles`, the memory pointers `flist`, `db`, `db->buf`, `db->fname` are not freed in error handling branches, which could lead to memory leak.
```c
static int proxy_init_startfiles(proxy_ctx_t *ctx, const char *files) {
    char *flist = strdup(settings.proxy_startfile);
    if (flist == NULL) {
        fprintf(stderr, "ERROR: failed to allocate memory for parsing proxy_startfile\n");
        return -1;
    }

    char *b;
    for (const char *p = strtok_r(flist, ":", &b);
            p != NULL;
            p = strtok_r(NULL, ":", &b)) {
        struct _mcp_luafile *db = calloc(sizeof(struct _mcp_luafile), 1);
        if (db == NULL) {
            fprintf(stderr, "ERROR: failed to allocate memory for parsing proxy_startfile\n");
            // memory leak here
            return -1;
        }
        db->size = MCP_LUAFILE_SIZE;
        db->buf = calloc(db->size, 1);
        db->fname = strdup(p);
        if (db->buf == NULL || db->fname == NULL) {
            fprintf(stderr, "ERROR: failed to allocate memory while parsing proxy_startfile\n");
            // memory leak here
            return -1;
        }

        // put new file at tail
        if (ctx->proxy_code == NULL) {
            ctx->proxy_code = db;
        } else {
            struct _mcp_luafile *list = ctx->proxy_code;
            while (list->next) {
                list = list->next;
            }
            assert(list->next == NULL);
            list->next = db;
        }
    }

    free(flist);
    return 0;
}
``` 