### PR TITLE
Release memory in function `assoc_get_iterator`

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -310,6 +310,7 @@ void *assoc_get_iterator(void) {
     if (mutex_trylock(&maintenance_lock) == 0) {
         return iter;
     } else {
+        free(iter);
         return NULL;
     }
 }


### PR DESCRIPTION
In function `assoc_get_iterator`, the pointer `iter` allocated at line 305 is not freed and not propagated to any function when the function returns NULL at line 10. Thus, I add a free operation before the function exits.
```c
void *assoc_get_iterator(void) {
    struct assoc_iterator *iter = calloc(1, sizeof(struct assoc_iterator));
    if (iter == NULL) {
        return NULL;
    }
    // this will hang the caller while a hash table expansion is running.
    if (mutex_trylock(&maintenance_lock) == 0) {
        return iter;
    } else {
        // memory leak here
        return NULL;
    }
}
``` 