### PR TITLE
crawler: speedup and extstore info

### DIFF
--- a/util.c
+++ b/util.c
@@ -44,6 +44,23 @@ bool uriencode(const char *src, char *dst, const size_t srclen, const size_t dst
     return true;
 }
 
+// No null byte termination, no dst length check, _must_ be at least 3x the
+// size of srclen.
+char *uriencode_p(const char *src, char *dst, const size_t srclen) {
+    int x;
+    size_t d = 0;
+    for (x = 0; x < srclen; x++) {
+        if (uriencode_map[(unsigned char) src[x]] != NULL) {
+            memcpy(&dst[d], uriencode_map[(unsigned char) src[x]], 3);
+            d += 3;
+        } else {
+            dst[d] = src[x];
+            d++;
+        }
+    }
+    return dst+d;
+}
+
 /* Avoid warnings on solaris, where isspace() is an index into an array, and gcc uses signed chars */
 #define xisspace(c) isspace((unsigned char)c)
 

--- a/util.h
+++ b/util.h
@@ -3,6 +3,7 @@
 /* fast-enough functions for uriencoding strings. */
 void uriencode_init(void);
 bool uriencode(const char *src, char *dst, const size_t srclen, const size_t dstlen);
+char *uriencode_p(const char *src, char *dst, const size_t srclen);
 
 /*
  * Wrappers around strtoull/strtoll that are safer and easier to


### PR DESCRIPTION
Unrolls the sprintf used for `lru_crawler metadump` since it is a hot path. Increases dump speed with no crawler sleep by 30%.

Also adds the disk page and disk page offset via `ext_page` and `ext_offset` if the item is on disk.

Credit to @hemal-shah for the idea on dumping extstore information.