### PR TITLE
Fix `mcplib_time_*_millis` overflow on 32bit systems

### DIFF
--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -223,7 +223,7 @@ static int mcplib_schedule_config_reload(lua_State *L) {
 static int mcplib_time_real_millis(lua_State *L) {
     struct timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
-    lua_Integer t = now.tv_nsec / 1000000 + now.tv_sec * 1000;
+    lua_Integer t = now.tv_nsec / 1000000 + (lua_Integer) now.tv_sec * 1000;
     lua_pushinteger(L, t);
     return 1;
 }
@@ -231,7 +231,7 @@ static int mcplib_time_real_millis(lua_State *L) {
 static int mcplib_time_mono_millis(lua_State *L) {
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
-    lua_Integer t = now.tv_nsec / 1000000 + now.tv_sec * 1000;
+    lua_Integer t = now.tv_nsec / 1000000 + (lua_Integer) now.tv_sec * 1000;
     lua_pushinteger(L, t);
     return 1;
 }


### PR DESCRIPTION
This fixes a time overflow by casting `tv_sec` to `lua_Integer` (which is `long long` unless explicitly configured otherwise) before multiplying it by 1000, which ensures the result doesn't become negative before being assigned to a `lua_Integer` value and returned.

Concretely, this fixes the test failure in `t/proxyunits.t` on systems that have not yet transitioned to `time64_t` (notably, Debian 12 / Bookworm; that transition should be part of 13 / Trixie, which will likely be released later this year).

Fixes https://github.com/memcached/memcached/issues/1220