### PR TITLE
Fix wrong format specifier for num_napi_ids

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1983,7 +1983,7 @@ void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("proxy_enabled", "%s", settings.proxy_enabled ? "yes" : "no");
     APPEND_STAT("proxy_uring_enabled", "%s", settings.proxy_uring ? "yes" : "no");
 #endif
-    APPEND_STAT("num_napi_ids", "%s", settings.num_napi_ids);
+    APPEND_STAT("num_napi_ids", "%d", settings.num_napi_ids);
     APPEND_STAT("memory_file", "%s", settings.memory_file);
     APPEND_STAT("client_flags_size", "%d", sizeof(client_flags_t));
 }


### PR DESCRIPTION
This fixes wrong format specifier for num_napi_ids, which has been defined as int, 
https://github.com/memcached/memcached/blob/db6cc06efcd77ca6c74f568507159066d2104349/memcached.h#L545

but string placeholder is being used as it's format specifier in the append_stat function.
https://github.com/memcached/memcached/blob/db6cc06efcd77ca6c74f568507159066d2104349/memcached.c#L1729

Fixes https://github.com/memcached/memcached/issues/1218