### PR TITLE
Fix possible NULL dereference in storage_conf_parse when memory allocation fails

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -1229,7 +1229,16 @@ struct extstore_conf_file *storage_conf_parse(char *arg, unsigned int page_size)
         goto error;
     // First arg is the filepath.
     cf = calloc(1, sizeof(struct extstore_conf_file));
+    if (cf == NULL) {
+       fprintf(stderr, "Failed to allocate extstore config structure\n");
+       goto error;
+    }
+
     cf->file = strdup(p);
+    if (cf->file == NULL) {
+       fprintf(stderr, "Failed to allocate extstore path string\n");
+       goto error;
+    }
 
     p = strtok_r(NULL, ":", &b);
     if (p == NULL) {


### PR DESCRIPTION
**Describe the bug**

When memcached is compiled and running under constrained memory conditions, the `storage_conf_parse()` function may cause a segmentation fault due to an unchecked NULL pointer dereference.

Specifically, the function allocates memory using `calloc()` and then assigns a duplicated string to `cf->file` using `strdup()`.  
However, the return values of both `calloc()` and `strdup()` are not checked for `NULL`.  
If either allocation fails (e.g., due to out-of-memory conditions), the code proceeds to dereference a `NULL` pointer, resulting in a crash.

---

**Affected Code**

```c
cf = calloc(1, sizeof(struct extstore_conf_file));
cf->file = strdup(p);
```

---

**Vulnerability**

- `cf == NULL` → `cf->file = ...` → NULL dereference
- `cf->file == NULL` → may cause undefined behavior or memory leak later

This issue can be triggered in low-memory environments and may occur on startup or during dynamic configuration parsing.

---

**Fix**

This patch adds proper `NULL` checks after both `calloc()` and `strdup()`, using the existing `goto error` cleanup path.  
The implementation follows the existing coding style in memcached (`fprintf`, `goto error`, no inline `exit()`), and does not alter the original control flow.

---

**Patched Code (excerpt)**

```c
cf = calloc(1, sizeof(struct extstore_conf_file));
if (cf == NULL) {
    fprintf(stderr, "Failed to allocate extstore config structure\n");
    goto error;
}

cf->file = strdup(p);
if (cf->file == NULL) {
    fprintf(stderr, "Failed to allocate extstore path string\n");
    goto error;
}
```

---

**Why This Should Be Merged**

- Prevents potential segmentation faults in memory-constrained environments  
- Consistent with defensive coding practices already used in other parts of the codebase  
- Maintains existing logic and structure (minimal and safe change)  
- Easy to review, localized fix with no side effects

Thanks!