### PR TITLE
Fix typecast on setting stop_time during restart

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4455,7 +4455,7 @@ static int _mc_meta_save_cb(const char *tag, void *ctx, void *data) {
     {
         struct timeval tv;
         gettimeofday(&tv, NULL);
-        restart_set_kv(ctx, "stop_time", "%lu", tv.tv_sec);
+        restart_set_kv(ctx, "stop_time", "%llu", (unsigned long long) tv.tv_sec);
     }
 
     // Might as well just fetch the next CAS value to use than tightly


### PR DESCRIPTION
Fixes https://github.com/memcached/memcached/issues/799
Closes https://github.com/memcached/memcached/issues/1220

See https://github.com/memcached/memcached/issues/1220#issuecomment-3109594827 and following comments for testing that led to this discovery :partying_face: