### PR TITLE
proxy mutator minor improvements

### DIFF
--- a/t/proxymut.lua
+++ b/t/proxymut.lua
@@ -11,6 +11,9 @@ function mcp_config_routes(p)
     local mgfgh = mgfg:new_handle(p)
     local msfg = mcp.funcgen_new()
     local msfgh = msfg:new_handle(p)
+    local mginth = mgfg:new_handle(mcp.internal_handler)
+    local msinth = msfg:new_handle(mcp.internal_handler)
+
     -- TODO: basic ascii handlers as well
     -- so we can test rewriting requests between command types
 
@@ -55,6 +58,11 @@ function mcp_config_routes(p)
         { t = "flagcopy", flag = "O", idx = 1 }
     )
 
+    local mut_mgresflagall = mcp.res_mutator_new(
+        { t = "rescodeset", val = "HD" },
+        { t = "flagcopyall", idx = 1 }
+    )
+
     -- error res.
     local mut_reserr = mcp.res_mutator_new(
         { t = "reserr", code = "server", msg = "teapot" }
@@ -97,6 +105,22 @@ function mcp_config_routes(p)
                     local res = rctx:enqueue_and_wait(r, mgfgh)
                     local ret = mut_mgresflag(nres, "toast")
                     return nres
+                elseif key == "mgresflag3" then
+                    local res = rctx:enqueue_and_wait(r, mgfgh)
+                    local ret = mut_mgresflag(nres, nil)
+                    return nres
+                elseif key == "mgresflag4" then
+                    local res = rctx:enqueue_and_wait(r, mgfgh)
+                    local ret = mut_mgresflag(nres, true)
+                    return nres
+                elseif key == "mgresflagall" then
+                    local res = rctx:enqueue_and_wait(r, mgfgh)
+                    local ret = mut_mgresflagall(nres, res)
+                    return nres
+                elseif key == "mgresflagallint" then
+                    local res = rctx:enqueue_and_wait(r, mginth)
+                    local ret = mut_mgresflagall(nres, res)
+                    return nres
                 elseif key == "mgresteapot" then
                     local res = mut_reserr(nres)
                     if nres:ok() or nres:hit() then
@@ -112,7 +136,9 @@ function mcp_config_routes(p)
         n = "mstest", u = 2, f = function(rctx)
             return function(r)
                 local key = r:key()
-                -- test tree
+                if key == "mgresflagallint" then
+                    return rctx:enqueue_and_wait(r, msinth)
+                end
             end
         end
     })

--- a/t/proxymut.t
+++ b/t/proxymut.t
@@ -98,6 +98,40 @@ sub test_mg {
         $t->clear();
     };
 
+    subtest 'mgresflag3' => sub {
+        $t->c_send("mg mgresflag3\r\n");
+        $t->be_recv(0, "mg mgresflag3\r\n");
+        $t->be_send(0, "HD s2 Omgresflag3 f3\r\n");
+        $t->c_recv("HD t37\r\n");
+        $t->clear();
+    };
+
+    subtest 'mgresflag4' => sub {
+        $t->c_send("mg mgresflag4\r\n");
+        $t->be_recv(0, "mg mgresflag4\r\n");
+        $t->be_send(0, "HD s2 Omgresflag4 f3\r\n");
+        $t->c_recv("HD t37 O\r\n");
+        $t->clear();
+    };
+
+    subtest 'mgresflagall' => sub {
+        $t->c_send("mg mgresflagall\r\n");
+        $t->be_recv(0, "mg mgresflagall\r\n");
+        # nonsense response for testing.
+        $t->be_send(0, "VA 2 t41 Oopaque s2 X W Z\r\nhi\r\n");
+        $t->c_recv("HD t41 Oopaque s2 X W Z\r\n");
+        $t->clear();
+    };
+
+    subtest 'mgresflagallint' => sub {
+        $t->c_send("ms mgresflagallint 2\r\nhi\r\n");
+        $t->c_recv("HD\r\n", "seeded item");
+
+        $t->c_send("mg mgresflagallint v t O123456 s h\r\n");
+        $t->c_recv("HD t-1 O123456 s2 h0\r\n");
+        $t->clear();
+    };
+
     subtest 'mgreserr' => sub {
         $t->c_send("mg mgresteapot\r\n");
         $t->c_recv("SERVER_ERROR teapot\r\n");

--- a/t/proxymut.t
+++ b/t/proxymut.t
@@ -81,6 +81,12 @@ sub test_mg {
         $t->be_recv(0, "mg mgresflag\r\n");
         $t->be_send(0, "HD s2 Omgresflag f3\r\n");
         $t->c_recv("HD t37 Omgresflag\r\n");
+
+        $t->c_send("mg mgresflag\r\n");
+        $t->be_recv(0, "mg mgresflag\r\n");
+        $t->be_send(0, "HD s2 f3\r\n");
+        $t->c_recv("HD t37\r\n");
+
         $t->clear();
     };
 


### PR DESCRIPTION
- lets mutator use results from mcp.internal calls.
- if flagcopy's index is a nil, does not set the flag at all.
- adds very limited flagcopyall that can copy the result line from a result object. can't do requests or selectively exempt flags.