### PR TITLE
Reload TLS certificates on SIGHUP

### DIFF
--- a/doc/tls.txt
+++ b/doc/tls.txt
@@ -126,7 +126,8 @@ When this happens we want server to use the new certificate without restarting t
 Memcached is a cache and restarting servers affects the latency of applications. We implement
 the automatic certificate refresh through a command. Upon receiving the "refresh_certs" command,
 the server reloads the certificates and key to the SSL Context object. Existing connection won't be
-interrupted but new connections will use the new certificate.
+interrupted but new connections will use the new certificate. Additionally to the "refresh_certs"
+command, memcached also refreshes its certificates upon receiving the SIGHUP signal.
 
 We understand not all users want to use TLS or have the OpenSSL dependency. Therefore
 it's an optional module at the compile time. We can build a TLS capable Memcached server with


### PR DESCRIPTION
SIGHUP is the standard way of forcing daemons to reload their configuration, but memcached only reloads TLS certificates in response to the `refresh_certs` command, which requires a lot more work to issue. When implementing automatic certificate updates, it's a lot more straightforward to follow the standard signal-based approach.