### PR TITLE
Use SSLv23 method when TLSv1.3 is unsupported (e.g., macOS)

### DIFF
--- a/t/ssl_ports.t
+++ b/t/ssl_ports.t
@@ -33,14 +33,15 @@ mem_get_is($tcp_sock, "foo:123", "foo set over SSL");
 # not trying very hard but: if the above works and this doesn't, it's going to
 # be the peer cert. If someone wants to tryhard you can try inspecting
 # $SSL_ERROR and/or checking `watch connevents` stream
-my $tls_version = 'TLSv1_3';
-MTLS_SOCK:
-my $mtls_sock = $server->new_nocert_tls_sock($mtls_port, $tls_version);
-unless ($mtls_sock) {
-    $tls_version = 'SSLv23';
-    goto MTLS_SOCK;
+my ($mtls_sock, $mtls_version);
+for my $tls ('TLSv1_3', 'SSLv23') {
+    $mtls_sock = $server->new_nocert_tls_sock($mtls_port, $tls);
+    if ($mtls_sock) {
+        $mtls_version = $tls;
+        last;
+    }
 }
 print $mtls_sock "version\r\n";
-is(scalar <$mtls_sock>, undef, "failed to connect without peer cert on $tls_version");
+is(scalar <$mtls_sock>, undef, "failed to connect without peer cert on $mtls_version");
 
 done_testing()

--- a/t/ssl_proto_version.t
+++ b/t/ssl_proto_version.t
@@ -37,15 +37,16 @@ like(scalar <$sock>, qr/VERSION/, "handshake with minimum proto version");
 SKIP: {
     skip 'TLS v1.3 not available', 1 if !$is_tls_13_available;
     # Above minimum supported protocol version
-    my $tls_version = 'TLSv1_3';
-    MTLS_SOCK:
-    $sock = $server->new_sock(undef, $tls_version);
-    unless ($sock) {
-        $tls_version = 'SSLv23';
-        goto MTLS_SOCK;
+    my ($mtls_sock, $mtls_version);
+    for my $tls ('TLSv1_3', 'SSLv23') {
+        $mtls_sock = $server->new_sock(undef, $tls);
+        if ($mtls_sock) {
+            $mtls_version = $tls;
+            last;
+        }
     }
-    print $sock "version\r\n";
-    like(scalar <$sock>, qr/VERSION/, "handshake above minimum proto version on $tls_version");
+    print $mtls_sock "version\r\n";
+    like(scalar <$mtls_sock>, qr/VERSION/, "handshake above minimum proto version on $mtls_version");
 }
 
 done_testing();


### PR DESCRIPTION
New macOS Tahoe versions ship with OpenSSL 3.6.0 builds that disable TLSv1.3. Update the SSL context creation to use SSL_version => 'SSLv23' after test fail with TLSv1.3.