### PR TITLE
Improve parallel test execution, RPM build, and test configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -154,7 +154,7 @@ memcached_debug_dtrace.o: $(memcached_debug_OBJECTS)
 SUBDIRS = doc
 DIST_DIRS = scripts
 EXTRA_DIST = doc scripts t memcached.spec memcached_dtrace.d version.m4 README.md LICENSE.bipbuffer
-EXTRA_DIST += vendor/Makefile vendor/lua/doc/* vendor/lua/Makefile vendor/lua/README
+EXTRA_DIST += vendor/Makefile vendor/lua/doc/* vendor/lua/Makefile vendor/lua/README parallel.mk
 EXTRA_DIST += vendor/lua/src/*.c vendor/lua/src/*.h vendor/lua/src/Makefile
 EXTRA_DIST += vendor/mcmc/LICENSE vendor/mcmc/Makefile vendor/mcmc/README.md vendor/mcmc/*.c vendor/mcmc/*.h
 EXTRA_DIST += vendor/routelib/*.h vendor/routelib/*.lua
@@ -165,15 +165,18 @@ endif
 
 MOSTLYCLEANFILES = *.gcov *.gcno *.gcda *.tcov
 
+@INC_PARALLEL_MK@
+
 if ENABLE_TLS
+
 test_tls:
 	$(MAKE) SSL_TEST=1 test
 
 test_basic_tls:
-	@if test $(SSL_TEST)1 != 1; then \
+	@if [ "$(SSL_TEST)" = "1" ]; then \
 	  echo "Running basic tests with TLS"; \
 	  $(builddir)/testapp && \
-	  prove $(srcdir)/t/binary.t $(srcdir)/t/getset.t $(srcdir)/t/ssl* && \
+	  prove $(PARALLEL) $(srcdir)/t/binary.t $(srcdir)/t/getset.t $(srcdir)/t/ssl* && \
 	  echo "Finished running basic TLS tests"; \
 	else \
 	  echo "Set SSL_TEST=1 to enable TLS tests"; \
@@ -184,15 +187,11 @@ test:	memcached-debug sizes testapp
 	$(builddir)/sizes
 	$(builddir)/testapp
 if ENABLE_TLS
-	@if test $(SSL_TEST)1 = 1; then \
-          $(MAKE) SSL_TEST=1  test_basic_tls; \
+	@if [ "$(SSL_TEST)" = "1" ]; then \
+          $(MAKE) SSL_TEST=1 test_basic_tls; \
 	fi
 endif
-	@if test -n "${PARALLEL}"; then \
-	  prove $(srcdir)/t -j ${PARALLEL}; \
-	else \
-	  prove $(srcdir)/t; \
-	fi
+	@prove $(PARALLEL) $(srcdir)/t
 	@if test `basename $(PROFILER)` = "gcov"; then \
 	  for file in memcached_debug-*.gc??; do \
 	    mv -f $$file `echo $$file | sed 's/memcached_debug-//'`; \
@@ -232,3 +231,4 @@ maintainer-clean-local:
 	-rm configure
 	-rm config.log
 	-rm config.status
+

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,8 @@ AC_SUBST(DTRACEFLAGS)
 AC_SUBST(ENABLE_SASL)
 AC_SUBST(PROFILER_LDFLAGS)
 
+AC_SUBST([INC_PARALLEL_MK], ['include $(top_srcdir)/parallel.mk'])
+
 AC_ARG_ENABLE(coverage,
   [AS_HELP_STRING([--disable-coverage],[Disable code coverage])])
 

--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -7,8 +7,6 @@
 %bcond_without option_checking
 %bcond_without coverage
 %bcond_without docs
-%bcond_with tls
-%bcond_with proxy
 
 # Set with_systemd on distros that use it, so we can install the service
 # file, otherwise the sysvinit script will be installed
@@ -75,12 +73,7 @@ web applications by alleviating database load.
   %{?with_64bit:--enable-64bit} \
   %{!?with_option_checking:--disable-option-checking}
   %{!?with_coverage:--disable-coverage} \
-  %{!?with_docs:--disable-docs} \
-  %{?with_tls:--enable-tls} \
-%if %{with_tls}
-  %{?with_proxy:--enable-proxy-tls} \
-%endif
-  %{?with_proxy:--enable-proxy}
+  %{!?with_docs:--disable-docs}
 
 make %{?_smp_mflags}
 

--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -7,6 +7,8 @@
 %bcond_without option_checking
 %bcond_without coverage
 %bcond_without docs
+%bcond_with tls
+%bcond_with proxy
 
 # Set with_systemd on distros that use it, so we can install the service
 # file, otherwise the sysvinit script will be installed
@@ -73,12 +75,23 @@ web applications by alleviating database load.
   %{?with_64bit:--enable-64bit} \
   %{!?with_option_checking:--disable-option-checking}
   %{!?with_coverage:--disable-coverage} \
-  %{!?with_docs:--disable-docs}
+  %{!?with_docs:--disable-docs} \
+  %{?with_tls:--enable-tls} \
+%if %{with_tls}
+  %{?with_proxy:--enable-proxy-tls} \
+%endif
+  %{?with_proxy:--enable-proxy}
 
 make %{?_smp_mflags}
 
 
 %check
+%if %{with_tls}
+export SSL_TEST=1
+%endif
+%if %{defined _smp_mflags}
+export PARALLEL=%{_smp_mflags}
+%endif
 make test
 
 

--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -79,9 +79,6 @@ make %{?_smp_mflags}
 
 
 %check
-%if %{with_tls}
-export SSL_TEST=1
-%endif
 %if %{defined _smp_mflags}
 export PARALLEL=%{_smp_mflags}
 %endif

--- a/parallel.mk
+++ b/parallel.mk
@@ -1,0 +1,7 @@
+# If PARALLEL is set and does not contain -j or --jobs, prepend it and export the variable
+ifneq ($(strip $(PARALLEL)),)
+ifeq ($(filter -j% --jobs%,$(PARALLEL)),)
+override PARALLEL := -j $(PARALLEL)
+endif
+endif
+export PARALLEL

--- a/t/binary-extstore.t
+++ b/t/binary-extstore.t
@@ -17,7 +17,8 @@ if (!supports_extstore()) {
 
 $ext_path = "/tmp/extstore.$$";
 
-my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,no_lru_crawler,slab_automove=0,ext_max_sleep=100000");
+my $port = free_port();
+my $server = new_memcached("-m 64 -U 0 -o ext_page_size=8,ext_wbuf_size=2,ext_threads=1,ext_io_depth=2,ext_item_size=512,ext_item_age=2,ext_recache_rate=10000,ext_max_frag=0.9,ext_path=$ext_path:64m,no_lru_crawler,slab_automove=0,ext_max_sleep=100000", $port);
 ok($server, "started the server");
 
 # Based almost 100% off testClient.py which is:

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -269,10 +269,17 @@ sub is_running {
 }
 
 sub new_memcached {
-    my ($args, $passed_port) = @_;
+    my $args = shift;
+    my $passed_port = shift;
+    my %opts = (
+        -disable_udp => 0,
+        -disable_ssl => 0,
+        @_
+    );
+
     my $port = $passed_port;
     my $host = '127.0.0.1';
-    my $ssl_enabled  = enabled_tls_testing();
+    my $ssl_enabled  = $opts{-disable_ssl} ? 0 : enabled_tls_testing();
     my $unix_socket_disabled  = !supports_unix_socket();
     my $use_external = 0;
     if ($ENV{T_MEMD_EXTERNAL}) {
@@ -316,7 +323,7 @@ sub new_memcached {
             $udpport = 31000;
         }
         $args .= " -p $port";
-        if (supports_udp() && $args !~ /-U (\S+)/) {
+        if (!$opts{-disable_udp} && supports_udp() && $args !~ /-U (\S+)/) {
             $args .= " -U $udpport";
         }
         if ($ssl_enabled) {
@@ -360,7 +367,7 @@ sub new_memcached {
                 $valgrind .= " $ENV{VALGRIND_EXTRA_ARGS}";
             }
             my $cmd = "$builddir/timedrun 600 $valgrind $exe $args";
-            #print STDERR "RUN: $cmd\n\n";
+            print STDERR "RUN: $cmd\n\n" if $ENV{TEST_CMD};
             exec $cmd;
             exit; # never gets here.
         }
@@ -493,11 +500,11 @@ sub sock {
 
 sub new_sock {
     my $self = shift;
+    my ($ssl_session_cache, $ssl_version) = @_;
+
     if ($self->{domainsocket}) {
         return IO::Socket::UNIX->new(Peer => $self->{domainsocket});
     } elsif (MemcachedTest::enabled_tls_testing()) {
-        my $ssl_session_cache = shift;
-        my $ssl_version = shift;
         return eval qq{ IO::Socket::SSL->new(PeerAddr => "$self->{host}:$self->{port}",
                                     SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,
                                     SSL_session_cache => \$ssl_session_cache,

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -367,7 +367,7 @@ sub new_memcached {
                 $valgrind .= " $ENV{VALGRIND_EXTRA_ARGS}";
             }
             my $cmd = "$builddir/timedrun 600 $valgrind $exe $args";
-            print STDERR "RUN: $cmd\n\n" if $ENV{TEST_CMD};
+            #print STDERR "RUN: $cmd\n\n";
             exec $cmd;
             exit; # never gets here.
         }

--- a/t/maxconns.t
+++ b/t/maxconns.t
@@ -8,19 +8,8 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $max_conn = 1024 ;
-# Raise open files limit (RLIMIT_NOFILE) for better compatibility
-#
-# macOS has a very low default soft limit (256) on open file descriptors,
-# causing EMFILE errors after ~270 connections. Increase it programmatically
-# (or via system config) to support higher concurrency, matching Linux defaults.
-my $soft_limit = `ulimit -n`;
-if ($soft_limit && $soft_limit < $max_conn) {
-    $max_conn = $soft_limit - 1;
-}
-
 my $port = free_port();
-my $server = new_memcached("-o maxconns_fast -c $max_conn", $port, -disable_ssl => 1);
+my $server = new_memcached(undef, $port, -disable_ssl => 1);
 
 test_maxconns($server);
 
@@ -29,7 +18,7 @@ if (supports_extstore()) {
     $ext_path = "/tmp/extstore.$$";
 
     my $port = free_port();
-    my $server = new_memcached("-m 64 -U 0 -o maxconns_fast,ext_path=$ext_path:64m -c $max_conn", $port, -disable_ssl => 1);
+    my $server = new_memcached("-m 64 -U 0 -o ext_path=$ext_path:64m", $port, -disable_ssl => 1);
     test_maxconns($server);
 }
 
@@ -41,7 +30,7 @@ sub test_maxconns {
     my $num_sockets;
     my $rejected_conns = 0;
     my $stats;
-    for (1 .. $max_conn) {
+    for (1 .. 1024) {
       my $sock = $server->new_sock;
       if (defined($sock)) {
         push(@sockets, $sock);

--- a/t/maxconns.t
+++ b/t/maxconns.t
@@ -8,14 +8,28 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
-my $server = new_memcached();
+my $max_conn = 1024 ;
+# Raise open files limit (RLIMIT_NOFILE) for better compatibility
+#
+# macOS has a very low default soft limit (256) on open file descriptors,
+# causing EMFILE errors after ~270 connections. Increase it programmatically
+# (or via system config) to support higher concurrency, matching Linux defaults.
+my $soft_limit = `ulimit -n`;
+if ($soft_limit && $soft_limit < $max_conn) {
+    $max_conn = $soft_limit - 1;
+}
+
+my $port = free_port();
+my $server = new_memcached("-o maxconns_fast -c $max_conn", $port, -disable_ssl => 1);
+
 test_maxconns($server);
 
 my $ext_path;
 if (supports_extstore()) {
     $ext_path = "/tmp/extstore.$$";
 
-    my $server = new_memcached("-m 64 -U 0 -o ext_path=$ext_path:64m");
+    my $port = free_port();
+    my $server = new_memcached("-m 64 -U 0 -o maxconns_fast,ext_path=$ext_path:64m -c $max_conn", $port, -disable_ssl => 1);
     test_maxconns($server);
 }
 
@@ -27,7 +41,7 @@ sub test_maxconns {
     my $num_sockets;
     my $rejected_conns = 0;
     my $stats;
-    for (1 .. 1024) {
+    for (1 .. $max_conn) {
       my $sock = $server->new_sock;
       if (defined($sock)) {
         push(@sockets, $sock);

--- a/t/proxyconfig.t
+++ b/t/proxyconfig.t
@@ -91,8 +91,9 @@ for my $port (11511, 11512, 11513) {
 
 diag "testing failure to start";
 write_modefile("invalid syntax");
+my $proxy_port = free_port();
 eval {
-    my $p_srv = new_memcached('-o proxy_config=./t/proxyconfig.lua');
+    my $p_srv = new_memcached('-o proxy_config=./t/proxyconfig.lua', $proxy_port);
 };
 ok($@ && $@ =~ m/Failed to connect/, "server successfully not started");
 

--- a/t/proxyinternal.t
+++ b/t/proxyinternal.t
@@ -32,8 +32,8 @@ sub check_version {
 }
 
 my $t = Memcached::ProxyTest->new(servers => []);
-
-my $p_srv = new_memcached("-R 500 -o proxy_config=./t/proxyinternal.lua,ext_item_size=500,ext_item_age=1,ext_path=$ext_path:64m,ext_max_sleep=100000 -t 1");
+my $p_srv = new_memcached("-R 500 -o proxy_config=./t/proxyinternal.lua,ext_item_size=500,ext_item_age=1,ext_path=$ext_path:64m,ext_max_sleep=100000 -t 1",
+                          undef, -disable_udp =>1);
 my $ps = $p_srv->sock;
 $ps->autoflush(1);
 

--- a/t/proxytags.t
+++ b/t/proxytags.t
@@ -19,7 +19,8 @@ my $modefile = "/tmp/proxytagmode.lua";
 my $t = Memcached::ProxyTest->new(servers => [12050]);
 
 write_modefile('return "start"');
-my $p_srv = new_memcached('-l 127.0.0.1:12051 -l tag_b_:127.0.0.1:12052 -l tag_cccc_:127.0.0.1:12053 -o proxy_config=./t/proxytags.lua -t 1', 12051);
+my $p_srv = new_memcached('-l 127.0.0.1:12051 -l tag_b_:127.0.0.1:12052 -l tag_cccc_:127.0.0.1:12053 -o proxy_config=./t/proxytags.lua -t 1',
+                          12051, -disable_ssl => 1);
 my $ps = $p_srv->sock;
 $ps->autoflush(1);
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -1,5 +1,4 @@
 all:
-	@if [ ! -f lua/Makefile ]; then echo "Missing lua application, run $(CURDIR)/fetch.sh script to download it"; exit 1; fi
 	cd lua && $(MAKE) all MYCFLAGS="-g" && cd ..
 
 clean:

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -1,4 +1,5 @@
 all:
+	@if [ ! -f lua/Makefile ]; then echo "Missing lua application, run $(CURDIR)/fetch.sh script to download it"; exit 1; fi
 	cd lua && $(MAKE) all MYCFLAGS="-g" && cd ..
 
 clean:


### PR DESCRIPTION
- Enable running tests in parallel using the Makefile variable PARALLEL. Example usage: PARALLEL=5, PARALLEL=-j5, PARALLEL=-jobs=5.

- Add environment variable TEST_CMD to print the memcached command executed during tests.

- Configure unit tests to skip starting memcached with SSL or UDP when not required.

- Fix parallel test execution:
    1. Each test allocates its own port to avoid conflicts.
    2. Disable SSL or UDP in tests when not used to prevent parallel test failures.