### PR TITLE
SSL tests run over TCP using IO::Socket::SSL, which typically inherits

### DIFF
--- a/t/idle-timeout.t
+++ b/t/idle-timeout.t
@@ -31,12 +31,9 @@ sleep(10);
 mem_stats($sock);   # Network activity, so socket code will see dead socket
 sleep(1);
 # we run SSL tests over TCP; hence IO::Socket::SSL
-# with IO::Socket::IP returns '' upon disconnecting with the server.
-if (enabled_tls_testing() && $INC{'IO/Socket/IP.pm'}) {
-    is($sock->connected(),'', "check disconnected");
-} else {
-    is($sock->connected(),undef, "check disconnected");
-}
+# with IO::Socket::IP returns '' or IO::Socket::INET returns undef
+# upon disconnecting with the server.
+ok(length($sock->connected()) == 0, "check disconnected");
 
 $sock = $server->sock;
 $stats = mem_stats($sock);

--- a/t/idle-timeout.t
+++ b/t/idle-timeout.t
@@ -30,9 +30,9 @@ is($stats->{idle_kicks}, "0", "check stats 2");
 sleep(10);
 mem_stats($sock);   # Network activity, so socket code will see dead socket
 sleep(1);
-# we run SSL tests over TCP; hence IO::Socket::SSL returns
-# '' upon disconnecting with the server.
-if (enabled_tls_testing()) {
+# we run SSL tests over TCP; hence IO::Socket::SSL
+# with IO::Socket::IP returns '' upon disconnecting with the server.
+if (enabled_tls_testing() && $INC{'IO/Socket/IP.pm'}) {
     is($sock->connected(),'', "check disconnected");
 } else {
     is($sock->connected(),undef, "check disconnected");


### PR DESCRIPTION
from IO::Socket::IP.

When IO::Socket::IP is not available, IO::Socket::SSL falls back to IO::Socket::INET. The latter returns undef (instead of an empty string) upon a server disconnect.