### PR TITLE
Exclude doc/xml2rfc/rfc2629.dtd, queue.h and t/authfile2

### DIFF
--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -7,7 +7,10 @@ my @exempted = qw(Makefile.am ChangeLog doc/Makefile.am README README.md md5.c m
 push(@exempted, glob("doc/*.xml"));
 push(@exempted, glob("doc/*.full"));
 push(@exempted, glob("doc/xml2rfc/*.xsl"));
+push(@exempted, glob("doc/xml2rfc/*.dtd"));
 push(@exempted, glob("m4/*backport*m4"));
+push(@exempted, glob("queue.h"));
+push(@exempted, glob("t/authfile2"));
 my %exempted_hash = map { $_ => 1 } @exempted;
 
 my @stuff = split /\0/, `git ls-files -z -c -m -o --exclude-standard`;
@@ -19,7 +22,7 @@ unless (@files) {
 }
 
 foreach my $f (@files) {
-    open(my $fh, $f) or die;
+    open(my $fh, $f) or die "Can't open '$f' : $!";
     my $before = do { local $/; <$fh>; };
     close ($fh);
     my $after = $before;


### PR DESCRIPTION
 from modifications by devtools/clean-whitespace.pl