### PR TITLE
fix: storage_compact_readback checks wrong refcount

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -1000,7 +1000,7 @@ static void storage_compact_readback(void *storage, logger *l,
 
                 if (do_update) {
                     bool rescued = false;
-                    if (it->refcount == 2) {
+                    if (hdr_it->refcount == 2) {
                         hdr->page_version = io.page_version;
                         hdr->page_id = io.page_id;
                         hdr->offset = io.offset;


### PR DESCRIPTION
### Access pattern
The key is being read 10-13K times per second, not being written at this time, meanwhile compaction is high due to high disk util and max_frag at 0.99 (but also on another node at similar access pattern and disk util but max_frag is 0.97). item_age at 0. 

### Root cause
When refcount is 3+, the else branch (line 1009) creates a new HDR via item_replace. The old HDR (held by the pending IO) gets unlinked by item_replace. When the  reader's IO later fails and the miss handler calls item_unlink(p->hdr_it), ITEM_LINKED is already cleared → no-op. The new HDR in the hash table survives.  the HDR points to the new valid page. But then the racing reader's miss handler does: item_unlink(p->hdr_it)

Here's the exact sequence that kills this key:                                                                                                                     
   
  1. Worker: do_item_get(key) → finds HDR, refcount 1→2                                                                                                              
  2. Worker: storage_get_item() → copies page_id=P_old, page_version=V_old into io_pending. p->hdr_it = hdr_it
  3. Worker: Releases item_lock. IO not yet dispatched.
  4. Compactor: Acquires item_lock for this key
  5. Compactor: refcount_incr(hdr_it) → refcount now 3
  6. Compactor: Checks it->refcount == 2 (disk copy) → TRUE (always 2 for cold LRU items)
  7. Compactor: Updates HDR in-place: hdr->page_id=P_new, hdr->page_version=V_new
  8. Compactor: Releases item_lock. Continues processing other items on page P_old.
  9. Compactor: Finishes page → extstore_close_page(P_old) → page P_old is now closed
  10. IO thread: Tries pread(page=P_old, version=V_old) → page closed → ret = -2
  11. IO callback: _storage_get_item_cb: ret < 1 → p->miss = true
  12. Worker: recache_or_free: item_unlink(p->hdr_it) → removes the LIVE HDR (which now has valid P_new/V_new data) from the hash table
  13. Key permanently gone. miss_from_extstore++

<img width="1260" height="492" alt="Screenshot 2026-02-27 at 4 47 26 AM" src="https://github.com/user-attachments/assets/e6044019-1c27-4ccd-b2d0-e5104e1f9eeb" />
