### PR TITLE
Add a warning message about a missing Lua application and include instructions on how to download and install it.

### DIFF
--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -1,4 +1,5 @@
 all:
+	@if [ ! -f lua/Makefile ]; then echo "Missing lua application, run $(CURDIR)/fetch.sh script to download it"; exit 1; fi
 	cd lua && $(MAKE) all MYCFLAGS="-g" && cd ..
 
 clean:


### PR DESCRIPTION
Add comment explaining what to do if attempting to compile Lua when Lua is not installed.