### PR TITLE
Add new configuration variable for enable proxy or tls in spec file

### DIFF
--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -86,6 +86,9 @@ make %{?_smp_mflags}
 
 
 %check
+%if %{with_tls}
+export SSL_TEST=1
+%endif
 make test
 
 

--- a/memcached.spec.in
+++ b/memcached.spec.in
@@ -7,6 +7,8 @@
 %bcond_without option_checking
 %bcond_without coverage
 %bcond_without docs
+%bcond_with tls
+%bcond_with proxy
 
 # Set with_systemd on distros that use it, so we can install the service
 # file, otherwise the sysvinit script will be installed
@@ -73,7 +75,12 @@ web applications by alleviating database load.
   %{?with_64bit:--enable-64bit} \
   %{!?with_option_checking:--disable-option-checking}
   %{!?with_coverage:--disable-coverage} \
-  %{!?with_docs:--disable-docs}
+  %{!?with_docs:--disable-docs} \
+  %{?with_tls:--enable-tls} \
+%if %{with_tls}
+  %{?with_proxy:--enable-proxy-tls} \
+%endif
+  %{?with_proxy:--enable-proxy}
 
 make %{?_smp_mflags}
 


### PR DESCRIPTION
Automatically configure parallel and SSL testing when building RPMs via the spec file

Introduce new configuration variables in SPEC file:

- **with_tls** which setup **--enable-tls**
- **with_proxy** which setup **--enable-proxy** 
- If both options are enabled, **--enable-proxy-tls** is automatically set.
