### PR TITLE
fix integer overflow in asciiauth size and binary protocol vlen

### DIFF
--- a/proto_bin.c
+++ b/proto_bin.c
@@ -903,6 +903,12 @@ static void dispatch_bin_command(conn *c, char *extbuf) {
         return;
     }
 
+    if (bodylen > (uint32_t)INT_MAX) {
+        write_bin_error(c, PROTOCOL_BINARY_RESPONSE_EINVAL, NULL, 0);
+        c->close_after_write = true;
+        return;
+    }
+
     if (settings.sasl && !authenticated(c)) {
         write_bin_error(c, PROTOCOL_BINARY_RESPONSE_AUTH_ERROR, NULL, 0);
         c->close_after_write = true;

--- a/proto_text.c
+++ b/proto_text.c
@@ -277,6 +277,16 @@ int try_read_command_asciiauth(conn *c) {
 
         // we don't actually care about the key at all; it can be anything.
         // we do care about the size of the remaining read.
+        if (size > INT_MAX - 2) {
+            if (!c->resp) {
+                if (!resp_start(c)) {
+                    conn_set_state(c, conn_closing);
+                    return 1;
+                }
+            }
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return 1;
+        }
         c->rlbytes = size + 2;
 
         c->sasl_started = true; // reuse from binprot sasl, but not sasl :)


### PR DESCRIPTION
## Summary

Two integer overflow issues in protocol parsing that can be triggered by unauthenticated network clients.

**ASCII auth (`proto_text.c`):** `try_read_command_asciiauth()` parses a `uint32_t size` from the set command and stores `size + 2` into `c->rlbytes` (signed `int`). Values near UINT32_MAX wrap the signed result, corrupting buffer tracking for subsequent reads. Fixed by rejecting `size > INT_MAX - 2` before the assignment.

**Binary protocol (`proto_bin.c`):** Multiple command handlers compute `int vlen = bodylen - nkey` or `bodylen - (nkey + extlen)` where `bodylen` is `uint32_t`. When `bodylen > INT_MAX`, the implicit conversion to signed int wraps negative. A negative `vlen` passed as the `swallow` parameter to `write_bin_error()` bypasses the `swallow > 0` guard, so residual body bytes stay in the read buffer and get parsed as new protocol commands. Fixed by rejecting `bodylen > INT_MAX` early in `dispatch_bin_command()`, before any handler runs.

Both checks close the connection after sending the error response.

Tested against 1.6.41 / current master.