### PR TITLE
SPARC traps on several memory accesses that are tolerated on x86.

### DIFF
--- a/logger.h
+++ b/logger.h
@@ -164,6 +164,9 @@ struct _logentry {
     struct timeval tv; /* not monotonic! */
     int size;
     union {
+#ifdef NEED_ALIGN
+        uint64_t align;
+#endif
         char end;
     } data[];
 };

--- a/memcached.c
+++ b/memcached.c
@@ -4071,7 +4071,12 @@ static void usage(void) {
            "                          forcefully killing LRU tail item.\n"
            "                          disabled by default; very dangerous option.\n"
            "   - hash_algorithm:      the hash table algorithm\n"
-           "                          default is murmur3 hash. options: jenkins, murmur3, xxh3\n"
+#ifdef NEED_ALIGN
+           "                          default is xxh3 hash on NEED_ALIGN builds.\n"
+#else
+           "                          default is murmur3 hash.\n"
+#endif
+           "                          options: jenkins, murmur3, xxh3\n"
            "   - no_lru_crawler:      disable LRU Crawler background thread.\n"
            "   - lru_crawler_sleep:   microseconds to sleep between items\n"
            "                          default is %d.\n"
@@ -4712,7 +4717,11 @@ int main (int argc, char **argv) {
     bool start_lru_maintainer = true;
     bool start_lru_crawler = true;
     bool start_assoc_maint = true;
+#ifdef NEED_ALIGN
+    enum hashfunc_type hash_type = XXH3_HASH;
+#else
     enum hashfunc_type hash_type = MURMUR3_HASH;
+#endif
     uint32_t tocrawl;
     uint32_t slab_sizes[MAX_NUMBER_OF_SLAB_CLASSES];
     bool use_slab_sizes = false;
@@ -4867,7 +4876,11 @@ int main (int argc, char **argv) {
 
     /* init settings */
     settings_init();
+#ifdef NEED_ALIGN
+    verify_default("hash_algorithm", hash_type == XXH3_HASH);
+#else
     verify_default("hash_algorithm", hash_type == MURMUR3_HASH);
+#endif
     void *storage = NULL;
 #ifdef EXTSTORE
     void *storage_cf = storage_init_config(&settings);

--- a/memcached.h
+++ b/memcached.h
@@ -20,6 +20,9 @@
 #include <assert.h>
 #include <grp.h>
 #include <signal.h>
+#ifdef NEED_ALIGN
+#include <string.h>
+#endif
 /* need this to get IOV_MAX on some platforms. */
 #ifndef __need_IOV_MAX
 #define __need_IOV_MAX
@@ -169,6 +172,18 @@ typedef uint32_t client_flags_t;
 #define APPEND_NUM_STAT(num, name, fmt, val) \
     APPEND_NUM_FMT_STAT("%d:%s", num, name, fmt, val)
 
+#ifdef NEED_ALIGN
+/** Item client flag conversion */
+#define FLAGS_CONV(it, flag) { \
+    if ((it)->it_flags & ITEM_CFLAGS) { \
+        client_flags_t _flags_conv; \
+        memcpy(&_flags_conv, ITEM_suffix((it)), sizeof(_flags_conv)); \
+        flag = _flags_conv; \
+    } else { \
+        flag = 0; \
+    } \
+}
+#else
 /** Item client flag conversion */
 #define FLAGS_CONV(it, flag) { \
     if ((it)->it_flags & ITEM_CFLAGS) { \
@@ -177,6 +192,7 @@ typedef uint32_t client_flags_t;
         flag = 0; \
     } \
 }
+#endif
 
 #define FLAGS_SIZE(item) (((item)->it_flags & ITEM_CFLAGS) ? sizeof(client_flags_t) : 0)
 

--- a/proto_parser.c
+++ b/proto_parser.c
@@ -636,7 +636,9 @@ static inline int make_ascii_get_suffix(char *suffix, item *it, bool return_cas,
         *p = '0';
         p++;
     } else {
-        p = itoa_u64(*((client_flags_t *) ITEM_suffix(it)), p);
+        client_flags_t flags;
+        FLAGS_CONV(it, flags);
+        p = itoa_u64(flags, p);
     }
     *p = ' ';
     p = itoa_u32(nbytes-2, p+1);
@@ -1108,7 +1110,9 @@ void process_mget_cmd(LIBEVENT_THREAD *t, mcp_parser_t *pr, mc_resp *resp,
                         *p = '0';
                         p++;
                     } else {
-                        p = itoa_u64(*((client_flags_t *) ITEM_suffix(it)), p);
+                        client_flags_t flags;
+                        FLAGS_CONV(it, flags);
+                        p = itoa_u64(flags, p);
                     }
                     break;
                 case 'l':


### PR DESCRIPTION
MurmurHash3_x86_32() may be called with unaligned key pointers, so load 32-bit blocks byte-by-byte while preserving the little-endian layout expected by the x86 MurmurHash3 variant.

Item client flags are stored after the item key and can also be unaligned. Use the existing FLAGS_CONV path, backed by memcpy(), instead of directly dereferencing ITEM_suffix() as client_flags_t.

Logger payloads are overlaid with typed records, including records with 64-bit fields. Align the flexible payload array to uint64_t so those overlays are safe on strict-alignment platforms.