### PR TITLE
lru_crawler: add missing OK\r\n prefix to metadump and mgdump

### DIFF
--- a/crawler.c
+++ b/crawler.c
@@ -263,6 +263,10 @@ static void crawler_expired_eval(crawler_module_t *cm, item *search, uint32_t hv
 
 static int crawler_metadump_init(crawler_module_t *cm, void *data) {
     cm->status = 0;
+    if (cm->c.buf != NULL) {
+        memcpy(cm->c.buf, "OK\r\n", 4);
+        cm->c.bufused += 4;
+    }
     return 0;
 }
 
@@ -390,6 +394,10 @@ static void crawler_metadump_finalize(crawler_module_t *cm) {
 
 static int crawler_mgdump_init(crawler_module_t *cm, void *data) {
     cm->status = 0;
+    if (cm->c.buf != NULL) {
+        memcpy(cm->c.buf, "OK\r\n", 4);
+        cm->c.bufused += 4;
+    }
     return 0;
 }
 
@@ -862,9 +870,7 @@ int lru_crawler_start(uint8_t *ids, uint32_t remaining,
         assert(crawler_mod_regs[type] != NULL);
         active_crawler_mod.mod = crawler_mod_regs[type];
         active_crawler_type = type;
-        if (active_crawler_mod.mod->init != NULL) {
-            active_crawler_mod.mod->init(&active_crawler_mod, data);
-        }
+        /* set client, then call init to be able to send OK */
         if (active_crawler_mod.mod->needs_client) {
             if (c == NULL || sfd == 0) {
                 pthread_mutex_unlock(&lru_crawler_lock);
@@ -874,6 +880,9 @@ int lru_crawler_start(uint8_t *ids, uint32_t remaining,
                 pthread_mutex_unlock(&lru_crawler_lock);
                 return -2;
             }
+        }
+        if (active_crawler_mod.mod->init != NULL) {
+            active_crawler_mod.mod->init(&active_crawler_mod, data);
         }
     }
 

--- a/t/lru-crawler.t
+++ b/t/lru-crawler.t
@@ -74,6 +74,7 @@ while (1) {
     my $count = 0;
     while (<$sock>) {
         last if /^(\.|END)/;
+        next if /^OK/;
         /^(key=) (\S+).*([^\r\n]+)/;
         $count++;
     }
@@ -113,6 +114,7 @@ for (1 .. 70000) {
     my $count = 0;
     while (<$sock>) {
         last if /^(\.|END)/;
+        next if /^OK/;
         if (/^key=bfoo(\S+)/) {
             ok(exists $bfoo{$1}, "found bfoo key $1 is still in test hash");
             delete $bfoo{$1};


### PR DESCRIPTION
The metadump and mgdump commands were supposed to return OK\r\n
before data, but init() was called before set_client(), so the
client buffer wasn't available yet.

### Changes

- Reordered set_client() before init() in lru_crawler_start() so
  modules with needs_client=true have the client buffer ready
  during initialization.
- Added OK\r\n output in crawler_metadump_init().
- Added OK\r\n output in crawler_mgdump_init().
- Updated metadump test to skip the OK line when counting results.

### Testing

- `make test` passes
- Manual verification

Fixes #667