### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   ubuntu-build-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install deps
       run: |
         sudo apt-get update -y


### PR DESCRIPTION
Several workflow files reference GitHub Actions via mutable version tags (e.g. `@v4`, `@v3`) instead of full commit SHAs. This is a supply chain risk — a compromised action repository could silently alter CI behavior.

This PR pins each action to the exact commit SHA corresponding to the version tag, making the dependency immutable and auditable.

Recommended by [GitHub security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).