### PR TITLE
seccomp: allow ppoll in worker sandbox for loongarch64

### DIFF
--- a/linux_priv.c
+++ b/linux_priv.c
@@ -143,6 +143,7 @@ void drop_worker_privileges(void) {
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(epoll_pwait), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(epoll_ctl), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(poll), 0);
+    rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ppoll), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(readv), 0);
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mprotect), 0);


### PR DESCRIPTION
poll() is already allowed, but on some architectures glibc's poll() wrapper is implemented via ppoll(). Without this rule the worker thread is killed by the seccomp filter as soon as it waits on I/O.

This is reproducible on LoongArch64 with --enable-seccomp, where t/lru-crawler.t fails because the worker syscall 73 ppoll is denied. ppoll is functionally equivalent to poll for memcached's purposes and does not increase the sandbox attack surface.

Tested on Arch Linux for Loong64.