### PR TITLE
tests: cap polling backoff in slabs-mover wait helpers

### DIFF
--- a/t/slabs-mover.t
+++ b/t/slabs-mover.t
@@ -40,6 +40,7 @@ sub wait_for_stat {
         last if ($stats_a->{$stat} == $amt);
         sleep $to_sleep;
         $to_sleep += $cnt / 100;
+        $to_sleep = 0.2 if $to_sleep > 0.2;
         #print STDERR "SLEEPING: $to_sleep STAT: ", $stats_a->{$stat}, " LAST BUSY: ", $stats_a->{slab_reassign_last_busy_status}, "\n";
     }
     return $stats_a;
@@ -57,6 +58,7 @@ sub wait_for_stat_incr {
         last if ($stats_a->{$stat} > $stats->{$stat}+$amt);
         sleep $to_sleep;
         $to_sleep += $cnt / 100;
+        $to_sleep = 0.2 if $to_sleep > 0.2;
         #print STDERR "SLEEPING: $to_sleep STAT: ", $stats_a->{$stat}, " LAST BUSY: ", $stats_a->{slab_reassign_last_busy_status}, "\n";
         #print STDERR Dumper(map { $_ => $stats_a->{$_} } sort keys %$stats_a), "\n";
     }


### PR DESCRIPTION
wait_for_stat and wait_for_stat_incr used an uncapped linearly increasing sleep.

Because $to_sleep itself accumulates, the per-iteration sleep grows quadratically. In the worst case of all 500 iterations the test would sleep for roughly 58 hours before giving up.

On fast x86_64 hosts the condition is satisfied in the first few polls, so the bug is hidden. On slower hardware the loop easily exceeds CI timeouts.

Cap the sleep at 0.2s. This preserves the original intent of polling quickly at first and then backing off, while bounding the total wait to about 50 seconds.